### PR TITLE
Switch .NET 5 target to .NET 6

### DIFF
--- a/CommunityToolkit.Common/CommunityToolkit.Common.csproj
+++ b/CommunityToolkit.Common/CommunityToolkit.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,8 +14,8 @@
     <PackageTags>Incremental;Loading;Collection;IncrementalLoadingCollection;String;Array;Extensions;Helpers</PackageTags>
   </PropertyGroup>
 
-  <!-- .NET Standard 2.1 and .NET 5 already have [NotNullIfNotNull] and [NotNullWhen] -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <!-- .NET Standard 2.1 and .NET 6 already have [NotNullIfNotNull] and [NotNullWhen] -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <DefineConstants>NETSTANDARD2_1_OR_GREATER</DefineConstants>
   </PropertyGroup>
 

--- a/CommunityToolkit.Common/Deferred/EventDeferral.cs
+++ b/CommunityToolkit.Common/Deferred/EventDeferral.cs
@@ -16,7 +16,7 @@ namespace CommunityToolkit.Common.Deferred;
 /// </summary>
 public class EventDeferral : IDisposable
 {
-    //// TODO: If/when .NET 5 is base, we can upgrade to non-generic version
+    //// TODO: If/when .NET 6 is base, we can upgrade to non-generic version
     private readonly TaskCompletionSource<object?> _taskCompletionSource = new();
 
     internal EventDeferral()

--- a/CommunityToolkit.Common/Extensions/TaskExtensions.cs
+++ b/CommunityToolkit.Common/Extensions/TaskExtensions.cs
@@ -39,7 +39,7 @@ public static class TaskExtensions
         {
             // We need an explicit check to ensure the input task is not the cached
             // Task.CompletedTask instance, because that can internally be stored as
-            // a Task<T> for some given T (eg. on .NET 5 it's VoidTaskResult), which
+            // a Task<T> for some given T (eg. on .NET 6 it's VoidTaskResult), which
             // would cause the following code to return that result instead of null.
             if (task != Task.CompletedTask)
             {

--- a/CommunityToolkit.Diagnostics/Attributes/SkipLocalsInitAttribute.cs
+++ b/CommunityToolkit.Diagnostics/Attributes/SkipLocalsInitAttribute.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !NET5_0
+#if !NET6_0_OR_GREATER
 
 namespace System.Runtime.CompilerServices;
 

--- a/CommunityToolkit.Diagnostics/CommunityToolkit.Diagnostics.csproj
+++ b/CommunityToolkit.Diagnostics/CommunityToolkit.Diagnostics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -34,7 +34,7 @@
       </ItemGroup>
     </When>
 
-    <When Condition="'$(TargetFramework)' == 'net5.0'">
+    <When Condition="'$(TargetFramework)' == 'net6.0'">
       <PropertyGroup>
         <DefineConstants>NETSTANDARD2_1_OR_GREATER</DefineConstants>
       </PropertyGroup>

--- a/CommunityToolkit.HighPerformance/Attributes/SkipLocalsInitAttribute.cs
+++ b/CommunityToolkit.HighPerformance/Attributes/SkipLocalsInitAttribute.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !NET5_0
+#if !NET6_0_OR_GREATER
 
 namespace System.Runtime.CompilerServices;
 

--- a/CommunityToolkit.HighPerformance/Buffers/ArrayPoolBufferWriter{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/ArrayPoolBufferWriter{T}.cs
@@ -9,7 +9,11 @@ using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance.Buffers.Views;
-using CommunityToolkit.HighPerformance.Helpers.Internals;
+#if NET6_0_OR_GREATER
+using BitOperations = System.Numerics.BitOperations;
+#else
+using BitOperations = CommunityToolkit.HighPerformance.Helpers.Internals.BitOperations;
+#endif
 
 namespace CommunityToolkit.HighPerformance.Buffers;
 
@@ -283,7 +287,7 @@ public sealed class ArrayPoolBufferWriter<T> : IBuffer<T>, IMemoryOwner<T>
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void ResizeBuffer(int sizeHint)
     {
-        int minimumSize = this.index + sizeHint;
+        uint minimumSize = (uint)this.index + (uint)sizeHint;
 
         // The ArrayPool<T> class has a maximum threshold of 1024 * 1024 for the maximum length of
         // pooled arrays, and once this is exceeded it will just allocate a new array every time
@@ -292,10 +296,10 @@ public sealed class ArrayPoolBufferWriter<T> : IBuffer<T>, IMemoryOwner<T>
         // use is bigger than that threshold don't end up causing a resize every single time.
         if (minimumSize > 1024 * 1024)
         {
-            minimumSize = BitOperations.RoundUpPowerOfTwo(minimumSize);
+            minimumSize = BitOperations.RoundUpToPowerOf2(minimumSize);
         }
 
-        this.pool.Resize(ref this.array, minimumSize);
+        this.pool.Resize(ref this.array, (int)minimumSize);
     }
 
     /// <inheritdoc/>

--- a/CommunityToolkit.HighPerformance/CommunityToolkit.HighPerformance.csproj
+++ b/CommunityToolkit.HighPerformance/CommunityToolkit.HighPerformance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -45,9 +45,9 @@
       </ItemGroup>
     </When>
 
-    <When Condition="'$(TargetFramework)' == 'net5.0'">
+    <When Condition="'$(TargetFramework)' == 'net6.0'">
 
-      <!-- NETSTANDARD2_1_OR_GREATER: includes both .NET Standard 2.1, .NET Core 3.1 and .NET 5 -->
+      <!-- NETSTANDARD2_1_OR_GREATER: includes both .NET Standard 2.1, .NET Core 3.1 and .NET 6 -->
       <PropertyGroup>
         <DefineConstants>NETSTANDARD2_1_OR_GREATER</DefineConstants>
       </PropertyGroup>

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.1D.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.1D.cs
@@ -33,7 +33,7 @@ public static partial class ArrayExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReference<T>(this T[] array)
     {
-#if NET5_0
+#if NET6_0_OR_GREATER
         return ref MemoryMarshal.GetArrayDataReference(array);
 #elif NETCOREAPP3_1
         RawArrayData? arrayData = Unsafe.As<RawArrayData>(array)!;
@@ -59,7 +59,7 @@ public static partial class ArrayExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this T[] array, int i)
     {
-#if NET5_0
+#if NET6_0_OR_GREATER
         ref T r0 = ref MemoryMarshal.GetArrayDataReference(array);
         ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)i);
 

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.2D.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.2D.cs
@@ -32,7 +32,9 @@ public static partial class ArrayExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReference<T>(this T[,] array)
     {
-#if NETCOREAPP3_1
+#if NET6_0_OR_GREATER
+        return ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array));
+#elif NETCOREAPP3_1
         RawArray2DData? arrayData = Unsafe.As<RawArray2DData>(array)!;
         ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
 
@@ -62,7 +64,14 @@ public static partial class ArrayExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this T[,] array, int i, int j)
     {
-#if NETCOREAPP3_1
+#if NET6_0_OR_GREATER
+        int width = array.GetLength(1);
+        nint index = ((nint)(uint)i * (nint)(uint)width) + (nint)(uint)j;
+        ref T r0 = ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array));
+        ref T ri = ref Unsafe.Add(ref r0, index);
+
+        return ref ri;
+#elif NETCOREAPP3_1
         RawArray2DData? arrayData = Unsafe.As<RawArray2DData>(array)!;
         nint offset = ((nint)(uint)i * (nint)(uint)arrayData.Width) + (nint)(uint)j;
         ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
