### PR TITLE
Optimize StrongReferenceMessenger

### DIFF
--- a/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.cs
+++ b/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.cs
@@ -254,6 +254,10 @@ public static class IMessengerExtensions
         {
             weakReferenceMessenger.Register(recipient, token);
         }
+        else if (messenger is StrongReferenceMessenger strongReferenceMessenger)
+        {
+            strongReferenceMessenger.Register(recipient, token);
+        }
         else
         {
             messenger.Register<IRecipient<TMessage>, TMessage, TToken>(recipient, token, static (r, m) => r.Receive(m));

--- a/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
@@ -122,7 +122,9 @@ public sealed class StrongReferenceMessenger : IMessenger
 
                 Recipient key = new(recipient);
 
-                return mapping.ContainsKey(key);
+                return
+                    mapping.TryGetValue(key, out Dictionary2<TToken, object?>? handlers) &&
+                    handlers.ContainsKey(token);
             }
         }
     }

--- a/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
@@ -46,23 +46,28 @@ public sealed class StrongReferenceMessenger : IMessenger
     // which holds the references from registered recipients to handlers. Mapping is used when the default channel is being
     // requested, as in that case there will only ever be up to a handler per recipient, per message type. In that case,
     // each recipient will only track the message dispatcher (stored as an object?, see notes below), instead of a dictionary
-    // mapping each TToken value to the corresponding dispatcher for that recipient. When a custom channel is used, the dispatchers
-    // are stored in a <TToken, object?> dictionary, so that each recipient can have up to one registered handler for a given token,
-    // for each message type. Note that the registered dispatchers are only stored as object references, as they can either be null
-    // or a MessageHandlerDispatcher.For<TRecipient, TMessage> instance. The first case happens if the handler was registered through
-    // an IRecipient<TMessage> instance, while the second one is used to wrap input MessageHandler<TRecipient, TMessage> instances.
-    // The MessageHandlerDispatcher.For<TRecipient, TMessage> instances will just be cast to MessageHandlerDispatcher when invoking it.
-    // This allows users to retain type information on each registered recipient, instead of having to manually cast each recipient
-    // to the right type within the handler (additionally, using double dispatch here avoids the need to alias delegate types).
-    // The type conversion is guaranteed to be respected due to how the messenger type itself works - as registered handlers are always
-    // invoked on their respective recipients. Each mapping is stored in the types map, which associates each pair of concrete types to
-    // its mapping instance. Mapping instances are exposed as IMapping items, as each will be a closed type over a different combination
-    // of TMessage and TToken generic type parameters (or just of TMessage, for the default channel). Each existing recipient is also
-    // stored in the main recipients map, along with a set of all the existing (dictionaries of) handlers for that recipient (for all
-    // message types and token types, if any). A recipient is stored in the main map as long as it has at least one registered handler in
-    // any of the existing mappings for every message/token type combination. The shared map is used to access the set of all registered
-    // handlers for a given recipient, without having to know in advance the type of message or token being used for the registration, and
-    // without having to use reflection. This is the same approach used in the types map, as we expose saved items as IMapping values too.
+    // mapping each TToken value to the corresponding dispatcher for that recipient. When a custom channel is used, the
+    // dispatchers are stored in a <TToken, object?> dictionary, so that each recipient can have up to one registered handler
+    // for a given token, for each message type. Note that the registered dispatchers are only stored as object references, as
+    // they can either be null or a MessageHandlerDispatcher.For<TRecipient, TMessage> instance.
+    //
+    // The first case happens if the handler was registered through an IRecipient<TMessage> instance, while the second one is
+    // used to wrap input MessageHandler<TRecipient, TMessage> instances. The MessageHandlerDispatcher.For<TRecipient, TMessage>
+    // instances will just be cast to MessageHandlerDispatcher when invoking it. This allows users to retain type information on
+    // each registered recipient, instead of having to manually cast each recipient to the right type within the handler
+    // (additionally, using double dispatch here avoids the need to alias delegate types). The type conversion is guaranteed to be
+    // respected due to how the messenger type itself works - as registered handlers are always invoked on their respective recipients.
+    //
+    // Each mapping is stored in the types map, which associates each pair of concrete types to its mapping instance. Mapping instances
+    // are exposed as IMapping items, as each will be a closed type over a different combination of TMessage and TToken generic type
+    // parameters (or just of TMessage, for the default channel). Each existing recipient is also stored in the main recipients map,
+    // along with a set of all the existing (dictionaries of) handlers for that recipient (for all message types and token types, if any).
+    //
+    // A recipient is stored in the main map as long as it has at least one registered handler in any of the existing mappings for every
+    // message/token type combination. The shared map is used to access the set of all registered handlers for a given recipient, without
+    // having to know in advance the type of message or token being used for the registration, and without having to use reflection. This
+    // is the same approach used in the types map, as we expose saved items as IMapping values too.
+    //
     // Note that each mapping stored in the associated set for each recipient also indirectly implements either IDictionary2<Recipient, Token>
     // or IDictionary2<Recipient>, with any token type currently in use by that recipient (or none, if using the default channel). This allows
     // to retrieve the type-closed mappings of registered handlers with a given token type, for any message type, for every receiver, again

