### PR TITLE
Add concurrency control to AsyncRelayCommand types

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -21,3 +21,4 @@ MVVMTK0013 | Microsoft.CodeAnalysis.CSharp.CSharpParseOptions | Error | See http
 MVVMTK0014 | CommunityToolkit.Mvvm.SourceGenerators.ICommandGenerator | Error | See https://aka.ms/mvvmtoolkit/error
 MVVMTK0015 | CommunityToolkit.Mvvm.SourceGenerators.ICommandGenerator | Error | See https://aka.ms/mvvmtoolkit/error
 MVVMTK0016 | CommunityToolkit.Mvvm.SourceGenerators.ICommandGenerator | Error | See https://aka.ms/mvvmtoolkit/error
+MVVMTK0017 | CommunityToolkit.Mvvm.SourceGenerators.ICommandGenerator | Error | See https://aka.ms/mvvmtoolkit/error

--- a/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -207,9 +207,6 @@ internal static class DiagnosticDescriptors
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> indicating when an unsupported C# language version is being used.
-    /// <para>
-    /// Format: <c>"The method {0}.{1} cannot be used to generate a command property, as its signature isn't compatible with any of the existing relay command types"</c>.
-    /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor UnsupportedCSharpLanguageVersionError = new(
         id: "MVVMTK0013",
@@ -267,5 +264,21 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "The CanExecute name in [ICommand] must refer to a compatible member (either a property or a method) to be used in a generated command.",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when <c>ICommandAttribute.AllowConcurrentExecutions</c> is being set for a non-asynchronous method.
+    /// <para>
+    /// Format: <c>"The method {0}.{1} cannot be annotated with the [ICommand] attribute specifying a concurrency control setting, as it maps to a non-asynchronous command type"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidConcurrentExecutionsParameterError = new(
+        id: "MVVMTK0014",
+        title: "Invalid concurrency control setting usage",
+        messageFormat: "The method {0}.{1} cannot be annotated with the [ICommand] attribute specifying a concurrency control setting, as it maps to a non-asynchronous command type",
+        category: typeof(ICommandGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Cannot apply the [ICommand] attribute specifying a concurrency control setting to methods mapping to non-asynchronous command types.",
         helpLinkUri: "https://aka.ms/mvvmtoolkit");
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -273,7 +273,7 @@ internal static class DiagnosticDescriptors
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidConcurrentExecutionsParameterError = new(
-        id: "MVVMTK0014",
+        id: "MVVMTK0017",
         title: "Invalid concurrency control setting usage",
         messageFormat: "The method {0}.{1} cannot be annotated with the [ICommand] attribute specifying a concurrency control setting, as it maps to a non-asynchronous command type",
         category: typeof(ICommandGenerator).FullName,

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AttributeDataExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AttributeDataExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -51,7 +50,7 @@ internal static class AttributeDataExtensions
     /// <param name="name">The name of the argument to check.</param>
     /// <param name="value">The resulting argument value, if present.</param>
     /// <returns>Whether or not <paramref name="attributeData"/> contains an argument named <paramref name="name"/> with a valid value.</returns>
-    public static bool TryGetNamedArgument<T>(this AttributeData attributeData, string name, [NotNullWhen(true)] out T? value)
+    public static bool TryGetNamedArgument<T>(this AttributeData attributeData, string name, out T? value)
     {
         foreach (KeyValuePair<string, TypedConstant> properties in attributeData.NamedArguments)
         {

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AttributeDataExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AttributeDataExtensions.cs
@@ -55,10 +55,9 @@ internal static class AttributeDataExtensions
     {
         foreach (KeyValuePair<string, TypedConstant> properties in attributeData.NamedArguments)
         {
-            if (properties.Key == name &&
-                properties.Value.Value is T argumentValue)
+            if (properties.Key == name)
             {
-                value = argumentValue;
+                value = (T?)properties.Value.Value;
 
                 return true;
             }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.SyntaxReceiver.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.SyntaxReceiver.cs
@@ -34,9 +34,9 @@ public sealed partial class ICommandGenerator
             if (context.Node is MethodDeclarationSyntax methodDeclaration &&
                 context.SemanticModel.GetDeclaredSymbol(methodDeclaration) is IMethodSymbol methodSymbol &&
                 context.SemanticModel.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.Input.ICommandAttribute") is INamedTypeSymbol iCommandSymbol &&
-                methodSymbol.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, iCommandSymbol)) is AttributeData commandData)
+                methodSymbol.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, iCommandSymbol)) is AttributeData attributeData)
             {
-                this.gatheredInfo.Add(new Item(methodDeclaration.GetLeadingTrivia(), methodSymbol, commandData));
+                this.gatheredInfo.Add(new Item(methodDeclaration.GetLeadingTrivia(), methodSymbol, attributeData));
             }
         }
 
