### PR TITLE
Add vectorized Count<T> support for nint/nuint

### DIFF
--- a/CommunityToolkit.HighPerformance/Helpers/Internals/SpanHelper.Count.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/SpanHelper.Count.cs
@@ -69,6 +69,17 @@ internal static partial class SpanHelper
             return CountSimd(ref r1, length, target);
         }
 
+#if NET6_0_OR_GREATER
+        if (typeof(T) == typeof(nint) ||
+            typeof(T) == typeof(nuint))
+        {
+            ref nint r1 = ref Unsafe.As<T, nint>(ref r0);
+            nint target = Unsafe.As<T, nint>(ref value);
+
+            return CountSimd(ref r1, length, target);
+        }
+#endif
+
         return CountSequential(ref r0, length, value);
     }
 
@@ -320,6 +331,13 @@ internal static partial class SpanHelper
             return (nint)(void*)long.MaxValue;
         }
 
+#if NET6_0_OR_GREATER
+        if (typeof(T) == typeof(nint))
+        {
+            return nint.MaxValue;
+        }
+#endif
+
         throw null!;
     }
 
@@ -352,6 +370,13 @@ internal static partial class SpanHelper
         {
             return (nint)(ulong)(long)(object)value;
         }
+
+#if NET6_0_OR_GREATER
+        if (typeof(T) == typeof(nint))
+        {
+            return (nint)(object)value;
+        }
+#endif
 
         throw null!;
     }

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/SpanHelper.Count.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/SpanHelper.Count.cs
@@ -240,7 +240,11 @@ internal static partial class SpanHelper
                     offset += Vector<T>.Count;
                 }
 
+#if NET6_0_OR_GREATER
+                result += CastToNativeInt(Vector.Sum(partials));
+#else
                 result += CastToNativeInt(Vector.Dot(partials, Vector<T>.One));
+#endif
                 length -= offset - initialOffset;
             }
             while (length >= Vector<T>.Count);

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.Count.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.Count.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.UnitTests.Buffers.Internals;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -48,6 +47,15 @@ public partial class Test_ReadOnlySpanExtensions
         TestForType((ulong)47128480128401, CreateRandomData);
         TestForType(Math.PI, CreateRandomData);
     }
+
+#if NET6_0_OR_GREATER
+    [TestMethod]
+    public void Test_ReadOnlySpanExtensions_RandomCountPtr()
+    {
+        TestForType(nint.MaxValue / 2, CreateRandomData);
+        TestForType(nuint.MaxValue / 2, CreateRandomData);
+    }
+#endif
 
     [TestMethod]
     public void Test_ReadOnlySpanExtensions_RandomCountManaged()
@@ -147,6 +155,15 @@ public partial class Test_ReadOnlySpanExtensions
         TestForType((long)47128480128401, (count, _) => CreateFilledData(count, (long)47128480128401));
         TestForType((ulong)47128480128401, (count, _) => CreateFilledData(count, (ulong)47128480128401));
     }
+
+#if NET6_0_OR_GREATER
+    [TestMethod]
+    public void Test_ReadOnlySpanExtensions_FilledCountPtr()
+    {
+        TestForType((nint)37438941, (count, _) => CreateFilledData(count, (nint)37438941));
+        TestForType((nuint)37438941, (count, _) => CreateFilledData(count, (nuint)37438941));
+    }
+#endif
 
     /// <summary>
     /// Performs a test for a specified type.


### PR DESCRIPTION
**Closes #36**

This PR enables the vectorized fast path for `Count<T>` for `nint` and `nuint` on .NET 6.
See https://github.com/dotnet/runtime/issues/36160.

Additionally, this PR also replaces `Vector.Dot<T>(Vector<T>, Vector<T>)` with `Vector.Sum<T>(Vector<T>)` on .NET 6.

### Codegen before (dot)

```asm
vmovupd ymm0, [rcx]
vpmulld ymm0, ymm0, [0x7ffcbd7004c0]
vphaddd ymm0, ymm0, ymm0
vphaddd ymm0, ymm0, ymm0
vextractf128 xmm1, ymm0, 1
vpaddd xmm0, xmm0, xmm1
vmovd eax, xmm0
```

### Codegen after (sum)

```asm
vmovupd ymm0, [rcx]
vphaddd ymm0, ymm0, ymm0
vphaddd ymm0, ymm0, ymm0
vextractf128 xmm1, ymm0, 1
vpaddd xmm0, xmm1, xmm0
vmovd eax, xmm0
```

Ie. that `vpmulld` loading `Vector<T>.One` from static data and multiplying is gone, as it wasn't really needed here 🚀