@@ -31,7 +31,9 @@ public static partial class ArrayExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReference<T>(this T[,,] array)
     {
-#if NETCOREAPP3_1
+#if NET6_0_OR_GREATER
+        return ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array));
+#elif NETCOREAPP3_1
         RawArray3DData? arrayData = Unsafe.As<RawArray3DData>(array)!;
         ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
 
@@ -62,7 +64,17 @@ public static partial class ArrayExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this T[,,] array, int i, int j, int k)
     {
-#if NETCOREAPP3_1
+#if NET6_0_OR_GREATER
+        int height = array.GetLength(1);
+        int width = array.GetLength(2);
+        nint index =
+            ((nint)(uint)i * (nint)(uint)height * (nint)(uint)width) +
+            ((nint)(uint)j * (nint)(uint)width) + (nint)(uint)k;
+        ref T r0 = ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array));
+        ref T ri = ref Unsafe.Add(ref r0, index);
+
+        return ref ri;
+#elif NETCOREAPP3_1
         RawArray3DData? arrayData = Unsafe.As<RawArray3DData>(array)!;
         nint offset =
             ((nint)(uint)i * (nint)(uint)arrayData.Height * (nint)(uint)arrayData.Width) +

--- a/CommunityToolkit.HighPerformance/Extensions/ListExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ListExtensions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NET5_0
+#if NET6_0_OR_GREATER
 
 using System;
 using System.Collections.Generic;

