### PR TITLE
Add [ICommand] CanExecute property

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -18,3 +18,6 @@ MVVMTK0010 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator 
 MVVMTK0011 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/error
 MVVMTK0012 | CommunityToolkit.Mvvm.SourceGenerators.ICommandGenerator | Error | See https://aka.ms/mvvmtoolkit/error
 MVVMTK0013 | Microsoft.CodeAnalysis.CSharp.CSharpParseOptions | Error | See https://aka.ms/mvvmtoolkit/error
+MVVMTK0014 | CommunityToolkit.Mvvm.SourceGenerators.ICommandGenerator | Error | See https://aka.ms/mvvmtoolkit/error
+MVVMTK0015 | CommunityToolkit.Mvvm.SourceGenerators.ICommandGenerator | Error | See https://aka.ms/mvvmtoolkit/error
+MVVMTK0016 | CommunityToolkit.Mvvm.SourceGenerators.ICommandGenerator | Error | See https://aka.ms/mvvmtoolkit/error

--- a/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -220,4 +220,52 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "The source generator features from the MVVM Toolkit require consuming projects to set the C# language version to at least C# 9.0. Make sure to add <LangVersion>9.0</LangVersion> (or above) to your .csproj file.",
         helpLinkUri: "https://aka.ms/mvvmtoolkit");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a specified <c>CanExecute</c> name has no matching member.
+    /// <para>
+    /// Format: <c>"The CanExecute name must refer to a valid member, but "{0}" has no matches in type {1}"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidCanExecuteMemberName = new(
+        id: "MVVMTK0014",
+        title: "Invalid ICommand.CanExecute member name",
+        messageFormat: "The CanExecute name must refer to a valid member, but \"{0}\" has no matches in type {1}",
+        category: typeof(ICommandGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The CanExecute name in [ICommand] must refer to a valid member in its parent type.",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a specified <c>CanExecute</c> name maps to multiple members.
+    /// <para>
+    /// Format: <c>"The CanExecute name must refer to a single member, but "{0}" has multiple matches in type {1}"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor MultipleCanExecuteMemberNameMatches = new(
+        id: "MVVMTK0015",
+        title: "Multiple ICommand.CanExecute member name matches",
+        messageFormat: "The CanExecute name must refer to a single member, but \"{0}\" has multiple matches in type {1}",
+        category: typeof(ICommandGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Cannot set the CanExecute name in [ICommand] to one that has multiple matches in its parent type (it must refer to a single compatible member).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a a specified <c>CanExecute</c> name maps to an invalid member.
+    /// <para>
+    /// Format: <c>"The CanExecute name must refer to a compatible member, but no valid members were found for "{0}" in type {1}"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidCanExecuteMember = new(
+        id: "MVVMTK0016",
+        title: "No valid ICommand.CanExecute member match",
+        messageFormat: "The CanExecute name must refer to a compatible member, but no valid members were found for \"{0}\" in type {1}",
+        category: typeof(ICommandGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The CanExecute name in [ICommand] must refer to a compatible member (either a property or a method) to be used in a generated command.",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit");
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AttributeDataExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AttributeDataExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -38,6 +39,32 @@ internal static class AttributeDataExtensions
                     EqualityComparer<T?>.Default.Equals(argumentValue, value);
             }
         }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to get a given named argument value from an <see cref="AttributeData"/> instance, if present.
+    /// </summary>
+    /// <typeparam name="T">The type of argument to check.</typeparam>
+    /// <param name="attributeData">The target <see cref="AttributeData"/> instance to check.</param>
+    /// <param name="name">The name of the argument to check.</param>
+    /// <param name="value">The resulting argument value, if present.</param>
+    /// <returns>Whether or not <paramref name="attributeData"/> contains an argument named <paramref name="name"/> with a valid value.</returns>
+    public static bool TryGetNamedArgument<T>(this AttributeData attributeData, string name, [NotNullWhen(true)] out T? value)
+    {
+        foreach (KeyValuePair<string, TypedConstant> properties in attributeData.NamedArguments)
+        {
+            if (properties.Key == name &&
+                properties.Value.Value is T argumentValue)
+            {
+                value = argumentValue;
+
+                return true;
+            }
+        }
+
+        value = default;
 
         return false;
     }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.SyntaxReceiver.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.SyntaxReceiver.cs
@@ -34,9 +34,9 @@ public sealed partial class ICommandGenerator
             if (context.Node is MethodDeclarationSyntax methodDeclaration &&
                 context.SemanticModel.GetDeclaredSymbol(methodDeclaration) is IMethodSymbol methodSymbol &&
                 context.SemanticModel.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.Input.ICommandAttribute") is INamedTypeSymbol iCommandSymbol &&
-                methodSymbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, iCommandSymbol)))
+                methodSymbol.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, iCommandSymbol)) is AttributeData commandData)
             {
-                this.gatheredInfo.Add(new Item(methodDeclaration.GetLeadingTrivia(), methodSymbol));
+                this.gatheredInfo.Add(new Item(methodDeclaration.GetLeadingTrivia(), methodSymbol, commandData));
             }
         }
 
