### PR TITLE
StrongReferenceMessenger.Unregister[All] fixes

### DIFF
--- a/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
@@ -233,12 +233,12 @@ public sealed class StrongReferenceMessenger : IMessenger
             // matches with the token type currently in use, and operate on those instances.
             foreach (object obj in maps.AsSpan(0, i))
             {
-                IDictionarySlim<Recipient, IDictionarySlim<TToken>>? map = Unsafe.As<IDictionarySlim<Recipient, IDictionarySlim<TToken>>>(obj);
+                IDictionarySlim<Recipient, IDictionarySlim<TToken>>? handlersMap = Unsafe.As<IDictionarySlim<Recipient, IDictionarySlim<TToken>>>(obj);
 
                 // We don't need whether or not the map contains the recipient, as the
                 // sequence of maps has already been copied from the set containing all
                 // the mappings for the target recipients: it is guaranteed to be here.
-                IDictionarySlim<TToken> holder = map[key];
+                IDictionarySlim<TToken> holder = handlersMap[key];
 
                 // Try to remove the registered handler for the input token,
                 // for the current message type (unknown from here).
@@ -246,18 +246,29 @@ public sealed class StrongReferenceMessenger : IMessenger
                     holder.Count == 0)
                 {
                     // If the map is empty, remove the recipient entirely from its container
-                    _ = map.TryRemove(key);
+                    _ = handlersMap.TryRemove(key);
 
-                    // If no handlers are left at all for the recipient, across all
-                    // message types and token types, remove the set of mappings
-                    // entirely for the current recipient, and lost the strong
-                    // reference to it as well. This is the same situation that
-                    // would've been achieved by just calling UnregisterAll(recipient).
-                    if (map.Count == 0 &&
-                        set.Remove(Unsafe.As<IMapping>(map)) &&
-                        set.Count == 0)
+                    IMapping mapping = Unsafe.As<IMapping>(handlersMap);
+
+                    // This recipient has no registrations left for this combination of token
+                    // and message type, so this mapping can be removed from its associated set.
+                    _ = set.Remove(mapping);
+
+                    // If the resulting set is empty, then this means that there are no more handlers
+                    // left for this recipient for any message or token type, so the recipient can also
+                    // be removed from the map of all existing recipients with at least one handler.
+                    if (set.Count == 0)
                     {
                         _ = this.recipientsMap.TryRemove(key);
+                    }
+
+                    // If no handlers are left at all for any recipient, across all message types and token
+                    // types, remove the set of mappings entirely for the current recipient, and remove the
+                    // strong reference to it as well. This is the same situation that would've been achieved
+                    // by just calling UnregisterAll(recipient).
+                    if (handlersMap.Count == 0)
+                    {
+                        _ = this.typesMap.TryRemove(mapping.TypeArguments);
                     }
                 }
             }
@@ -320,6 +331,7 @@ public sealed class StrongReferenceMessenger : IMessenger
                     set.Count == 0)
                 {
                     _ = this.recipientsMap.TryRemove(key);
+                    _ = this.typesMap.TryRemove(mapping.TypeArguments);
                 }
             }
         }

--- a/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
@@ -325,13 +325,21 @@ public sealed class StrongReferenceMessenger : IMessenger
                 // to the current mapping between existing registered recipients (or entire recipients too).
                 _ = mapping.TryRemove(key);
 
+                // If there are no handlers left at all for this type combination, drop it
+                if (mapping.Count == 0)
+                {
+                    _ = this.typesMap.TryRemove(mapping.TypeArguments);
+                }
+
                 HashSet<IMapping> set = this.recipientsMap[key];
 
-                if (set.Remove(mapping) &&
-                    set.Count == 0)
+                // The current mapping no longer has any handlers left for this recipient
+                _ = set.Remove(mapping);
+
+                // If the current recipients has no handlers left at all, remove it
+                if (set.Count == 0)
                 {
                     _ = this.recipientsMap.TryRemove(key);
-                    _ = this.typesMap.TryRemove(mapping.TypeArguments);
                 }
             }
         }

--- a/CommunityToolkit.Mvvm/Properties/AssemblyInfo.cs
+++ b/CommunityToolkit.Mvvm/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CommunityToolkit.Mvvm.UnitTests")]

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_Messenger.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_Messenger.cs
@@ -6,7 +6,11 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
+using CommunityToolkit.Mvvm.Messaging.Internals;
+using Microsoft.Collections.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.Mvvm.UnitTests;
@@ -449,7 +453,7 @@ public partial class Test_Messenger
 
 #if NETCOREAPP // Auto-trimming is disabled on .NET Framework
     [TestMethod]
-    public void Test_Messenger_AutoCleanup()
+    public void Test_WeakReferenceMessenger_AutoCleanup()
     {
         IMessenger messenger = new WeakReferenceMessenger();
 
@@ -495,6 +499,144 @@ public partial class Test_Messenger
         GC.KeepAlive(messenger);
     }
 #endif