--- a/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// This extension is restricted to the .NET 5 because it shares the same BCL
+// This extension is restricted to the .NET 6 because it shares the same BCL
 // across all targets, ensuring that the layout of our Nullable<T> mapping type
 // will be correct. Exposing this API on older targets (especially .NET Standard)
 // is not guaranteed to be correct and could result in invalid memory accesses.
-#if NET5_0
+
+#if NET6_0_OR_GREATER
 
 using System;
 using System.Runtime.CompilerServices;

--- a/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
@@ -28,7 +28,7 @@ public static class StringExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref char DangerousGetReference(this string text)
     {
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
         return ref Unsafe.AsRef(text.GetPinnableReference());
 #else
         return ref MemoryMarshal.GetReference(text.AsSpan());
@@ -46,7 +46,7 @@ public static class StringExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref char DangerousGetReferenceAt(this string text, int i)
     {
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
         ref char r0 = ref Unsafe.AsRef(text.GetPinnableReference());
 #else
         ref char r0 = ref MemoryMarshal.GetReference(text.AsSpan());

--- a/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
@@ -28,7 +28,7 @@ public static class StringExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref char DangerousGetReference(this string text)
     {
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         return ref Unsafe.AsRef(text.GetPinnableReference());
 #else
         return ref MemoryMarshal.GetReference(text.AsSpan());
@@ -46,7 +46,7 @@ public static class StringExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref char DangerousGetReferenceAt(this string text, int i)
     {
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         ref char r0 = ref Unsafe.AsRef(text.GetPinnableReference());
 #else
         ref char r0 = ref MemoryMarshal.GetReference(text.AsSpan());

--- a/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -233,7 +233,7 @@ public static class BitHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint ExtractRange(uint value, byte start, byte length)
     {
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
         if (Bmi1.IsSupported)
         {
             return Bmi1.BitFieldExtract(value, start, length);
@@ -280,7 +280,7 @@ public static class BitHelper
         uint loadMask = highBits << start;
         uint storeMask = (flags & highBits) << start;
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
         if (Bmi1.IsSupported)
         {
             return Bmi1.AndNot(loadMask, value) | storeMask;
@@ -400,7 +400,7 @@ public static class BitHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong ExtractRange(ulong value, byte start, byte length)
     {
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
         if (Bmi1.X64.IsSupported)
         {
             return Bmi1.X64.BitFieldExtract(value, start, length);
@@ -447,7 +447,7 @@ public static class BitHelper
         ulong loadMask = highBits << start;
         ulong storeMask = (flags & highBits) << start;
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
         if (Bmi1.X64.IsSupported)
         {
             return Bmi1.X64.AndNot(loadMask, value) | storeMask;

--- a/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -233,7 +233,7 @@ public static class BitHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint ExtractRange(uint value, byte start, byte length)
     {
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         if (Bmi1.IsSupported)
         {
             return Bmi1.BitFieldExtract(value, start, length);
@@ -280,7 +280,7 @@ public static class BitHelper
         uint loadMask = highBits << start;
         uint storeMask = (flags & highBits) << start;
 
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         if (Bmi1.IsSupported)
         {
             return Bmi1.AndNot(loadMask, value) | storeMask;
@@ -400,7 +400,7 @@ public static class BitHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong ExtractRange(ulong value, byte start, byte length)
     {
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         if (Bmi1.X64.IsSupported)
         {
             return Bmi1.X64.BitFieldExtract(value, start, length);
@@ -447,7 +447,7 @@ public static class BitHelper
         ulong loadMask = highBits << start;
         ulong storeMask = (flags & highBits) << start;
 
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         if (Bmi1.X64.IsSupported)
         {
             return Bmi1.X64.AndNot(loadMask, value) | storeMask;

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/BitOperations.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/BitOperations.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
 using static System.Numerics.BitOperations;
 #endif
 
@@ -25,7 +25,7 @@ internal static class BitOperations
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int RoundUpPowerOfTwo(int x)
     {
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
         return 1 << (32 - LeadingZeroCount((uint)(x - 1)));
 #else
         x--;

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/BitOperations.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/BitOperations.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
+#if !NET6_0_OR_GREATER
+
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1
+using System.Runtime.Intrinsics.X86;
 using static System.Numerics.BitOperations;
 #endif
 
@@ -17,26 +19,42 @@ namespace CommunityToolkit.HighPerformance.Helpers.Internals;
 internal static class BitOperations
 {
     /// <summary>
-    /// Rounds up an <see cref="int"/> value to a power of 2.
+    /// Round the given integral value up to a power of 2.
     /// </summary>
-    /// <param name="x">The input value to round up.</param>
-    /// <returns>The smallest power of two greater than or equal to <paramref name="x"/>.</returns>
-    [Pure]
+    /// <param name="value">The value.</param>
+    /// <returns>
+    /// The smallest power of 2 which is greater than or equal to <paramref name="value"/>.
+    /// If <paramref name="value"/> is 0 or the result overflows, returns 0.
+    /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int RoundUpPowerOfTwo(int x)
+    public static unsafe uint RoundUpToPowerOf2(uint value)
     {
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
-        return 1 << (32 - LeadingZeroCount((uint)(x - 1)));
-#else
-        x--;
-        x |= x >> 1;
-        x |= x >> 2;
-        x |= x >> 4;
-        x |= x >> 8;
-        x |= x >> 16;
-        x++;
+#if NETCOREAPP3_1
+        if (Lzcnt.IsSupported)
+        {
+            if (sizeof(nint) == 8)
+            {
+                return (uint)(0x1_0000_0000ul >> LeadingZeroCount(value - 1));
+            }
+            else
+            {
+                int shift = 32 - LeadingZeroCount(value - 1);
 
-        return x;
+                return (1u ^ (uint)(shift >> 5)) << shift;
+            }
+        }
 #endif
+
+        // Based on https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+        --value;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+
+        return value + 1;
     }
 }
+
+#endif

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/RuntimeHelpers.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/RuntimeHelpers.cs
@@ -79,6 +79,7 @@ internal static class RuntimeHelpers
         return (nint)array.LongLength;
     }
 
+#if !NETCOREAPP3_1_OR_GREATER
     /// <summary>
     /// Gets the byte offset to the first <typeparamref name="T"/> element in a SZ array.
     /// </summary>
@@ -90,6 +91,7 @@ internal static class RuntimeHelpers
     {
         return TypeInfo<T>.ArrayDataByteOffset;
     }
+#endif
 
     /// <summary>
     /// Gets the byte offset to the first <typeparamref name="T"/> element in a 2D array.

--- a/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,9 +40,9 @@ jobs:
   - powershell: dotnet build -c Release
     displayName: Build solution
 
-  # Run .NET 5 tests
-  - powershell: dotnet test --logger "trx;LogFileName=VsTestResultsNet5.trx" --framework net5.0 --configuration Release
-    displayName: Run .NET 5 unit tests
+  # Run .NET 6 tests
+  - powershell: dotnet test --logger "trx;LogFileName=VsTestResultsNet6.trx" --framework net6.0 --configuration Release
+    displayName: Run .NET 6 unit tests
 
   # Run .NET Core 3.1 tests
   - powershell: dotnet test --logger "trx;LogFileName=VsTestResultsNetCore31.trx" --framework netcoreapp3.1 --configuration Release

--- a/tests/CommunityToolkit.Common.UnitTests/CommunityToolkit.Common.UnitTests.csproj
+++ b/tests/CommunityToolkit.Common.UnitTests/CommunityToolkit.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Diagnostics.UnitTests/CommunityToolkit.Diagnostics.UnitTests.csproj
+++ b/tests/CommunityToolkit.Diagnostics.UnitTests/CommunityToolkit.Diagnostics.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/CommunityToolkit.HighPerformance.UnitTests.csproj
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/CommunityToolkit.HighPerformance.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayExtensions.2D.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayExtensions.2D.cs
@@ -419,7 +419,7 @@ public partial class Test_ArrayExtensions
         _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() => array.GetColumn(0).ToArray());
     }
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
     [TestMethod]
     public void Test_ArrayExtensions_2D_AsSpan_Empty()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayExtensions.2D.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayExtensions.2D.cs
@@ -419,7 +419,7 @@ public partial class Test_ArrayExtensions
         _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() => array.GetColumn(0).ToArray());
     }
 
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
     [TestMethod]
     public void Test_ArrayExtensions_2D_AsSpan_Empty()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_HashCode{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_HashCode{T}.cs
@@ -56,7 +56,7 @@ public class Test_HashCodeOfT
         TestForType<char>();
     }
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
     [TestMethod]
     public void Test_HashCodeOfT_ManagedType_TestRepeat()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_HashCode{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_HashCode{T}.cs
@@ -56,7 +56,7 @@ public class Test_HashCodeOfT
         TestForType<char>();
     }
 
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
     [TestMethod]
     public void Test_HashCodeOfT_ManagedType_TestRepeat()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For.cs
@@ -38,7 +38,7 @@ public partial class Test_ParallelHelper
         }
     }
 
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
     [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
     public void Test_ParallelHelper_ForInvalidRange_FromEnd()

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For.cs
@@ -38,7 +38,7 @@ public partial class Test_ParallelHelper
         }
     }
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
     [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
     public void Test_ParallelHelper_ForInvalidRange_FromEnd()

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For2D.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For2D.cs
@@ -50,7 +50,7 @@ public partial class Test_ParallelHelper
         }
     }
 
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
     [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
     public void Test_ParallelHelper_For2DInvalidRange_FromEnd()

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For2D.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For2D.cs
@@ -50,7 +50,7 @@ public partial class Test_ParallelHelper
         }
     }
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
     [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
     public void Test_ParallelHelper_For2DInvalidRange_FromEnd()

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableReadOnlyRef{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableReadOnlyRef{T}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
 
 using System;
 using System.Runtime.CompilerServices;

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableReadOnlyRef{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableReadOnlyRef{T}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
 
 using System;
 using System.Runtime.CompilerServices;

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableRef{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableRef{T}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0_OR_GREATER
 
 using System;
 using System.Runtime.CompilerServices;

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableRef{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableRef{T}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
 
 using System;
 using System.Runtime.CompilerServices;

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/CommunityToolkit.Mvvm.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/CommunityToolkit.Mvvm.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Closes #34**

This PR introduces the following change:

- Switch .NET 5 targets to .NET 6 (.NET 5 is no longer directly supported)
- Update CI script accordingly