@@ -45,6 +45,7 @@ public sealed partial class ICommandGenerator
         /// </summary>
         /// <param name="LeadingTrivia">The leading trivia for the field declaration.</param>
         /// <param name="MethodSymbol">The <see cref="IMethodSymbol"/> instance for the target method.</param>
-        public sealed record Item(SyntaxTriviaList LeadingTrivia, IMethodSymbol MethodSymbol);
+        /// <param name="CommandData">The <see cref="AttributeData"/> instance the method was annotated with.</param>
+        public sealed record Item(SyntaxTriviaList LeadingTrivia, IMethodSymbol MethodSymbol, AttributeData CommandData);
     }
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.cs
@@ -180,7 +180,7 @@ public sealed partial class ICommandGenerator : ISourceGenerator
             }
             else
             {
-                context.ReportDiagnostic(InvalidCanExecuteMemberName, methodSymbol, memberName, methodSymbol.ContainingType);
+                context.ReportDiagnostic(InvalidCanExecuteMember, methodSymbol, memberName, methodSymbol.ContainingType);
             }
         }
 
@@ -427,6 +427,7 @@ public sealed partial class ICommandGenerator : ISourceGenerator
 
             // If the method has parameters, it has to have a single one matching the command type
             if (canExecuteMethodSymbol.Parameters.Length == 1 &&
+                commandInterfaceTypeSymbol.IsGenericType &&
                 SymbolEqualityComparer.Default.Equals(canExecuteMethodSymbol.Parameters[0].Type, commandInterfaceTypeSymbol.TypeArguments[0]))
             {
                 // Create a method groupd expression again

--- a/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
+++ b/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
@@ -31,7 +31,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// <code>
 /// partial class MyViewModel
 /// {
-///     private IRelayCommand? greetUserCommand;
+///     private RelayCommand? greetUserCommand;
 ///
 ///     public IRelayCommand GreetUserCommand => greetUserCommand ??= new RelayCommand(GreetUser);
 /// }
@@ -62,4 +62,10 @@ namespace CommunityToolkit.Mvvm.Input;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public sealed class ICommandAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets the name of the property or method that will be invoked to check whether the
+    /// generated command can be executed at any given time. The referenced member needs to return
+    /// a <see cref="bool"/> value, and has to have a signature compatible with the target command.
+    /// </summary>
+    public string? CanExecute { get; set; }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
@@ -128,6 +128,92 @@ public partial class Test_ICommandAttribute
         Assert.AreEqual(model.Counter, 1);
     }
 
