### PR TITLE
Add NullableExtensions.DangerousGetValueOrNullReference

### DIFF
--- a/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
@@ -12,7 +12,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace CommunityToolkit.HighPerformance.Extensions;
+namespace CommunityToolkit.HighPerformance;
 
 /// <summary>
 /// Helpers for working with the <see cref="Nullable{T}"/> type.

--- a/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
@@ -24,17 +24,37 @@ public static class NullableExtensions
     /// the <see cref="Nullable{T}.HasValue"/> property is returning <see langword="true"/> or not. If that is not
     /// the case, this method will still return a reference to the underlying <see langword="default"/> value.
     /// </summary>
-    /// <typeparam name="T">The type of the underlying value</typeparam>
-    /// <param name="value">The <see cref="Nullable{T}"/></param>
+    /// <typeparam name="T">The type of the underlying value.</typeparam>
+    /// <param name="value">The <see cref="Nullable{T}"/>.</param>
     /// <returns>A reference to the underlying value from the input <see cref="Nullable{T}"/> instance.</returns>
     /// <remarks>
     /// Note that attempting to mutate the returned reference will not change the value returned by <see cref="Nullable{T}.HasValue"/>.
     /// That means that reassigning the value of an empty instance will not make <see cref="Nullable{T}.HasValue"/> return <see langword="true"/>.
     /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetValueOrDefaultReference<T>(this ref T? value)
         where T : struct
     {
         return ref Unsafe.As<T?, RawNullableData<T>>(ref value).Value;
+    }
+
+    /// <summary>
+    /// Returns a reference to the value of the input <see cref="Nullable{T}"/> instance, or a <see langword="null"/> <typeparamref name="T"/> reference.
+    /// </summary>
+    /// <typeparam name="T">The type of the underlying value.</typeparam>
+    /// <param name="value">The <see cref="Nullable{T}"/>.</param>
+    /// <returns>A reference to the value of the input <see cref="Nullable{T}"/> instance, or a <see langword="null"/> <typeparamref name="T"/> reference.</returns>
+    /// <remarks>The returned reference can be tested for <see langword="null"/> using <see cref="Unsafe.IsNullRef{T}(ref T)"/>.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe ref T DangerousGetValueOrNullReference<T>(ref this T? value)
+        where T : struct
+    {
+        if (value.HasValue)
+        {
+            return ref Unsafe.As<T?, RawNullableData<T>>(ref value).Value;
+        }
+
+        return ref Unsafe.NullRef<T>();
     }
 
     /// <summary>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_NullableExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_NullableExtensions.cs
@@ -4,7 +4,9 @@
 
 #if NET6_0_OR_GREATER
 
+using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.HighPerformance.UnitTests.Extensions;
@@ -13,7 +15,7 @@ namespace CommunityToolkit.HighPerformance.UnitTests.Extensions;
 public class Test_NullableExtensions
 {
     [TestMethod]
-    public void Test_NullableExtensions_DangerousGetReference()
+    public void Test_NullableExtensions_DangerousGetValueOrDefaultReference()
     {
         static void Test<T>(T before, T after)
             where T : struct
@@ -33,6 +35,55 @@ public class Test_NullableExtensions
         Test(0.555, 8.49);
         Test(Vector4.Zero, new Vector4(1, 5.55f, 2, 3.14f));
         Test(Matrix4x4.Identity, Matrix4x4.CreateOrthographic(35, 88.34f, 9.99f, 24.6f));
+        Test(new[] { 1, 2 }.AsMemory(), new[] { 3, 4 }.AsMemory());
+        Test(new[] { "a", "b" }.AsMemory(), new[] { "c", "d" }.AsMemory());
+    }
+
+    [TestMethod]
+    public void Test_NullableExtensions_DangerousGetValueOrNullReference_HasValue()
+    {
+        static void Test<T>(T before, T after)
+            where T : struct
+        {
+            T? nullable = before;
+            ref T reference = ref nullable.DangerousGetValueOrNullReference();
+
+            Assert.IsFalse(Unsafe.IsNullRef(ref reference));
+            Assert.AreEqual(nullable!.Value, before);
+
+            reference = after;
+
+            Assert.AreEqual(nullable.Value, after);
+        }
+
+        Test(0, 42);
+        Test(1.3f, 3.14f);
+        Test(0.555, 8.49);
+        Test(Vector4.Zero, new Vector4(1, 5.55f, 2, 3.14f));
+        Test(Matrix4x4.Identity, Matrix4x4.CreateOrthographic(35, 88.34f, 9.99f, 24.6f));
+        Test(new[] { 1, 2 }.AsMemory(), new[] { 3, 4 }.AsMemory());
+        Test(new[] { "a", "b" }.AsMemory(), new[] { "c", "d" }.AsMemory());
+    }
+
+    [TestMethod]
+    public void Test_NullableExtensions_DangerousGetValueOrNullReference_IsNull()
+    {
+        static void Test<T>()
+            where T : struct
+        {
+            T? nullable = null;
+            ref T reference = ref nullable.DangerousGetValueOrNullReference();
+
+            Assert.IsTrue(Unsafe.IsNullRef(ref reference));
+        }
+
+        Test<int>();
+        Test<float>();
+        Test<double>();
+        Test<Vector4>();
+        Test<Matrix4x4>();
+        Test<Memory<int>>();
+        Test<Memory<string>>();
     }
 }
 

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_NullableExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_NullableExtensions.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NET5_0
+#if NET6_0_OR_GREATER
 
 using System.Numerics;
-using CommunityToolkit.HighPerformance.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.HighPerformance.UnitTests.Extensions;


### PR DESCRIPTION
**Closes #61**

This PR adds the `NullableExtensions.DangerousGetValueOrNullReference` method.
It also adjusts the namespace for `NullableExtensions`, which was incorrect.

cc. @rickbrew

### API breakdown:

```csharp
namespace CommunityToolkit.HighPerformance
{
    public static class NullableExtensions
    {
        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        public static unsafe ref T DangerousGetValueOrNullReference<T>(ref this T? value)
            where T : struct;
    }
}
```