### PR TITLE
Enable INotifyPropertyChanging AppContext switch

### DIFF
--- a/CommunityToolkit.Mvvm/ComponentModel/ObservableObject.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/ObservableObject.cs
@@ -66,6 +66,11 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
     protected void OnPropertyChanging([CallerMemberName] string? propertyName = null)
     {
+        if (Configuration.IsINotifyPropertyChangingDisabled)
+        {
+            return;
+        }
+
         OnPropertyChanging(new PropertyChangingEventArgs(propertyName));
     }
 

--- a/CommunityToolkit.Mvvm/Properties/Configuration.cs
+++ b/CommunityToolkit.Mvvm/Properties/Configuration.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.Contracts;
+
+/// <summary>
+/// A container for all shared <see cref="AppContext"/> configuration switches for the MVVM Toolkit.
+/// </summary>
+internal static class Configuration
+{
+    /// <summary>
+    /// The configuration property name for <see cref="IsINotifyPropertyChangingDisabled"/>.
+    /// </summary>
+    private const string DisableINotifyPropertyChangingSupport = "MVVMTOOLKIT_DISABLE_INOTIFYPROPERTYCHANGING";
+
+    /// <summary>
+    /// Indicates whether or not support for <see cref="INotifyPropertyChanging"/> is disabled.
+    /// </summary>
+    public static readonly bool IsINotifyPropertyChangingDisabled = GetConfigurationValue(DisableINotifyPropertyChangingSupport);
+
+    /// <summary>
+    /// Gets a configuration value for a specified property.
+    /// </summary>
+    /// <param name="propertyName">The property name to retrieve the value for.</param>
+    /// <returns>The value of the specified configuration setting.</returns>
+    [Pure]
+    private static bool GetConfigurationValue(string propertyName)
+    {
+        if (AppContext.TryGetSwitch(propertyName, out bool isEnabled))
+        {
+            return isEnabled;
+        }
+
+        return false;
+    }
+}

--- a/dotnet Community Toolkit.sln
+++ b/dotnet Community Toolkit.sln
@@ -53,20 +53,24 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{CD16E790
 		build\Build.bat = build\Build.bat
 		build\build.cake = build\build.cake
 		build\build.ps1 = build\build.ps1
+		build\Community.Toolkit.Common.props = build\Community.Toolkit.Common.props
+		build\Community.Toolkit.Common.targets = build\Community.Toolkit.Common.targets
 		build\header.txt = build\header.txt
 		build\nuget.png = build\nuget.png
 		build\Sign-Package.ps1 = build\Sign-Package.ps1
 		build\SignClientSettings.json = build\SignClientSettings.json
 		build\StyleXaml.bat = build\StyleXaml.bat
 		build\UpdateHeaders.bat = build\UpdateHeaders.bat
-		build\Community.Toolkit.Common.props = build\Community.Toolkit.Common.props
-		build\Community.Toolkit.Common.targets = build\Community.Toolkit.Common.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{11CB82CB-F72A-4690-9C0F-0AD5303C79B6}"
 	ProjectSection(SolutionItems) = preProject
 		build\tools\packages.config = build\tools\packages.config
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configuration", "{6640D447-C28D-4DBB-91F4-3ADCE0CA64AD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests", "tests\CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests\CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj", "{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -302,6 +306,26 @@ Global
 		{17522D0B-CA70-40B6-AFD8-8B8D45E75D92}.Release|x64.Build.0 = Release|Any CPU
 		{17522D0B-CA70-40B6-AFD8-8B8D45E75D92}.Release|x86.ActiveCfg = Release|Any CPU
 		{17522D0B-CA70-40B6-AFD8-8B8D45E75D92}.Release|x86.Build.0 = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|ARM.Build.0 = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|ARM.ActiveCfg = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|ARM.Build.0 = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|ARM64.Build.0 = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|x64.Build.0 = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -316,6 +340,8 @@ Global
 		{17522D0B-CA70-40B6-AFD8-8B8D45E75D92} = {B30036C4-D514-4E5B-A323-587A061772CE}
 		{CD16E790-7B7B-411E-9CE7-768E759CC22D} = {CFA75BE0-5A44-45DE-8114-426A605B062B}
 		{11CB82CB-F72A-4690-9C0F-0AD5303C79B6} = {CD16E790-7B7B-411E-9CE7-768E759CC22D}
+		{6640D447-C28D-4DBB-91F4-3ADCE0CA64AD} = {B30036C4-D514-4E5B-A323-587A061772CE}
+		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90} = {6640D447-C28D-4DBB-91F4-3ADCE0CA64AD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5403B0C4-F244-4F73-A35C-FE664D0F4345}

--- a/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\CommunityToolkit.Mvvm\CommunityToolkit.Mvvm.csproj" />
+    <ProjectReference Include="..\..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/Test_DisableINotifyPropertyChanging.cs
+++ b/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/Test_DisableINotifyPropertyChanging.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommunityToolkit.Mvvm.UnitTests.Configuration;
+
+[TestClass]
+public class Test_DisableINotifyPropertyChanging
+{
+    static Test_DisableINotifyPropertyChanging()
+    {
+        AppContext.SetSwitch("MVVMTOOLKIT_DISABLE_INOTIFYPROPERTYCHANGING", true);
+    }
+
+    [TestMethod]
+    public void Test_ObservableObject_Events()
+    {
+        SampleModel<int>? model = new();
+
+        (PropertyChangedEventArgs, int) changed = default;
+
+        model.PropertyChanging += (s, e) => Assert.Fail();
+
+        model.PropertyChanged += (s, e) =>
+        {
+            Assert.IsNull(changed.Item1);
+            Assert.AreSame(model, s);
+            Assert.IsNotNull(s);
+            Assert.IsNotNull(e);
+
+            changed = (e, model.Data);
+        };
+
+        model.Data = 42;
+
+        Assert.AreEqual(changed.Item1?.PropertyName, nameof(SampleModel<int>.Data));
+        Assert.AreEqual(changed.Item2, 42);
+    }
+
+    public class SampleModel<T> : ObservableObject
+    {
+        private T? data;
+
+        public T? Data
+        {
+            get => data;
+            set => SetProperty(ref data, value);
+        }
+
+        protected override void OnPropertyChanging(PropertyChangingEventArgs e)
+        {
+            Assert.Fail();
+        }
+    }
+}


### PR DESCRIPTION
**Contributes to #46**

This PR adds a new "MVVMTOOLKIT_DISABLE_INOTIFYPROPERTYCHANGING" switch that disables `INotifyPropertyChanging` in `ObservableObject` and inherited classes. This needs to be set through `AppContext.SetSwitch` right at startup.

**NOTE:** this is a draft as this branch is based on top of #47. Rebasing and switch to non-draft once that's merged.