+    [TestMethod]
+    public async Task Test_ICommandAttribute_CanExecute_Async_NoParameters_Property()
+    {
+        CanExecuteViewModel model = new();
+
+        model.Flag = true;
+
+        await model.IncrementCounter_Async_NoParameters_PropertyCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.Flag = false;
+
+        await model.IncrementCounter_Async_NoParameters_PropertyCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
+    [TestMethod]
+    public async Task Test_ICommandAttribute_CanExecute_Async_WithParameter_Property()
+    {
+        CanExecuteViewModel model = new();
+
+        model.Flag = true;
+
+        await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.Flag = false;
+
+        await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
+    [TestMethod]
+    public async Task Test_ICommandAttribute_CanExecute_Async_NoParameters_MethodWithNoParameters()
+    {
+        CanExecuteViewModel model = new();
+
+        model.Flag = true;
+
+        await model.IncrementCounter_Async_NoParameters_MethodWithNoParametersCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.Flag = false;
+
+        await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
+    [TestMethod]
+    public async Task Test_ICommandAttribute_CanExecute_Async_WithParameters_MethodWithNoParameters()
+    {
+        CanExecuteViewModel model = new();
+
+        model.Flag = true;
+
+        await model.IncrementCounter_Async_WithParameters_MethodWithNoParametersCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.Flag = false;
+
+        await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
+    [TestMethod]
+    public async Task Test_ICommandAttribute_CanExecute_Async_WithParameters_MethodWithMatchingParameter()
+    {
+        CanExecuteViewModel model = new();
+
+        await model.IncrementCounter_Async_WithParameters_MethodWithMatchingParameterCommand.ExecuteAsync(new User { Name = nameof(CanExecuteViewModel) });
+
+        Assert.AreEqual(model.Counter, 1);
+
+        await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(new User());
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
     public sealed partial class MyViewModel
     {
         public int Counter { get; private set; }
@@ -232,6 +318,46 @@ public partial class Test_ICommandAttribute
         private void IncrementCounter_WithParameters_MethodWithMatchingParameter(User user)
         {
             Counter++;
+        }
+
+        [ICommand(CanExecute = nameof(Flag))]
+        private async Task IncrementCounter_Async_NoParameters_Property()
+        {
+            Counter++;
+
+            await Task.Delay(100);
+        }
+
+        [ICommand(CanExecute = nameof(Flag))]
+        private async Task IncrementCounter_Async_WithParameter_Property(User user)
+        {
+            Counter++;
+
+            await Task.Delay(100);
+        }
+
+        [ICommand(CanExecute = nameof(GetFlag1))]
+        private async Task IncrementCounter_Async_NoParameters_MethodWithNoParameters()
+        {
+            Counter++;
+
+            await Task.Delay(100);
+        }
+
+        [ICommand(CanExecute = nameof(GetFlag1))]
+        private async Task IncrementCounter_Async_WithParameters_MethodWithNoParameters(User user)
+        {
+            Counter++;
+
+            await Task.Delay(100);
+        }
+
+        [ICommand(CanExecute = nameof(GetFlag2))]
+        private async Task IncrementCounter_Async_WithParameters_MethodWithMatchingParameter(User user)
+        {
+            Counter++;
+
+            await Task.Delay(100);
         }
     }
 

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
@@ -17,8 +17,6 @@ public partial class Test_ICommandAttribute
     {
         MyViewModel? model = new();
 
-        Assert.AreEqual(model.Counter, 0);
-
         model.IncrementCounterCommand.Execute(null);
 
         Assert.AreEqual(model.Counter, 1);
@@ -42,6 +40,92 @@ public partial class Test_ICommandAttribute
         await model.DelayAndIncrementCounterWithValueAndTokenCommand.ExecuteAsync(5);
 
         Assert.AreEqual(model.Counter, 18);
+    }
+
+    [TestMethod]
+    public void Test_ICommandAttribute_CanExecute_NoParameters_Property()
+    {
+        CanExecuteViewModel model = new();
+
+        model.Flag = true;
+
+        model.IncrementCounter_NoParameters_PropertyCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.Flag = false;
+
+        model.IncrementCounter_NoParameters_PropertyCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
+    [TestMethod]
+    public void Test_ICommandAttribute_CanExecute_WithParameter_Property()
+    {
+        CanExecuteViewModel model = new();
+
+        model.Flag = true;
+
+        model.IncrementCounter_WithParameter_PropertyCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.Flag = false;
+
+        model.IncrementCounter_WithParameter_PropertyCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
+    [TestMethod]
+    public void Test_ICommandAttribute_CanExecute_NoParameters_MethodWithNoParameters()
+    {
+        CanExecuteViewModel model = new();
+
+        model.Flag = true;
+
+        model.IncrementCounter_NoParameters_MethodWithNoParametersCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.Flag = false;
+
+        model.IncrementCounter_WithParameter_PropertyCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
+    [TestMethod]
+    public void Test_ICommandAttribute_CanExecute_WithParameters_MethodWithNoParameters()
+    {
+        CanExecuteViewModel model = new();
+
+        model.Flag = true;
+
+        model.IncrementCounter_WithParameters_MethodWithNoParametersCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.Flag = false;
+
+        model.IncrementCounter_WithParameter_PropertyCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 1);
+    }
+
+    [TestMethod]
+    public void Test_ICommandAttribute_CanExecute_WithParameters_MethodWithMatchingParameter()
+    {
+        CanExecuteViewModel model = new();
+
+        model.IncrementCounter_WithParameters_MethodWithMatchingParameterCommand.Execute(new User { Name = nameof(CanExecuteViewModel) });
+
+        Assert.AreEqual(model.Counter, 1);
+
+        model.IncrementCounter_WithParameter_PropertyCommand.Execute(new User());
+
+        Assert.AreEqual(model.Counter, 1);
     }
 
     public sealed partial class MyViewModel
@@ -108,5 +192,51 @@ public partial class Test_ICommandAttribute
 
             Counter += count;
         }
+    }
+    
+    public sealed partial class CanExecuteViewModel
+    {
+        public int Counter { get; private set; }
+
+        public bool Flag { get; set; }
+
+        private bool GetFlag1() => Flag;
+
+        private bool GetFlag2(User user) => user.Name == nameof(CanExecuteViewModel);
+
+        [ICommand(CanExecute = nameof(Flag))]
+        private void IncrementCounter_NoParameters_Property()
+        {
+            Counter++;
+        }
+
+        [ICommand(CanExecute = nameof(Flag))]
+        private void IncrementCounter_WithParameter_Property(User user)
+        {
+            Counter++;
+        }
+
+        [ICommand(CanExecute = nameof(GetFlag1))]
+        private void IncrementCounter_NoParameters_MethodWithNoParameters()
+        {
+            Counter++;
+        }
+
+        [ICommand(CanExecute = nameof(GetFlag1))]
+        private void IncrementCounter_WithParameters_MethodWithNoParameters(User user)
+        {
+            Counter++;
+        }
+
+        [ICommand(CanExecute = nameof(GetFlag2))]
+        private void IncrementCounter_WithParameters_MethodWithMatchingParameter(User user)
+        {
+            Counter++;
+        }
+    }
+
+    public sealed class User
+    {
+        public string? Name { get; set; }
     }
 }


### PR DESCRIPTION
**Contributes to #8**

This PR adds the `CanExecute` property to `[ICommand]`.

### API breakdown:

```diff
 namespace CommunityToolkit.Mvvm.Input
 {
     public sealed class ICommandAttribute : Attribute
     {
+        public string? CanExecute { get; set; }
     }
 }
```