+
+    [TestMethod]
+    public void Test_StrongReferenceMessenger_AutoTrimming_UnregisterAll()
+    {
+        StrongReferenceMessenger messenger = new();
+        IDictionarySlim recipientsMap = (IDictionarySlim)typeof(StrongReferenceMessenger).GetField("recipientsMap", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(messenger)!;
+        IDictionarySlim<Type2, object> typesMap = (IDictionarySlim<Type2, object>)typeof(StrongReferenceMessenger).GetField("typesMap", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(messenger)!;
+
+        RecipientWithSomeMessages recipientA = new();
+        RecipientWithSomeMessages recipientB = new();
+
+        messenger.Register<MessageA>(recipientA);
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA>(recipientA));
+
+        // There's one registered handler
+        Assert.AreEqual(1, recipientsMap.Count);
+        Assert.AreEqual(1, typesMap.Count);
+
+        messenger.Register<MessageB>(recipientA);
+
+        Assert.IsTrue(messenger.IsRegistered<MessageB>(recipientA));
+
+        // There's two message types, for the same recipient
+        Assert.AreEqual(1, recipientsMap.Count);
+        Assert.AreEqual(2, typesMap.Count);
+
+        messenger.Register<MessageA>(recipientB);
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA>(recipientB));
+
+        // Now there's two recipients too
+        Assert.AreEqual(2, recipientsMap.Count);
+        Assert.AreEqual(2, typesMap.Count);
+
+        messenger.UnregisterAll(recipientA);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA>(recipientA));
+        Assert.IsFalse(messenger.IsRegistered<MessageB>(recipientA));
+
+        // Only the second recipient is left, which has a single message type
+        Assert.AreEqual(1, recipientsMap.Count);
+        Assert.AreEqual(1, typesMap.Count);
+
+        messenger.UnregisterAll(recipientB);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageB>(recipientA));
+
+        // Now both lists should be empty
+        Assert.AreEqual(0, recipientsMap.Count);
+        Assert.AreEqual(0, typesMap.Count);
+    }
+
+    [TestMethod]
+    public void Test_StrongReferenceMessenger_AutoTrimming_UnregisterAllWithToken()
+    {
+        StrongReferenceMessenger messenger = new();
+        IDictionarySlim recipientsMap = (IDictionarySlim)typeof(StrongReferenceMessenger).GetField("recipientsMap", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(messenger)!;
+        IDictionarySlim<Type2, object> typesMap = (IDictionarySlim<Type2, object>)typeof(StrongReferenceMessenger).GetField("typesMap", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(messenger)!;
+
+        RecipientWithSomeMessages recipientA = new();
+        RecipientWithSomeMessages recipientB = new();
+
+        messenger.Register<MessageA, int>(recipientA, 42);
+        messenger.Register<MessageB, int>(recipientA, 42);
+        messenger.Register<MessageA, int>(recipientB, 42);
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipientA, 42));
+        Assert.IsTrue(messenger.IsRegistered<MessageB, int>(recipientA, 42));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipientB, 42));
+
+        // There are two recipients, for two message types
+        Assert.AreEqual(2, recipientsMap.Count);
+        Assert.AreEqual(2, typesMap.Count);
+
+        messenger.UnregisterAll(recipientA, 42);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipientA, 42));
+        Assert.IsFalse(messenger.IsRegistered<MessageB, int>(recipientA, 42));
+
+        // Only the second recipient is left again
+        Assert.AreEqual(1, recipientsMap.Count);
+        Assert.AreEqual(1, typesMap.Count);
+
+        messenger.UnregisterAll(recipientB, 42);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipientB, 42));
+
+        // Now both lists should be empty
+        Assert.AreEqual(0, recipientsMap.Count);
+        Assert.AreEqual(0, typesMap.Count);
+    }
+
+    [TestMethod]
+    public void Test_StrongReferenceMessenger_AutoTrimming_UnregisterAllWithMessageTypeAndToken()
+    {
+        StrongReferenceMessenger messenger = new();
+        IDictionarySlim recipientsMap = (IDictionarySlim)typeof(StrongReferenceMessenger).GetField("recipientsMap", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(messenger)!;
+        IDictionarySlim<Type2, object> typesMap = (IDictionarySlim<Type2, object>)typeof(StrongReferenceMessenger).GetField("typesMap", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(messenger)!;
+
+        RecipientWithSomeMessages recipientA = new();
+        RecipientWithSomeMessages recipientB = new();
+
+        messenger.Register<MessageA, int>(recipientA, 42);
+        messenger.Register<MessageB, int>(recipientA, 42);
+        messenger.Register<MessageA, int>(recipientB, 42);
+
+        messenger.Unregister<MessageA, int>(recipientA, 42);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipientA, 42));
+        Assert.IsTrue(messenger.IsRegistered<MessageB, int>(recipientA, 42));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipientB, 42));
+
+        // First recipient is still subscribed to MessageB.
+        // The second one has a single subscription to MessageA.
+        Assert.AreEqual(2, recipientsMap.Count);
+        Assert.AreEqual(2, typesMap.Count);
+
+        messenger.Unregister<MessageB, int>(recipientA, 42);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipientA, 42));
+        Assert.IsFalse(messenger.IsRegistered<MessageB, int>(recipientA, 42));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipientB, 42));
+
+        // Only the second recipient is left
+        Assert.AreEqual(1, recipientsMap.Count);
+        Assert.AreEqual(1, typesMap.Count);
+
+        messenger.Unregister<MessageA, int>(recipientB, 42);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipientA, 42));
+        Assert.IsFalse(messenger.IsRegistered<MessageB, int>(recipientA, 42));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipientB, 42));
+
+        // Now both lists should be empty
+        Assert.AreEqual(0, recipientsMap.Count);
+        Assert.AreEqual(0, typesMap.Count);
+    }
 
     [TestMethod]
     [DataRow(typeof(StrongReferenceMessenger))]
@@ -579,12 +721,12 @@ public partial class Test_Messenger
     {
         public int As { get; private set; }
 
+        public int Bs { get; private set; }
+
         public void Receive(MessageA message)
         {
             As++;
         }
-
-        public int Bs { get; private set; }
 
         public void Receive(MessageB message)
         {


### PR DESCRIPTION
This PR fixes a couple of issues in the `StrongReferenceMessenger.Unregister[Add]` APIs.
It also adds several new unit tests, including a few stress tests with concurrent usage of all APIs.