@@ -45,7 +45,7 @@ public sealed partial class ICommandGenerator
         /// </summary>
         /// <param name="LeadingTrivia">The leading trivia for the field declaration.</param>
         /// <param name="MethodSymbol">The <see cref="IMethodSymbol"/> instance for the target method.</param>
-        /// <param name="CommandData">The <see cref="AttributeData"/> instance the method was annotated with.</param>
-        public sealed record Item(SyntaxTriviaList LeadingTrivia, IMethodSymbol MethodSymbol, AttributeData CommandData);
+        /// <param name="AttributeData">The <see cref="AttributeData"/> instance the method was annotated with.</param>
+        public sealed record Item(SyntaxTriviaList LeadingTrivia, IMethodSymbol MethodSymbol, AttributeData AttributeData);
     }
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.cs
@@ -89,7 +89,7 @@ public sealed partial class ICommandGenerator : ISourceGenerator
         ClassDeclarationSyntax? classDeclarationSyntax =
             ClassDeclaration(classDeclarationSymbol.Name)
             .WithModifiers(classDeclaration.Modifiers)
-            .AddMembers(items.Select(item => CreateCommandMembers(context, classDeclarationSymbol, item.LeadingTrivia, item.MethodSymbol, item.CommandData)).SelectMany(static g => g).ToArray());
+            .AddMembers(items.Select(item => CreateCommandMembers(context, classDeclarationSymbol, item.LeadingTrivia, item.MethodSymbol, item.AttributeData)).SelectMany(static g => g).ToArray());
 
         TypeDeclarationSyntax typeDeclarationSyntax = classDeclarationSyntax;
 
@@ -129,7 +129,7 @@ public sealed partial class ICommandGenerator : ISourceGenerator
     /// <param name="classDeclarationSymbol">The <see cref="INamedTypeSymbol"/> for the parent type.</param>
     /// <param name="leadingTrivia">The leading trivia for the field to process.</param>
     /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
-    /// <param name="commandData">The <see cref="AttributeData"/> instance the method was annotated with.</param>
+    /// <param name="attributeData">The <see cref="AttributeData"/> instance the method was annotated with.</param>
     /// <returns>The <see cref="MemberDeclarationSyntax"/> instances for the input command.</returns>
     [Pure]
     private static IEnumerable<MemberDeclarationSyntax> CreateCommandMembers(
@@ -137,7 +137,7 @@ public sealed partial class ICommandGenerator : ISourceGenerator
         INamedTypeSymbol classDeclarationSymbol,
         SyntaxTriviaList leadingTrivia,
         IMethodSymbol methodSymbol,
-        AttributeData commandData)
+        AttributeData attributeData)
     {
         // Get the command member names
         (string fieldName, string propertyName) = GetGeneratedFieldAndPropertyNames(context, methodSymbol);
@@ -156,31 +156,40 @@ public sealed partial class ICommandGenerator : ISourceGenerator
         }
 
         // Prepares the argument to pass the underlying method to invoke