--- a/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
@@ -115,6 +115,14 @@ public sealed class StrongReferenceMessenger : IMessenger
         Register<TMessage, TToken>(recipient, token, new MessageHandlerDispatcher.For<TRecipient, TMessage>(handler));
     }
 
+    /// <inheritdoc cref="WeakReferenceMessenger.Register{TMessage, TToken}(IRecipient{TMessage}, TToken)"/>
+    internal void Register<TMessage, TToken>(IRecipient<TMessage> recipient, TToken token)
+        where TMessage : class
+        where TToken : IEquatable<TToken>
+    {
+        Register<TMessage, TToken>(recipient, token, null);
+    }
+
     /// <summary>
     /// Registers a recipient for a given type of message.
     /// </summary>

--- a/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/StrongReferenceMessenger.cs
@@ -255,7 +255,13 @@ public sealed class StrongReferenceMessenger : IMessenger
     public void UnregisterAll<TToken>(object recipient, TToken token)
         where TToken : IEquatable<TToken>
     {
-        // This method is never called with the unit type
+        // This method is never called with the unit type, so this path is not implemented. This
+        // exception should not ever be thrown, it's here just to double check for regressions in
+        // case a bug was introduced that caused this path to somehow be invoked with the Unit type.
+        // This type is internal, so consumers of the library would never be able to pass it here,
+        // and there are (and shouldn't be) any APIs publicly exposed from the library that would
+        // cause this path to be taken either. When using the default channel, only UnregisterAll(object)
+        // is supported, which would just unregister all recipients regardless of the selected channel.
         if (typeof(TToken) == typeof(Unit))
         {
             throw new NotImplementedException();

--- a/CommunityToolkit.Mvvm/Messaging/WeakReferenceMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/WeakReferenceMessenger.cs
@@ -218,6 +218,12 @@ public sealed class WeakReferenceMessenger : IMessenger
     public void UnregisterAll<TToken>(object recipient, TToken token)
         where TToken : IEquatable<TToken>
     {
+        // This method is never called with the unit type
+        if (typeof(TToken) == typeof(Unit))
+        {
+            throw new NotImplementedException();
+        }
+
         lock (this.recipientsMap)
         {
             Dictionary2<Type2, ConditionalWeakTable2<object, object?>>.Enumerator enumerator = this.recipientsMap.GetEnumerator();
@@ -229,11 +235,7 @@ public sealed class WeakReferenceMessenger : IMessenger
             {
                 if (enumerator.GetKey().TToken == typeof(TToken))
                 {
-                    if (typeof(TToken) == typeof(Unit))
-                    {
-                        _ = enumerator.GetValue().Remove(recipient);
-                    }
-                    else if (enumerator.GetValue().TryGetValue(recipient, out object? mapping))
+                    if (enumerator.GetValue().TryGetValue(recipient, out object? mapping))
                     {
                         _ = Unsafe.As<Dictionary2<TToken, object?>>(mapping!).TryRemove(token);
                     }
@@ -344,7 +346,7 @@ public sealed class WeakReferenceMessenger : IMessenger
     /// of the EH block (the <see langword="try"/> block) can help result in slightly better codegen.
     /// </remarks>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void SendAll<TMessage>(ReadOnlySpan<object?> pairs, int i, TMessage message)
+    internal static void SendAll<TMessage>(ReadOnlySpan<object?> pairs, int i, TMessage message)
         where TMessage : class
     {
         // This Slice calls executes bounds checks for the loop below, in case i was somehow wrong.

--- a/CommunityToolkit.Mvvm/Messaging/WeakReferenceMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/WeakReferenceMessenger.cs
@@ -218,7 +218,8 @@ public sealed class WeakReferenceMessenger : IMessenger
     public void UnregisterAll<TToken>(object recipient, TToken token)
         where TToken : IEquatable<TToken>
     {
-        // This method is never called with the unit type
+        // This method is never called with the unit type. See more details in
+        // the comments in the corresponding method in StrongReferenceMessenger.
         if (typeof(TToken) == typeof(Unit))
         {
             throw new NotImplementedException();

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_Messenger.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_Messenger.cs
@@ -73,6 +73,8 @@ public partial class Test_Messenger
 
         messenger.Register<MessageA>(recipient, (r, m) => { });
 
+        Assert.IsTrue(messenger.IsRegistered<MessageA>(recipient));
+
         messenger.Unregister<MessageA>(recipient);
 
         Assert.IsFalse(messenger.IsRegistered<MessageA>(recipient));
@@ -88,9 +90,81 @@ public partial class Test_Messenger
 
         messenger.Register<MessageA, string>(recipient, nameof(MessageA), (r, m) => { });
 
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, nameof(MessageA)));
+
         messenger.Unregister<MessageA, string>(recipient, nameof(MessageA));
 
         Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, nameof(MessageA)));
+    }
+
+    [TestMethod]
+    [DataRow(typeof(StrongReferenceMessenger))]
+    [DataRow(typeof(WeakReferenceMessenger))]
+    public void Test_Messenger_RegisterAndUnregisterRecipientWithMessageTypeAndMultipleTokens(Type type)
+    {
+        IMessenger? messenger = (IMessenger)Activator.CreateInstance(type)!;
+        object? recipient = new();
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "b"));
+
+        messenger.Register<MessageA, int>(recipient, 1, (r, m) => { });
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "b"));
+
+        messenger.Register<MessageA, int>(recipient, 2, (r, m) => { });
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "b"));
+
+        messenger.Register<MessageA, string>(recipient, "a", (r, m) => { });
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "b"));
+
+        messenger.Register<MessageA, string>(recipient, "b", (r, m) => { });
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, "b"));
+
+        messenger.Unregister<MessageA, int>(recipient, 1);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, "b"));
+
+        messenger.Unregister<MessageA, int>(recipient, 2);
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, "b"));
+
+        messenger.Unregister<MessageA, string>(recipient, "a");
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, "b"));
+
+        messenger.Unregister<MessageA, string>(recipient, "b");
+
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 1));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, int>(recipient, 2));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "a"));
+        Assert.IsFalse(messenger.IsRegistered<MessageA, string>(recipient, "b"));
     }
 
     [TestMethod]
@@ -102,6 +176,8 @@ public partial class Test_Messenger
         object? recipient = new();
 
         messenger.Register<MessageA, string>(recipient, nameof(MessageA), (r, m) => { });
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, nameof(MessageA)));
 
         messenger.UnregisterAll(recipient, nameof(MessageA));
 
@@ -117,6 +193,8 @@ public partial class Test_Messenger
         object? recipient = new();
 
         messenger.Register<MessageA, string>(recipient, nameof(MessageA), (r, m) => { });
+
+        Assert.IsTrue(messenger.IsRegistered<MessageA, string>(recipient, nameof(MessageA)));
 
         messenger.UnregisterAll(recipient);
 


### PR DESCRIPTION
This PR brings some of the optimizations and improvements from #44 to `StrongReferenceMessenger` too.
Specifically, this includes:

- Using double-dispatch through `MessageHandlerDispatcher` to avoid aliasing delegate types during broadcast.
- Type specialization for `Unit` (used when sending messages through the default channel)
- Specialization for `IRecipient<TMessage>` to avoid the double delegate dispatch
- Other general tweaks and code refactoring

## Benchmarks

| Method |     Mean |     Error |    StdDev | Ratio | Allocated |
|------- |---------:|----------:|----------:|------:|----------:|
|   main | 5.586 ms | 0.0317 ms | 0.0264 ms |  1.00 |         - |
|     **PR** | **4.013 ms** | 0.0074 ms | 0.0058 ms |  **0.71** |         - |

Overall this results in a ~30% speedup 🚀