-        ArgumentSyntax[] commandCreationArguments = new[] {
-            Argument(ObjectCreationExpression(IdentifierName(delegateTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
-            .AddArgumentListArguments(Argument(IdentifierName(methodSymbol.Name))))
+        List<ArgumentSyntax> commandCreationArguments = new()
+        {
+            Argument(
+                ObjectCreationExpression(IdentifierName(delegateTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
+                .AddArgumentListArguments(Argument(IdentifierName(methodSymbol.Name))))
         };
 
         // Get the can execute member, if any
-        if (commandData.TryGetNamedArgument("CanExecute", out string? memberName))
+        if (attributeData.TryGetNamedArgument("CanExecute", out string? memberName))
         {
-            ImmutableArray<ISymbol> canExecuteSymbols = classDeclarationSymbol.GetMembers(memberName);
-
-            if (canExecuteSymbols.IsEmpty)
+            if (memberName is null)
             {
-                context.ReportDiagnostic(InvalidCanExecuteMemberName, methodSymbol, memberName, methodSymbol.ContainingType);
-            }
-            else if (canExecuteSymbols.Length > 1)
-            {
-                context.ReportDiagnostic(MultipleCanExecuteMemberNameMatches, methodSymbol, memberName, methodSymbol.ContainingType);
-            }
-            else if (TryGetCanExecuteExpressionFromSymbol(context, memberName, canExecuteSymbols[0], commandInterfaceTypeSymbol, out ExpressionSyntax? canExecuteExpression))
-            {
-                commandCreationArguments = new ArgumentSyntax[] { commandCreationArguments[0], Argument(canExecuteExpression) };
+                context.ReportDiagnostic(InvalidCanExecuteMemberName, methodSymbol, memberName ?? string.Empty, methodSymbol.ContainingType);
             }
             else
             {
-                context.ReportDiagnostic(InvalidCanExecuteMember, methodSymbol, memberName, methodSymbol.ContainingType);
+                ImmutableArray<ISymbol> canExecuteSymbols = classDeclarationSymbol.GetMembers(memberName);
+
+                if (canExecuteSymbols.IsEmpty)
+                {
+                    context.ReportDiagnostic(InvalidCanExecuteMemberName, methodSymbol, memberName, methodSymbol.ContainingType);
+                }
+                else if (canExecuteSymbols.Length > 1)
+                {
+                    context.ReportDiagnostic(MultipleCanExecuteMemberNameMatches, methodSymbol, memberName, methodSymbol.ContainingType);
+                }
+                else if (TryGetCanExecuteExpressionFromSymbol(context, memberName, canExecuteSymbols[0], commandInterfaceTypeSymbol, out ExpressionSyntax? canExecuteExpression))
+                {
+                    commandCreationArguments.Add(Argument(canExecuteExpression));
+                }
+                else
+                {
+                    context.ReportDiagnostic(InvalidCanExecuteMember, methodSymbol, memberName, methodSymbol.ContainingType);
+                }
             }
         }
 
@@ -220,15 +229,6 @@ public sealed partial class ICommandGenerator : ISourceGenerator
             }
         }
 
-        // Prepare the command creation expression. The basic initialization is as follows:
-        //
-        // new <RELAY_COMMAND_TYPE>(new <DELEGATE_TYPE>(<METHOD_NAME>));
-        ObjectCreationExpressionSyntax commandInitialization =
-            ObjectCreationExpression(IdentifierName(commandClassTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
-            .AddArgumentListArguments(Argument(
-                ObjectCreationExpression(IdentifierName(delegateTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
-                .AddArgumentListArguments(Argument(IdentifierName(methodSymbol.Name)))));
-
         // If the current type is an async command type and concurrent execution is disabled, pass that value to the constructor.
         // If concurrent executions are allowed, there is no need to add any additional argument, as that is the default value.
         if (commandClassTypeSymbol.Name is "AsyncRelayCommand" or "AsyncRelayCommand`1")
@@ -236,7 +236,7 @@ public sealed partial class ICommandGenerator : ISourceGenerator
             if (attributeData.TryGetNamedArgument("AllowConcurrentExecutions", out bool allowConcurrentExecutions) &&
                 !allowConcurrentExecutions)
             {
-                commandInitialization = commandInitialization.AddArgumentListArguments(Argument(LiteralExpression(SyntaxKind.FalseLiteralExpression)));
+                commandCreationArguments.Add(Argument(LiteralExpression(SyntaxKind.FalseLiteralExpression)));
             }
         }
         else if (attributeData.TryGetNamedArgument("AllowConcurrentExecutions", out bool _))
@@ -250,7 +250,7 @@ public sealed partial class ICommandGenerator : ISourceGenerator
         // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
         // [global::System.Diagnostics.DebuggerNonUserCode]
         // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        // public <COMMAND_TYPE> <COMMAND_PROPERTY_NAME> => <COMMAND_FIELD_NAME> ??= <COMMAND_INITIALIZATION_EXPRESSION>;
+        // public <COMMAND_TYPE> <COMMAND_PROPERTY_NAME> => <COMMAND_FIELD_NAME> ??= new <RELAY_COMMAND_TYPE>(new <DELEGATE_TYPE>(<METHOD_NAME>), <OPTIONAL_CAN_EXECUTE>, <OPTIONAL_ALLOW_CONCURRENT_EXECUTIONS>);
         PropertyDeclarationSyntax propertyDeclaration =
             PropertyDeclaration(
                 IdentifierName(commandInterfaceTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
@@ -271,8 +271,7 @@ public sealed partial class ICommandGenerator : ISourceGenerator
                         SyntaxKind.CoalesceAssignmentExpression,
                         IdentifierName(fieldName),
                         ObjectCreationExpression(IdentifierName(commandClassTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
-                        .AddArgumentListArguments(commandCreationArguments))))
-            //.WithExpressionBody(ArrowExpressionClause(AssignmentExpression(SyntaxKind.CoalesceAssignmentExpression, IdentifierName(fieldName), commandInitialization)))
+                        .AddArgumentListArguments(commandCreationArguments.ToArray()))))
             .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
         return new MemberDeclarationSyntax[] { fieldDeclaration, propertyDeclaration };

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -176,38 +176,36 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
                 return;
             }
 
-            bool isAlreadyCompletedOrNull = value?.IsCompleted ?? true;
-
             this.executionTask = value;
 
             PropertyChanged?.Invoke(this, ExecutionTaskChangedEventArgs);
             PropertyChanged?.Invoke(this, IsRunningChangedEventArgs);
             PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
 
-            if (isAlreadyCompletedOrNull)
+            if (value?.IsCompleted ?? true)
             {
                 return;
             }
 
-            async void MonitorTask()
+            static async void MonitorTask(AsyncRelayCommand @this, Task task)
             {
                 try
                 {
-                    await value!;
+                    await task;
                 }
                 catch
                 {
                 }
 
-                if (ReferenceEquals(this.executionTask, value))
+                if (ReferenceEquals(@this.executionTask, task))
                 {
-                    PropertyChanged?.Invoke(this, ExecutionTaskChangedEventArgs);
-                    PropertyChanged?.Invoke(this, IsRunningChangedEventArgs);
-                    PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
+                    @this.PropertyChanged?.Invoke(@this, ExecutionTaskChangedEventArgs);
+                    @this.PropertyChanged?.Invoke(@this, IsRunningChangedEventArgs);
+                    @this.PropertyChanged?.Invoke(@this, CanBeCanceledChangedEventArgs);
                 }
             }
 
-            MonitorTask();
+            MonitorTask(this, value!);
         }
     }
 

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace CommunityToolkit.Mvvm.Input;
 
@@ -17,8 +16,13 @@ namespace CommunityToolkit.Mvvm.Input;
 /// action, and providing an <see cref="ExecutionTask"/> property that notifies changes when
 /// <see cref="ExecuteAsync"/> is invoked and when the returned <see cref="Task"/> completes.
 /// </summary>
-public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
+public sealed class AsyncRelayCommand : IAsyncRelayCommand
 {
+    /// <summary>
+    /// The cached <see cref="PropertyChangedEventArgs"/> for <see cref="ExecutionTask"/>.
+    /// </summary>
+    internal static readonly PropertyChangedEventArgs ExecutionTaskChangedEventArgs = new(nameof(ExecutionTask));
+
     /// <summary>
     /// The cached <see cref="PropertyChangedEventArgs"/> for <see cref="CanBeCanceled"/>.
     /// </summary>
@@ -51,10 +55,18 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
     private readonly Func<bool>? canExecute;
 
     /// <summary>
+    /// Indicates whether or not concurrent executions of the command are allowed.
+    /// </summary>
+    private readonly bool allowConcurrentExecutions;
+
+    /// <summary>
     /// The <see cref="CancellationTokenSource"/> instance to use to cancel <see cref="cancelableExecute"/>.
     /// </summary>
     /// <remarks>This is only used when <see cref="cancelableExecute"/> is not <see langword="null"/>.</remarks>
     private CancellationTokenSource? cancellationTokenSource;
+
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <inheritdoc/>
     public event EventHandler? CanExecuteChanged;
@@ -66,6 +78,18 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
     public AsyncRelayCommand(Func<Task> execute)
     {
         this.execute = execute;
+        this.allowConcurrentExecutions = true;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class that can always execute.
+    /// </summary>
+    /// <param name="execute">The execution logic.</param>
+    /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
+    public AsyncRelayCommand(Func<Task> execute, bool allowConcurrentExecutions)
+    {
+        this.execute = execute;
+        this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
     /// <summary>
@@ -75,6 +99,18 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
     public AsyncRelayCommand(Func<CancellationToken, Task> cancelableExecute)
     {
         this.cancelableExecute = cancelableExecute;
+        this.allowConcurrentExecutions = true;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class that can always execute.
+    /// </summary>
+    /// <param name="cancelableExecute">The cancelable execution logic.</param>
+    /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
+    public AsyncRelayCommand(Func<CancellationToken, Task> cancelableExecute, bool allowConcurrentExecutions)
+    {
+        this.cancelableExecute = cancelableExecute;
+        this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
     /// <summary>
@@ -86,6 +122,20 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
     {
         this.execute = execute;
         this.canExecute = canExecute;
+        this.allowConcurrentExecutions = true;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class.
+    /// </summary>
+    /// <param name="execute">The execution logic.</param>
+    /// <param name="canExecute">The execution status logic.</param>
+    /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
+    public AsyncRelayCommand(Func<Task> execute, Func<bool> canExecute, bool allowConcurrentExecutions)
+    {
+        this.execute = execute;
+        this.canExecute = canExecute;
+        this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
     /// <summary>
@@ -97,9 +147,23 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
     {
         this.cancelableExecute = cancelableExecute;
         this.canExecute = canExecute;
+        this.allowConcurrentExecutions = true;
     }
 
-    private TaskNotifier? executionTask;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class.
+    /// </summary>
+    /// <param name="cancelableExecute">The cancelable execution logic.</param>
+    /// <param name="canExecute">The execution status logic.</param>
+    /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
+    public AsyncRelayCommand(Func<CancellationToken, Task> cancelableExecute, Func<bool> canExecute, bool allowConcurrentExecutions)
+    {
+        this.cancelableExecute = cancelableExecute;
+        this.canExecute = canExecute;
+        this.allowConcurrentExecutions = allowConcurrentExecutions;
+    }
+
+    private Task? executionTask;
 
     /// <inheritdoc/>
     public Task? ExecutionTask
@@ -107,17 +171,43 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
         get => this.executionTask;
         private set
         {
-            if (SetPropertyAndNotifyOnCompletion(ref this.executionTask, value, _ =>
+            if (ReferenceEquals(this.executionTask, value))
             {
-                    // When the task completes
-                    OnPropertyChanged(IsRunningChangedEventArgs);
-                OnPropertyChanged(CanBeCanceledChangedEventArgs);
-            }))
-            {
-                // When setting the task
-                OnPropertyChanged(IsRunningChangedEventArgs);
-                OnPropertyChanged(CanBeCanceledChangedEventArgs);
+                return;
             }
+
+            bool isAlreadyCompletedOrNull = value?.IsCompleted ?? true;
+
+            this.executionTask = value;
+
+            PropertyChanged?.Invoke(this, ExecutionTaskChangedEventArgs);
+            PropertyChanged?.Invoke(this, IsRunningChangedEventArgs);
+            PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
+
+            if (isAlreadyCompletedOrNull)
+            {
+                return;
+            }
+
+            async void MonitorTask()
+            {
+                try
+                {
+                    await value!;
+                }
+                catch
+                {
+                }
+
+                if (ReferenceEquals(this.executionTask, value))
+                {
+                    PropertyChanged?.Invoke(this, ExecutionTaskChangedEventArgs);
+                    PropertyChanged?.Invoke(this, IsRunningChangedEventArgs);
+                    PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
+                }
+            }
+
+            MonitorTask();
         }
     }
 
@@ -140,7 +230,9 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool CanExecute(object? parameter)
     {
-        return this.canExecute?.Invoke() != false;
+        bool canExecute = this.canExecute?.Invoke() != false;
+
+        return canExecute && (this.allowConcurrentExecutions || ExecutionTask?.IsCompleted != false);
     }
 
     /// <inheritdoc/>
@@ -165,7 +257,7 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
 
             CancellationTokenSource cancellationTokenSource = this.cancellationTokenSource = new();
 
-            OnPropertyChanged(IsCancellationRequestedChangedEventArgs);
+            PropertyChanged?.Invoke(this, IsCancellationRequestedChangedEventArgs);
 
             // Invoke the cancelable command delegate with a new linked token
             return ExecutionTask = this.cancelableExecute!(cancellationTokenSource.Token);
@@ -179,7 +271,7 @@ public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
     {
         this.cancellationTokenSource?.Cancel();
 
-        OnPropertyChanged(IsCancellationRequestedChangedEventArgs);
-        OnPropertyChanged(CanBeCanceledChangedEventArgs);
+        PropertyChanged?.Invoke(this, IsCancellationRequestedChangedEventArgs);
+        PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
     }
 }

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -160,38 +160,36 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
                 return;
             }
 
-            bool isAlreadyCompletedOrNull = value?.IsCompleted ?? true;
-
             this.executionTask = value;
 
             PropertyChanged?.Invoke(this, AsyncRelayCommand.ExecutionTaskChangedEventArgs);
             PropertyChanged?.Invoke(this, AsyncRelayCommand.IsRunningChangedEventArgs);
             PropertyChanged?.Invoke(this, AsyncRelayCommand.CanBeCanceledChangedEventArgs);
 
-            if (isAlreadyCompletedOrNull)
+            if (value?.IsCompleted ?? true)
             {
                 return;
             }
 
-            async void MonitorTask()
+            static async void MonitorTask(AsyncRelayCommand<T> @this, Task task)
             {
                 try
                 {
-                    await value!;
+                    await task;
                 }
                 catch
                 {
                 }
 
-                if (ReferenceEquals(this.executionTask, value))
+                if (ReferenceEquals(@this.executionTask, task))
                 {
-                    PropertyChanged?.Invoke(this, AsyncRelayCommand.ExecutionTaskChangedEventArgs);
-                    PropertyChanged?.Invoke(this, AsyncRelayCommand.IsRunningChangedEventArgs);
-                    PropertyChanged?.Invoke(this, AsyncRelayCommand.CanBeCanceledChangedEventArgs);
+                    @this.PropertyChanged?.Invoke(@this, AsyncRelayCommand.ExecutionTaskChangedEventArgs);
+                    @this.PropertyChanged?.Invoke(@this, AsyncRelayCommand.IsRunningChangedEventArgs);
+                    @this.PropertyChanged?.Invoke(@this, AsyncRelayCommand.CanBeCanceledChangedEventArgs);
                 }
             }
 
-            MonitorTask();
+            MonitorTask(this, value!);
         }
     }
 

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace CommunityToolkit.Mvvm.Input;
 
@@ -14,7 +14,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// A generic command that provides a more specific version of <see cref="AsyncRelayCommand"/>.
 /// </summary>
 /// <typeparam name="T">The type of parameter being passed as input to the callbacks.</typeparam>
-public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<T>
+public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
 {
     /// <summary>
     /// The <see cref="Func{TResult}"/> to invoke when <see cref="Execute(T)"/> is used.
@@ -32,9 +32,17 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
     private readonly Predicate<T?>? canExecute;
 
     /// <summary>
+    /// Indicates whether or not concurrent executions of the command are allowed.
+    /// </summary>
+    private readonly bool allowConcurrentExecutions;
+
+    /// <summary>
     /// The <see cref="CancellationTokenSource"/> instance to use to cancel <see cref="cancelableExecute"/>.
     /// </summary>
     private CancellationTokenSource? cancellationTokenSource;
+
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <inheritdoc/>
     public event EventHandler? CanExecuteChanged;
@@ -47,6 +55,19 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
     public AsyncRelayCommand(Func<T?, Task> execute)
     {
         this.execute = execute;
+        this.allowConcurrentExecutions = true;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class that can always execute.
+    /// </summary>
+    /// <param name="execute">The execution logic.</param>
+    /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
+    /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
+    public AsyncRelayCommand(Func<T?, Task> execute, bool allowConcurrentExecutions)
+    {
+        this.execute = execute;
+        this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
     /// <summary>
@@ -57,6 +78,19 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
     public AsyncRelayCommand(Func<T?, CancellationToken, Task> cancelableExecute)
     {
         this.cancelableExecute = cancelableExecute;
+        this.allowConcurrentExecutions = true;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class that can always execute.
+    /// </summary>
+    /// <param name="cancelableExecute">The cancelable execution logic.</param>
+    /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
+    /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
+    public AsyncRelayCommand(Func<T?, CancellationToken, Task> cancelableExecute, bool allowConcurrentExecutions)
+    {
+        this.cancelableExecute = cancelableExecute;
+        this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
     /// <summary>
@@ -69,6 +103,21 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
     {
         this.execute = execute;
         this.canExecute = canExecute;
+        this.allowConcurrentExecutions = true;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
+    /// </summary>
+    /// <param name="execute">The execution logic.</param>
+    /// <param name="canExecute">The execution status logic.</param>
+    /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
+    /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
+    public AsyncRelayCommand(Func<T?, Task> execute, Predicate<T?> canExecute, bool allowConcurrentExecutions)
+    {
+        this.execute = execute;
+        this.canExecute = canExecute;
+        this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
     /// <summary>
@@ -81,9 +130,24 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
     {
         this.cancelableExecute = cancelableExecute;
         this.canExecute = canExecute;
+        this.allowConcurrentExecutions = true;
     }
 
-    private TaskNotifier? executionTask;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
+    /// </summary>
+    /// <param name="cancelableExecute">The cancelable execution logic.</param>
+    /// <param name="canExecute">The execution status logic.</param>
+    /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
+    /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
+    public AsyncRelayCommand(Func<T?, CancellationToken, Task> cancelableExecute, Predicate<T?> canExecute, bool allowConcurrentExecutions)
+    {
+        this.cancelableExecute = cancelableExecute;
+        this.canExecute = canExecute;
+        this.allowConcurrentExecutions = allowConcurrentExecutions;
+    }
+
+    private Task? executionTask;
 
     /// <inheritdoc/>
     public Task? ExecutionTask
@@ -91,17 +155,43 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
         get => this.executionTask;
         private set
         {
-            if (SetPropertyAndNotifyOnCompletion(ref this.executionTask, value, _ =>
+            if (ReferenceEquals(this.executionTask, value))
             {
-                    // When the task completes
-                    OnPropertyChanged(AsyncRelayCommand.IsRunningChangedEventArgs);
-                OnPropertyChanged(AsyncRelayCommand.CanBeCanceledChangedEventArgs);
-            }))
-            {
-                // When setting the task
-                OnPropertyChanged(AsyncRelayCommand.IsRunningChangedEventArgs);
-                OnPropertyChanged(AsyncRelayCommand.CanBeCanceledChangedEventArgs);
+                return;
             }
+
+            bool isAlreadyCompletedOrNull = value?.IsCompleted ?? true;
+
+            this.executionTask = value;
+
+            PropertyChanged?.Invoke(this, AsyncRelayCommand.ExecutionTaskChangedEventArgs);
+            PropertyChanged?.Invoke(this, AsyncRelayCommand.IsRunningChangedEventArgs);
+            PropertyChanged?.Invoke(this, AsyncRelayCommand.CanBeCanceledChangedEventArgs);
+
+            if (isAlreadyCompletedOrNull)
+            {
+                return;
+            }
+
+            async void MonitorTask()
+            {
+                try
+                {
+                    await value!;
+                }
+                catch
+                {
+                }
+
+                if (ReferenceEquals(this.executionTask, value))
+                {
+                    PropertyChanged?.Invoke(this, AsyncRelayCommand.ExecutionTaskChangedEventArgs);
+                    PropertyChanged?.Invoke(this, AsyncRelayCommand.IsRunningChangedEventArgs);
+                    PropertyChanged?.Invoke(this, AsyncRelayCommand.CanBeCanceledChangedEventArgs);
+                }
+            }
+
+            MonitorTask();
         }
     }
 
@@ -124,7 +214,9 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool CanExecute(T? parameter)
     {
-        return this.canExecute?.Invoke(parameter) != false;
+        bool canExecute = this.canExecute?.Invoke(parameter) != false;
+
+        return canExecute && (this.allowConcurrentExecutions || ExecutionTask?.IsCompleted != false);
     }
 
     /// <inheritdoc/>
@@ -169,7 +261,7 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
 
             CancellationTokenSource cancellationTokenSource = this.cancellationTokenSource = new();
 
-            OnPropertyChanged(AsyncRelayCommand.IsCancellationRequestedChangedEventArgs);
+            PropertyChanged?.Invoke(this, AsyncRelayCommand.IsCancellationRequestedChangedEventArgs);
 
             // Invoke the cancelable command delegate with a new linked token
             return ExecutionTask = this.cancelableExecute!(parameter, cancellationTokenSource.Token);
@@ -189,7 +281,7 @@ public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<
     {
         this.cancellationTokenSource?.Cancel();
 
-        OnPropertyChanged(AsyncRelayCommand.IsCancellationRequestedChangedEventArgs);
-        OnPropertyChanged(AsyncRelayCommand.CanBeCanceledChangedEventArgs);
+        PropertyChanged?.Invoke(this, AsyncRelayCommand.IsCancellationRequestedChangedEventArgs);
+        PropertyChanged?.Invoke(this, AsyncRelayCommand.CanBeCanceledChangedEventArgs);
     }
 }

--- a/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
+++ b/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
@@ -68,4 +68,13 @@ public sealed class ICommandAttribute : Attribute
     /// a <see cref="bool"/> value, and has to have a signature compatible with the target command.
     /// </summary>
     public string? CanExecute { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not to allow concurrent executions for an asynchronous command.
+    /// When set for an attribute used on a method that would result in an <see cref="AsyncRelayCommand"/> or an
+    /// <see cref="AsyncRelayCommand{T}"/> property to be generated, this will modify the behavior of these commands
+    /// when an execution is invoked while a previous one is still running. It is the same as creating an instance of
+    /// these command types with a constructor such as <see cref="AsyncRelayCommand(Func{System.Threading.Tasks.Task}, bool)"/>.
+    /// </summary>
+    public bool AllowConcurrentExecutions { get; set; } = true;
 }

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -357,6 +357,26 @@ public class Test_SourceGeneratorsDiagnostics
     }
 
     [TestMethod]
+    public void InvalidICommandAllowConcurrentExecutionsSettings()
+    {
+        string source = @"
+            using CommunityToolkit.Mvvm.Input;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel
+                {
+                    [ICommand(AllowConcurrentExecutions = false)]
+                    private void GreetUser(User user)
+                    {
+                    }
+                }
+            }";
+
+        VerifyGeneratedDiagnostics<ICommandGenerator>(source, "MVVMTK0014");
+    }
+
+    [TestMethod]
     public void InvalidCanExecuteMemberName()
     {
         string source = @"

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -357,26 +357,6 @@ public class Test_SourceGeneratorsDiagnostics
     }
 
     [TestMethod]
-    public void InvalidICommandAllowConcurrentExecutionsSettings()
-    {
-        string source = @"
-            using CommunityToolkit.Mvvm.Input;
-
-            namespace MyApp
-            {
-                public partial class SampleViewModel
-                {
-                    [ICommand(AllowConcurrentExecutions = false)]
-                    private void GreetUser(User user)
-                    {
-                    }
-                }
-            }";
-
-        VerifyGeneratedDiagnostics<ICommandGenerator>(source, "MVVMTK0014");
-    }
-
-    [TestMethod]
     public void InvalidCanExecuteMemberName()
     {
         string source = @"
@@ -552,6 +532,26 @@ public class Test_SourceGeneratorsDiagnostics
             }";
 
         VerifyGeneratedDiagnostics<ICommandGenerator>(source, "MVVMTK0016");
+    }
+
+    [TestMethod]
+    public void InvalidICommandAllowConcurrentExecutionsSettings()
+    {
+        string source = @"
+            using CommunityToolkit.Mvvm.Input;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel
+                {
+                    [ICommand(AllowConcurrentExecutions = false)]
+                    private void GreetUser(User user)
+                    {
+                    }
+                }
+            }";
+
+        VerifyGeneratedDiagnostics<ICommandGenerator>(source, "MVVMTK0017");
     }
 
     /// <summary>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
@@ -40,6 +42,20 @@ public partial class Test_ICommandAttribute
         await model.DelayAndIncrementCounterWithValueAndTokenCommand.ExecuteAsync(5);
 
         Assert.AreEqual(model.Counter, 18);
+
+        List<Task> tasks = new();
+
+        for (int i = 0; i < 10; i++)
+        {
+            tasks.Add(model.AddValueToListAndDelayCommand.ExecuteAsync(i));
+        }
+
+        // All values should already be in the list, as commands are executed
+        // concurrently. Each invocation should still be pending here, but the
+        // values are added to the list before starting the delay.
+        CollectionAssert.AreEqual(model.Values, Enumerable.Range(0, 10).ToArray());
+
+        await Task.WhenAll(tasks);
     }
 
     [TestMethod]
@@ -260,6 +276,8 @@ public partial class Test_ICommandAttribute
 
         public int Counter { get; private set; }
 
+        public List<int> Values { get; } = new();
+
         /// <summary>This is a single line summary.</summary>
         [ICommand]
         private void IncrementCounter()
@@ -285,6 +303,14 @@ public partial class Test_ICommandAttribute
             await Task.Delay(50);
 
             Counter += 1;
+        }
+
+        [ICommand]
+        private async Task AddValueToListAndDelayAsync(int value)
+        {
+            Values.Add(value);
+
+            await Task.Delay(100);
         }
 
         #region Test region


### PR DESCRIPTION
**Closes #1**
**Closes #2**
**Closes #16**

This PR includes the following changes:

- Add a new `allowConcurrentExecutions` parameter to async command constructors
- Add support for this through surce generators as well
- Remove the base `ObservableObject` type from async relay commands
- Minor performance/memory optimizations