### PR TITLE
Remove [Pure] attribute usages

### DIFF
--- a/CommunityToolkit.Common/Collections/ObservableGroupedCollectionExtensions.cs
+++ b/CommunityToolkit.Common/Collections/ObservableGroupedCollectionExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -24,7 +23,6 @@ public static class ObservableGroupedCollectionExtensions
     /// <param name="key">The key of the group to query.</param>
     /// <returns>The first group matching <paramref name="key"/>.</returns>
     /// <exception cref="InvalidOperationException">The target group does not exist.</exception>
-    [Pure]
     public static ObservableGroup<TKey, TValue> First<TKey, TValue>(this ObservableGroupedCollection<TKey, TValue> source, TKey key)
         where TKey : notnull
     {
@@ -51,7 +49,6 @@ public static class ObservableGroupedCollectionExtensions
     /// <param name="source">The source <see cref="ObservableGroupedCollection{TKey, TValue}"/> instance.</param>
     /// <param name="key">The key of the group to query.</param>
     /// <returns>The first group matching <paramref name="key"/> or null.</returns>
-    [Pure]
     public static ObservableGroup<TKey, TValue>? FirstOrDefault<TKey, TValue>(this ObservableGroupedCollection<TKey, TValue> source, TKey key)
         where TKey : notnull
     {
@@ -89,7 +86,6 @@ public static class ObservableGroupedCollectionExtensions
     /// <returns>The element.</returns>
     /// <exception cref="InvalidOperationException">The target group does not exist.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than zero or <paramref name="index"/> is greater than the group elements' count.</exception>
-    [Pure]
     public static TValue ElementAt<TKey, TValue>(
         this ObservableGroupedCollection<TKey, TValue> source,
         TKey key,
@@ -106,7 +102,6 @@ public static class ObservableGroupedCollectionExtensions
     /// <param name="key">The key of the group to query.</param>
     /// <param name="index">The index of the item from the targeted group.</param>
     /// <returns>The element or default(TValue) if it does not exist.</returns>
-    [Pure]
     public static TValue? ElementAtOrDefault<TKey, TValue>(
         this ObservableGroupedCollection<TKey, TValue> source,
         TKey key,

--- a/CommunityToolkit.Common/Extensions/TaskExtensions.cs
+++ b/CommunityToolkit.Common/Extensions/TaskExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -24,7 +23,6 @@ public static class TaskExtensions
     /// and uses reflection to access the <see cref="Task{TResult}.Result"/> property and boxes the result if it's
     /// a value type, which adds overhead. It should only be used when using generics is not possible.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static object? GetResultOrDefault(this Task task)
     {
@@ -66,7 +64,6 @@ public static class TaskExtensions
     /// <param name="task">The input <see cref="Task{TResult}"/> instance to get the result for.</param>
     /// <returns>The result of <paramref name="task"/> if completed successfully, or <see langword="default"/> otherwise.</returns>
     /// <remarks>This method does not block if <paramref name="task"/> has not completed yet.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T? GetResultOrDefault<T>(this Task<T?> task)
     {

--- a/CommunityToolkit.Diagnostics/Extensions/TypeExtensions.cs
+++ b/CommunityToolkit.Diagnostics/Extensions/TypeExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -48,7 +47,6 @@ public static class TypeExtensions
     /// </summary>
     /// <param name="type">The input type.</param>
     /// <returns>The string representation of <paramref name="type"/>.</returns>
-    [Pure]
     public static string ToTypeString(this Type type)
     {
         // Local function to create the formatted string for a given type

--- a/CommunityToolkit.Diagnostics/Extensions/ValueTypeExtensions.cs
+++ b/CommunityToolkit.Diagnostics/Extensions/ValueTypeExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -42,7 +41,6 @@ public static class ValueTypeExtensions
     /// Console.WriteLine((-1).ToHexString()); // "0xFFFFFFFF"
     /// </code>
     /// </remarks>
-    [Pure]
     [SkipLocalsInit]
     public static unsafe string ToHexString<T>(this T value)
         where T : unmanaged

--- a/CommunityToolkit.Diagnostics/Guard.Comparable.Generic.cs
+++ b/CommunityToolkit.Diagnostics/Guard.Comparable.Generic.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
 namespace CommunityToolkit.Diagnostics;
@@ -191,7 +190,6 @@ public static partial class Guard
     }
 
     // Compares 64 bits of data from two given memory locations for bitwise equality
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static unsafe bool Bit64Compare(ref ulong left, ref ulong right)
     {

--- a/CommunityToolkit.Diagnostics/Internals/Guard.ThrowHelper.cs
+++ b/CommunityToolkit.Diagnostics/Internals/Guard.ThrowHelper.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 
 namespace CommunityToolkit.Diagnostics;
 
@@ -23,7 +22,6 @@ public static partial class Guard
         /// </summary>
         /// <param name="obj">The input <see cref="object"/> to format.</param>
         /// <returns>A formatted representation of <paramref name="obj"/> to display in error messages.</returns>
-        [Pure]
         private static string AssertString(object? obj)
         {
             return obj switch

--- a/CommunityToolkit.HighPerformance/Box{T}.cs
+++ b/CommunityToolkit.HighPerformance/Box{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
 namespace CommunityToolkit.HighPerformance;
@@ -69,7 +68,6 @@ public sealed class Box<T>
     /// </summary>
     /// <param name="obj">The input <see cref="object"/> instance, representing a boxed <typeparamref name="T"/> value.</param>
     /// <returns>A <see cref="Box{T}"/> reference pointing to <paramref name="obj"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Box<T> GetFrom(object obj)
     {
@@ -90,7 +88,6 @@ public sealed class Box<T>
     /// This method doesn't check the actual type of <paramref name="obj"/>, so it is responsibility of the caller
     /// to ensure it actually represents a boxed <typeparamref name="T"/> value and not some other instance.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Box<T> DangerousGetFrom(object obj)
     {
@@ -197,7 +194,6 @@ public static class BoxExtensions
     /// <typeparam name="T">The type of reference to retrieve.</typeparam>
     /// <param name="box">The input <see cref="Box{T}"/> instance.</param>
     /// <returns>A <typeparamref name="T"/> reference to the boxed value within <paramref name="box"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T GetReference<T>(this Box<T> box)
         where T : struct

--- a/CommunityToolkit.HighPerformance/Buffers/ArrayPoolBufferWriter{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/ArrayPoolBufferWriter{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance.Buffers.Views;
@@ -320,7 +319,6 @@ public sealed class ArrayPoolBufferWriter<T> : IBuffer<T>, IMemoryOwner<T>
     }
 
     /// <inheritdoc/>
-    [Pure]
     public override string ToString()
     {
         // See comments in MemoryOwner<T> about this

--- a/CommunityToolkit.HighPerformance/Buffers/MemoryBufferWriter{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/MemoryBufferWriter{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Buffers.Views;
 
@@ -144,7 +143,6 @@ public sealed class MemoryBufferWriter<T> : IBuffer<T>
     }
 
     /// <inheritdoc/>
-    [Pure]
     public override string ToString()
     {
         // See comments in MemoryOwner<T> about this

--- a/CommunityToolkit.HighPerformance/Buffers/MemoryOwner{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/MemoryOwner{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 #if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.InteropServices;
@@ -86,7 +85,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     /// <summary>
     /// Gets an empty <see cref="MemoryOwner{T}"/> instance.
     /// </summary>
-    [Pure]
     public static MemoryOwner<T> Empty
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -100,7 +98,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     /// <returns>A <see cref="MemoryOwner{T}"/> instance of the requested length.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
     /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static MemoryOwner<T> Allocate(int size) => new(size, ArrayPool<T>.Shared, AllocationMode.Default);
 
@@ -112,7 +109,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     /// <returns>A <see cref="MemoryOwner{T}"/> instance of the requested length.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
     /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static MemoryOwner<T> Allocate(int size, ArrayPool<T> pool) => new(size, pool, AllocationMode.Default);
 
@@ -124,7 +120,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     /// <returns>A <see cref="MemoryOwner{T}"/> instance of the requested length.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
     /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static MemoryOwner<T> Allocate(int size, AllocationMode mode) => new(size, ArrayPool<T>.Shared, mode);
 
@@ -137,7 +132,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     /// <returns>A <see cref="MemoryOwner{T}"/> instance of the requested length.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
     /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static MemoryOwner<T> Allocate(int size, ArrayPool<T> pool, AllocationMode mode) => new(size, pool, mode);
 
@@ -211,7 +205,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     /// the buffer itself has been disposed or not. This check should not be removed, and it's also
     /// the reason why the method to get a reference at a specified offset is not present.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T DangerousGetReference()
     {
@@ -236,7 +229,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     /// not used after the current <see cref="MemoryOwner{T}"/> instance is disposed. Doing so is considered undefined behavior,
     /// as the same array might be in use within another <see cref="MemoryOwner{T}"/> instance.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ArraySegment<T> DangerousGetArray()
     {
@@ -311,7 +303,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     }
 
     /// <inheritdoc/>
-    [Pure]
     public override string ToString()
     {
         // Normally we would throw if the array has been disposed,

--- a/CommunityToolkit.HighPerformance/Buffers/SpanOwner{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/SpanOwner{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 #if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.InteropServices;
@@ -75,7 +74,6 @@ public readonly ref struct SpanOwner<T>
     /// <summary>
     /// Gets an empty <see cref="SpanOwner{T}"/> instance.
     /// </summary>
-    [Pure]
     public static SpanOwner<T> Empty
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -89,7 +87,6 @@ public readonly ref struct SpanOwner<T>
     /// <returns>A <see cref="SpanOwner{T}"/> instance of the requested length.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
     /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SpanOwner<T> Allocate(int size) => new(size, ArrayPool<T>.Shared, AllocationMode.Default);
 
@@ -101,7 +98,6 @@ public readonly ref struct SpanOwner<T>
     /// <returns>A <see cref="SpanOwner{T}"/> instance of the requested length.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
     /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SpanOwner<T> Allocate(int size, ArrayPool<T> pool) => new(size, pool, AllocationMode.Default);
 
@@ -113,7 +109,6 @@ public readonly ref struct SpanOwner<T>
     /// <returns>A <see cref="SpanOwner{T}"/> instance of the requested length.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
     /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SpanOwner<T> Allocate(int size, AllocationMode mode) => new(size, ArrayPool<T>.Shared, mode);
 
@@ -126,7 +121,6 @@ public readonly ref struct SpanOwner<T>
     /// <returns>A <see cref="SpanOwner{T}"/> instance of the requested length.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
     /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SpanOwner<T> Allocate(int size, ArrayPool<T> pool, AllocationMode mode) => new(size, pool, mode);
 
@@ -161,7 +155,6 @@ public readonly ref struct SpanOwner<T>
     /// Returns a reference to the first element within the current instance, with no bounds check.
     /// </summary>
     /// <returns>A reference to the first element within the current instance.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T DangerousGetReference()
     {
@@ -178,7 +171,6 @@ public readonly ref struct SpanOwner<T>
     /// not used after the current <see cref="SpanOwner{T}"/> instance is disposed. Doing so is considered undefined behavior,
     /// as the same array might be in use within another <see cref="SpanOwner{T}"/> instance.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ArraySegment<T> DangerousGetArray()
     {
@@ -195,7 +187,6 @@ public readonly ref struct SpanOwner<T>
     }
 
     /// <inheritdoc/>
-    [Pure]
     public override string ToString()
     {
         if (typeof(T) == typeof(char) &&

--- a/CommunityToolkit.HighPerformance/Buffers/StringPool.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/StringPool.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Text;
 using CommunityToolkit.HighPerformance.Helpers;
@@ -767,7 +766,6 @@ public sealed class StringPool
     /// </summary>
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> instance.</param>
     /// <returns>The hashcode for <paramref name="span"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int GetHashCode(ReadOnlySpan<char> span)
     {

--- a/CommunityToolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
+++ b/CommunityToolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 #if NETSTANDARD2_1_OR_GREATER
 using System.Runtime.InteropServices;
@@ -85,7 +84,6 @@ public readonly ref struct ReadOnlyRefEnumerable<T>
     /// <param name="step">The distance between items in the sequence to enumerate.</param>
     /// <returns>A <see cref="ReadOnlyRefEnumerable{T}"/> instance with the specified parameters.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when one of the parameters are negative.</exception>
-    [Pure]
     public static ReadOnlyRefEnumerable<T> DangerousCreate(in T value, int length, int step)
     {
         if (length < 0)
@@ -180,7 +178,6 @@ public readonly ref struct ReadOnlyRefEnumerable<T>
 #endif
 
     /// <inheritdoc cref="System.Collections.IEnumerable.GetEnumerator"/>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator GetEnumerator()
     {
@@ -316,7 +313,6 @@ public readonly ref struct ReadOnlyRefEnumerable<T>
     }
 
     /// <inheritdoc cref="RefEnumerable{T}.ToArray"/>
-    [Pure]
     public T[] ToArray()
     {
 #if NETSTANDARD2_1_OR_GREATER

--- a/CommunityToolkit.HighPerformance/Enumerables/ReadOnlySpanEnumerable{T}.cs
+++ b/CommunityToolkit.HighPerformance/Enumerables/ReadOnlySpanEnumerable{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -43,7 +42,6 @@ public ref struct ReadOnlySpanEnumerable<T>
     /// Implements the duck-typed <see cref="IEnumerable{T}.GetEnumerator"/> method.
     /// </summary>
     /// <returns>An <see cref="ReadOnlySpanEnumerable{T}"/> instance targeting the current <see cref="ReadOnlySpan{T}"/> value.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly ReadOnlySpanEnumerable<T> GetEnumerator() => this;
 

--- a/CommunityToolkit.HighPerformance/Enumerables/ReadOnlySpanTokenizer{T}.cs
+++ b/CommunityToolkit.HighPerformance/Enumerables/ReadOnlySpanTokenizer{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
 namespace CommunityToolkit.HighPerformance.Enumerables;
@@ -56,7 +55,6 @@ public ref struct ReadOnlySpanTokenizer<T>
     /// Implements the duck-typed <see cref="IEnumerable{T}.GetEnumerator"/> method.
     /// </summary>
     /// <returns>An <see cref="ReadOnlySpanTokenizer{T}"/> instance targeting the current <see cref="ReadOnlySpan{T}"/> value.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly ReadOnlySpanTokenizer<T> GetEnumerator() => this;
 

--- a/CommunityToolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
+++ b/CommunityToolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 #if NETSTANDARD2_1_OR_GREATER
 using System.Runtime.InteropServices;
@@ -68,7 +67,6 @@ public readonly ref struct RefEnumerable<T>
     /// <param name="step">The distance between items in the sequence to enumerate.</param>
     /// <returns>A <see cref="RefEnumerable{T}"/> instance with the specified parameters.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when one of the parameters are negative.</exception>
-    [Pure]
     public static RefEnumerable<T> DangerousCreate(ref T value, int length, int step)
     {
         if (length < 0)
@@ -163,7 +161,6 @@ public readonly ref struct RefEnumerable<T>
 #endif
 
     /// <inheritdoc cref="System.Collections.IEnumerable.GetEnumerator"/>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator GetEnumerator()
     {
@@ -411,7 +408,6 @@ public readonly ref struct RefEnumerable<T>
     /// This method will allocate a new <typeparamref name="T"/> array, so only
     /// use it if you really need to copy the target items in a new memory location.
     /// </remarks>
-    [Pure]
     public T[] ToArray()
     {
 #if NETSTANDARD2_1_OR_GREATER

--- a/CommunityToolkit.HighPerformance/Enumerables/SpanEnumerable{T}.cs
+++ b/CommunityToolkit.HighPerformance/Enumerables/SpanEnumerable{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -43,7 +42,6 @@ public ref struct SpanEnumerable<T>
     /// Implements the duck-typed <see cref="IEnumerable{T}.GetEnumerator"/> method.
     /// </summary>
     /// <returns>An <see cref="SpanEnumerable{T}"/> instance targeting the current <see cref="Span{T}"/> value.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly SpanEnumerable<T> GetEnumerator() => this;
 

--- a/CommunityToolkit.HighPerformance/Enumerables/SpanTokenizer{T}.cs
+++ b/CommunityToolkit.HighPerformance/Enumerables/SpanTokenizer{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
 namespace CommunityToolkit.HighPerformance.Enumerables;
@@ -56,7 +55,6 @@ public ref struct SpanTokenizer<T>
     /// Implements the duck-typed <see cref="IEnumerable{T}.GetEnumerator"/> method.
     /// </summary>
     /// <returns>An <see cref="SpanTokenizer{T}"/> instance targeting the current <see cref="Span{T}"/> value.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly SpanTokenizer<T> GetEnumerator() => this;
 

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.1D.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.1D.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 #if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.InteropServices;
@@ -29,7 +28,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input <typeparamref name="T"/> array instance.</param>
     /// <returns>A reference to the first element within <paramref name="array"/>, or the location it would have used, if <paramref name="array"/> is empty.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to perform checks in case the returned value is dereferenced.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReference<T>(this T[] array)
     {
@@ -55,7 +53,6 @@ public static partial class ArrayExtensions
     /// <param name="i">The index of the element to retrieve within <paramref name="array"/>.</param>
     /// <returns>A reference to the element within <paramref name="array"/> at the index specified by <paramref name="i"/>.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this T[] array, int i)
     {
@@ -106,7 +103,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input <typeparamref name="T"/> array instance.</param>
     /// <param name="value">The <typeparamref name="T"/> value to look for.</param>
     /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Count<T>(this T[] array, T value)
         where T : IEquatable<T>
@@ -142,7 +138,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The source <typeparamref name="T"/> array to enumerate.</param>
     /// <returns>A wrapper type that will handle the reference/index enumeration for <paramref name="array"/>.</returns>
     /// <remarks>The returned <see cref="SpanEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SpanEnumerable<T> Enumerate<T>(this T[] array)
     {
@@ -167,7 +162,6 @@ public static partial class ArrayExtensions
     /// <param name="separator">The separator <typeparamref name="T"/> item to use.</param>
     /// <returns>A wrapper type that will handle the tokenization for <paramref name="array"/>.</returns>
     /// <remarks>The returned <see cref="SpanTokenizer{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SpanTokenizer<T> Tokenize<T>(this T[] array, T separator)
         where T : IEquatable<T>
@@ -183,7 +177,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input <typeparamref name="T"/> array instance.</param>
     /// <returns>The Djb2 value for the input <typeparamref name="T"/> array instance.</returns>
     /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetDjb2HashCode<T>(this T[] array)
         where T : notnull
@@ -200,7 +193,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of items in the input <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input <typeparamref name="T"/> array instance.</param>
     /// <returns>Whether or not <paramref name="array"/> is covariant.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsCovariant<T>(this T[] array)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.2D.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.2D.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 #if NETSTANDARD2_1_OR_GREATER
 using System.Runtime.InteropServices;
@@ -28,7 +27,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input <typeparamref name="T"/> array instance.</param>
     /// <returns>A reference to the first element within <paramref name="array"/>, or the location it would have used, if <paramref name="array"/> is empty.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to perform checks in case the returned value is dereferenced.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReference<T>(this T[,] array)
     {
@@ -60,7 +58,6 @@ public static partial class ArrayExtensions
     /// array, and will just assume that the input index is 0-based. It is responsibility of the caller to adjust the input
     /// indices to account for the actual lower bounds, if the input array has either axis not starting at 0.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this T[,] array, int i, int j)
     {
@@ -121,7 +118,6 @@ public static partial class ArrayExtensions
     /// <returns>A <see cref="RefEnumerable{T}"/> with the items from the target row within <paramref name="array"/>.</returns>
     /// <remarks>The returned <see cref="RefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when one of the input parameters is out of range.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static RefEnumerable<T> GetRow<T>(this T[,] array, int row)
     {
@@ -175,7 +171,6 @@ public static partial class ArrayExtensions
     /// <returns>A wrapper type that will handle the column enumeration for <paramref name="array"/>.</returns>
     /// <remarks>The returned <see cref="RefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when one of the input parameters is out of range.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static RefEnumerable<T> GetColumn<T>(this T[,] array, int column)
     {
@@ -211,7 +206,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of elements in the input 2D <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input 2D <typeparamref name="T"/> array instance.</param>
     /// <returns>A <see cref="Span2D{T}"/> instance with the values of <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span2D<T> AsSpan2D<T>(this T[,]? array)
     {
@@ -235,7 +229,6 @@ public static partial class ArrayExtensions
     /// are negative or not within the bounds that are valid for <paramref name="array"/>.
     /// </exception>
     /// <returns>A <see cref="Span2D{T}"/> instance with the values of <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span2D<T> AsSpan2D<T>(this T[,]? array, int row, int column, int height, int width)
     {
@@ -248,7 +241,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of elements in the input 2D <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input 2D <typeparamref name="T"/> array instance.</param>
     /// <returns>A <see cref="Memory2D{T}"/> instance with the values of <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory2D<T> AsMemory2D<T>(this T[,]? array)
     {
@@ -272,7 +264,6 @@ public static partial class ArrayExtensions
     /// are negative or not within the bounds that are valid for <paramref name="array"/>.
     /// </exception>
     /// <returns>A <see cref="Memory2D{T}"/> instance with the values of <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory2D<T> AsMemory2D<T>(this T[,]? array, int row, int column, int height, int width)
     {
@@ -289,7 +280,6 @@ public static partial class ArrayExtensions
     /// <returns>A <see cref="Span{T}"/> with the items from the target row within <paramref name="array"/>.</returns>
     /// <exception cref="ArrayTypeMismatchException">Thrown when <paramref name="array"/> doesn't match <typeparamref name="T"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="row"/> is invalid.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<T> GetRowSpan<T>(this T[,] array, int row)
     {
@@ -317,7 +307,6 @@ public static partial class ArrayExtensions
     /// <returns>A <see cref="Memory{T}"/> with the items from the target row within <paramref name="array"/>.</returns>
     /// <exception cref="ArrayTypeMismatchException">Thrown when <paramref name="array"/> doesn't match <typeparamref name="T"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="row"/> is invalid.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory<T> GetRowMemory<T>(this T[,] array, int row)
     {
@@ -343,7 +332,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of elements in the input 2D <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input 2D <typeparamref name="T"/> array instance.</param>
     /// <returns>A <see cref="Memory{T}"/> instance with the values of <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory<T> AsMemory<T>(this T[,]? array)
     {
@@ -369,7 +357,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of elements in the input 2D <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input 2D <typeparamref name="T"/> array instance.</param>
     /// <returns>A <see cref="Span{T}"/> instance with the values of <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<T> AsSpan<T>(this T[,]? array)
     {
@@ -397,7 +384,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input 2D <typeparamref name="T"/> array instance.</param>
     /// <param name="value">The <typeparamref name="T"/> value to look for.</param>
     /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe int Count<T>(this T[,] array, T value)
         where T : IEquatable<T>
@@ -422,7 +408,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input 2D <typeparamref name="T"/> array instance.</param>
     /// <returns>The Djb2 value for the input 2D <typeparamref name="T"/> array instance.</returns>
     /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe int GetDjb2HashCode<T>(this T[,] array)
         where T : notnull
@@ -439,7 +424,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of items in the input <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input <typeparamref name="T"/> array instance.</param>
     /// <returns>Whether or not <paramref name="array"/> is covariant.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsCovariant<T>(this T[,] array)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Helpers;
 #if NETSTANDARD2_1_OR_GREATER
@@ -27,7 +26,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input <typeparamref name="T"/> array instance.</param>
     /// <returns>A reference to the first element within <paramref name="array"/>, or the location it would have used, if <paramref name="array"/> is empty.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to perform checks in case the returned value is dereferenced.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReference<T>(this T[,,] array)
     {
@@ -60,7 +58,6 @@ public static partial class ArrayExtensions
     /// array, and will just assume that the input index is 0-based. It is responsibility of the caller to adjust the input
     /// indices to account for the actual lower bounds, if the input array has either axis not starting at 0.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this T[,,] array, int i, int j, int k)
     {
@@ -123,7 +120,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of elements in the input 3D <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input 3D <typeparamref name="T"/> array instance.</param>
     /// <returns>A <see cref="Memory{T}"/> instance with the values of <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory<T> AsMemory<T>(this T[,,]? array)
     {
@@ -149,7 +145,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of elements in the input 3D <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input 3D <typeparamref name="T"/> array instance.</param>
     /// <returns>A <see cref="Span{T}"/> instance with the values of <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<T> AsSpan<T>(this T[,,]? array)
     {
@@ -178,7 +173,6 @@ public static partial class ArrayExtensions
     /// <exception cref="ArrayTypeMismatchException">Thrown when <paramref name="array"/> doesn't match <typeparamref name="T"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="depth"/> is invalid.</exception>
     /// <returns>A <see cref="Span{T}"/> instance wrapping the target layer within <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<T> AsSpan<T>(this T[,,] array, int depth)
     {
@@ -207,7 +201,6 @@ public static partial class ArrayExtensions
     /// <exception cref="ArrayTypeMismatchException">Thrown when <paramref name="array"/> doesn't match <typeparamref name="T"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="depth"/> is invalid.</exception>
     /// <returns>A <see cref="Memory{T}"/> instance wrapping the target layer within <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory<T> AsMemory<T>(this T[,,] array, int depth)
     {
@@ -240,7 +233,6 @@ public static partial class ArrayExtensions
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when either <paramref name="depth"/> is invalid.</exception>
     /// <returns>A <see cref="Span2D{T}"/> instance wrapping the target layer within <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span2D<T> AsSpan2D<T>(this T[,,] array, int depth)
     {
@@ -258,7 +250,6 @@ public static partial class ArrayExtensions
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when either <paramref name="depth"/> is invalid.</exception>
     /// <returns>A <see cref="Memory2D{T}"/> instance wrapping the target layer within <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory2D<T> AsMemory2D<T>(this T[,,] array, int depth)
     {
@@ -272,7 +263,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input 3D <typeparamref name="T"/> array instance.</param>
     /// <param name="value">The <typeparamref name="T"/> value to look for.</param>
     /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="array"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Count<T>(this T[,,] array, T value)
         where T : IEquatable<T>
@@ -297,7 +287,6 @@ public static partial class ArrayExtensions
     /// <param name="array">The input 3D <typeparamref name="T"/> array instance.</param>
     /// <returns>The Djb2 value for the input 3D <typeparamref name="T"/> array instance.</returns>
     /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetDjb2HashCode<T>(this T[,,] array)
         where T : notnull
@@ -314,7 +303,6 @@ public static partial class ArrayExtensions
     /// <typeparam name="T">The type of items in the input <typeparamref name="T"/> array instance.</typeparam>
     /// <param name="array">The input <typeparamref name="T"/> array instance.</param>
     /// <returns>Whether or not <paramref name="array"/> is covariant.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsCovariant<T>(this T[,,] array)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayPoolBufferWriterExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayPoolBufferWriterExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Buffers;
@@ -21,7 +20,6 @@ public static class ArrayPoolBufferWriterExtensions
     /// <param name="writer">The target <see cref="ArrayPoolBufferWriter{T}"/> instance.</param>
     /// <returns>A <see cref="Stream"/> wrapping <paramref name="writer"/> and writing data to its underlying buffer.</returns>
     /// <remarks>The returned <see cref="Stream"/> can only be written to and does not support seeking.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Stream AsStream(this ArrayPoolBufferWriter<byte> writer)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/BoolExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/BoolExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
 namespace CommunityToolkit.HighPerformance;
@@ -18,7 +17,6 @@ public static class BoolExtensions
     /// <param name="flag">The input value to convert.</param>
     /// <returns>1 if <paramref name="flag"/> is <see langword="true"/>, 0 otherwise.</returns>
     /// <remarks>This method does not contain branching instructions.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe byte ToByte(this bool flag)
     {
@@ -46,7 +44,6 @@ public static class BoolExtensions
     /// or by using <see cref="Unsafe.As{T}"/> or other unsafe APIs to directly manipulate the underlying
     /// data though, it is responsibility of the caller to ensure the validity of the provided value.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe int ToBitwiseMask32(this bool flag)
     {
@@ -65,7 +62,6 @@ public static class BoolExtensions
     /// <param name="flag">The input value to convert.</param>
     /// <returns>All 1s if <paramref name="flag"/> is <see langword="true"/>, all 0s otherwise.</returns>
     /// <remarks>This method does not contain branching instructions. See additional note in <see cref="ToBitwiseMask32"/>.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe long ToBitwiseMask64(this bool flag)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/IBufferWriterExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/IBufferWriterExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -24,7 +23,6 @@ public static class IBufferWriterExtensions
     /// <param name="writer">The target <see cref="IBufferWriter{T}"/> instance.</param>
     /// <returns>A <see cref="Stream"/> wrapping <paramref name="writer"/> and writing data to its underlying buffer.</returns>
     /// <remarks>The returned <see cref="Stream"/> can only be written to and does not support seeking.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Stream AsStream(this IBufferWriter<byte> writer)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/IMemoryOwnerExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/IMemoryOwnerExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.CompilerServices;
 using MemoryStream = CommunityToolkit.HighPerformance.Streams.MemoryStream;
@@ -26,7 +25,6 @@ public static class IMemoryOwnerExtensions
     /// instance, as the returned <see cref="Stream"/> will take care of disposing that buffer when it is closed.
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <paramref name="memoryOwner"/> has an invalid data store.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Stream AsStream(this IMemoryOwner<byte> memoryOwner)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/ListExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ListExtensions.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -30,7 +29,6 @@ public static class ListExtensions
     /// scenario, the <see cref="Span{T}"/> would end up wrapping an array no longer in use. Always make sure to use
     /// the returned <see cref="Span{T}"/> while the target <see cref="List{T}"/> is not modified.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<T> AsSpan<T>(this List<T>? list)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/MemoryExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/MemoryExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -31,7 +30,6 @@ public static class MemoryExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="memory"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory2D<T> AsMemory2D<T>(this Memory<T> memory, int height, int width)
     {
@@ -54,7 +52,6 @@ public static class MemoryExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="memory"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory2D<T> AsMemory2D<T>(this Memory<T> memory, int offset, int height, int width, int pitch)
     {
@@ -72,7 +69,6 @@ public static class MemoryExtensions
     /// Thrown if the <see cref="Memory{T}.Length"/> property of the new <see cref="Memory{T}"/> would exceed <see cref="int.MaxValue"/>.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when the data store of <paramref name="memory"/> is not supported.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory<byte> AsBytes<T>(this Memory<T> memory)
         where T : unmanaged
@@ -88,7 +84,6 @@ public static class MemoryExtensions
     /// <param name="memory">The source <see cref="Memory{T}"/>, of type <typeparamref name="TFrom"/>.</param>
     /// <returns>A <see cref="Memory{T}"/> of type <typeparamref name="TTo"/></returns>
     /// <exception cref="ArgumentException">Thrown when the data store of <paramref name="memory"/> is not supported.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Memory<TTo> Cast<TFrom, TTo>(this Memory<TFrom> memory)
         where TFrom : unmanaged
@@ -109,7 +104,6 @@ public static class MemoryExtensions
     /// as the returned <see cref="Stream"/> is in use, to avoid unexpected issues.
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <paramref name="memory"/> has an invalid data store.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Stream AsStream(this Memory<byte> memory)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/ReadOnlyMemoryExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ReadOnlyMemoryExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -34,7 +33,6 @@ public static class ReadOnlyMemoryExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="memory"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlyMemory2D<T> AsMemory2D<T>(this ReadOnlyMemory<T> memory, int height, int width)
     {
@@ -57,7 +55,6 @@ public static class ReadOnlyMemoryExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="memory"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlyMemory2D<T> AsMemory2D<T>(this ReadOnlyMemory<T> memory, int offset, int height, int width, int pitch)
     {
@@ -75,7 +72,6 @@ public static class ReadOnlyMemoryExtensions
     /// Thrown if the <see cref="ReadOnlyMemory{T}.Length"/> property of the new <see cref="ReadOnlyMemory{T}"/> would exceed <see cref="int.MaxValue"/>.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when the data store of <paramref name="memory"/> is not supported.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlyMemory<byte> AsBytes<T>(this ReadOnlyMemory<T> memory)
         where T : unmanaged
@@ -91,7 +87,6 @@ public static class ReadOnlyMemoryExtensions
     /// <param name="memory">The source <see cref="ReadOnlyMemory{T}"/>, of type <typeparamref name="TFrom"/>.</param>
     /// <returns>A <see cref="ReadOnlyMemory{T}"/> of type <typeparamref name="TTo"/></returns>
     /// <exception cref="ArgumentException">Thrown when the data store of <paramref name="memory"/> is not supported.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlyMemory<TTo> Cast<TFrom, TTo>(this ReadOnlyMemory<TFrom> memory)
         where TFrom : unmanaged
@@ -148,7 +143,6 @@ public static class ReadOnlyMemoryExtensions
     /// as the returned <see cref="Stream"/> is in use, to avoid unexpected issues.
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <paramref name="memory"/> has an invalid data store.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Stream AsStream(this ReadOnlyMemory<byte> memory)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance.Enumerables;
@@ -23,7 +22,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> instance.</param>
     /// <returns>A reference to the first element within <paramref name="span"/>.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to perform checks in case the returned value is dereferenced.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReference<T>(this ReadOnlySpan<T> span)
     {
@@ -38,7 +36,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="i">The index of the element to retrieve within <paramref name="span"/>.</param>
     /// <returns>A reference to the element within <paramref name="span"/> at the index specified by <paramref name="i"/>.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this ReadOnlySpan<T> span, int i)
     {
@@ -86,7 +83,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="i">The index of the element to retrieve within <paramref name="span"/>.</param>
     /// <returns>A reference to the element within <paramref name="span"/> at the index specified by <paramref name="i"/>.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this ReadOnlySpan<T> span, nint i)
     {
@@ -133,7 +129,6 @@ public static class ReadOnlySpanExtensions
     /// A reference to the element within <paramref name="span"/> at the index specified by <paramref name="i"/>,
     /// or a reference to the first element within <paramref name="span"/> if <paramref name="i"/> was not a valid index.
     /// </returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref readonly T DangerousGetLookupReferenceAt<T>(this ReadOnlySpan<T> span, int i)
     {
@@ -178,7 +173,6 @@ public static class ReadOnlySpanExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="span"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpan2D<T> AsSpan2D<T>(this ReadOnlySpan<T> span, int height, int width)
     {
@@ -201,7 +195,6 @@ public static class ReadOnlySpanExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="span"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpan2D<T> AsSpan2D<T>(this ReadOnlySpan<T> span, int offset, int height, int width, int pitch)
     {
@@ -217,7 +210,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="value">The reference to the target item to get the index for.</param>
     /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> does not belong to <paramref name="span"/>.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int IndexOf<T>(this ReadOnlySpan<T> span, in T value)
     {
@@ -242,7 +234,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> instance to read.</param>
     /// <param name="value">The <typeparamref name="T"/> value to look for.</param>
     /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="span"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Count<T>(this ReadOnlySpan<T> span, T value)
         where T : IEquatable<T>
@@ -262,7 +253,6 @@ public static class ReadOnlySpanExtensions
     /// <exception cref="OverflowException">
     /// Thrown if the <see cref="ReadOnlySpan{T}.Length"/> property of the new <see cref="ReadOnlySpan{T}"/> would exceed <see cref="int.MaxValue"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> span)
         where T : unmanaged
@@ -280,7 +270,6 @@ public static class ReadOnlySpanExtensions
     /// <remarks>
     /// Supported only for platforms that support misaligned memory access or when the memory block is aligned by other means.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpan<TTo> Cast<TFrom, TTo>(this ReadOnlySpan<TFrom> span)
         where TFrom : unmanaged
@@ -308,7 +297,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="span">The source <see cref="ReadOnlySpan{T}"/> to enumerate.</param>
     /// <returns>A wrapper type that will handle the value/index enumeration for <paramref name="span"/>.</returns>
     /// <remarks>The returned <see cref="ReadOnlySpanEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpanEnumerable<T> Enumerate<T>(this ReadOnlySpan<T> span)
     {
@@ -333,7 +321,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="separator">The separator <typeparamref name="T"/> item to use.</param>
     /// <returns>A wrapper type that will handle the tokenization for <paramref name="span"/>.</returns>
     /// <remarks>The returned <see cref="ReadOnlySpanTokenizer{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpanTokenizer<T> Tokenize<T>(this ReadOnlySpan<T> span, T separator)
         where T : IEquatable<T>
@@ -360,7 +347,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> instance.</param>
     /// <returns>The Djb2 value for the input <see cref="ReadOnlySpan{T}"/> instance.</returns>
     /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetDjb2HashCode<T>(this ReadOnlySpan<T> span)
         where T : notnull

--- a/CommunityToolkit.HighPerformance/Extensions/SpanExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/SpanExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance.Enumerables;
@@ -23,7 +22,6 @@ public static class SpanExtensions
     /// <param name="span">The input <see cref="Span{T}"/> instance.</param>
     /// <returns>A reference to the first element within <paramref name="span"/>.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to perform checks in case the returned value is dereferenced.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReference<T>(this Span<T> span)
     {
@@ -38,7 +36,6 @@ public static class SpanExtensions
     /// <param name="i">The index of the element to retrieve within <paramref name="span"/>.</param>
     /// <returns>A reference to the element within <paramref name="span"/> at the index specified by <paramref name="i"/>.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this Span<T> span, int i)
     {
@@ -56,7 +53,6 @@ public static class SpanExtensions
     /// <param name="i">The index of the element to retrieve within <paramref name="span"/>.</param>
     /// <returns>A reference to the element within <paramref name="span"/> at the index specified by <paramref name="i"/>.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetReferenceAt<T>(this Span<T> span, nint i)
     {
@@ -81,7 +77,6 @@ public static class SpanExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="span"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span2D<T> AsSpan2D<T>(this Span<T> span, int height, int width)
     {
@@ -104,7 +99,6 @@ public static class SpanExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="span"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span2D<T> AsSpan2D<T>(this Span<T> span, int offset, int height, int width, int pitch)
     {
@@ -121,7 +115,6 @@ public static class SpanExtensions
     /// <exception cref="OverflowException">
     /// Thrown if the <see cref="Span{T}.Length"/> property of the new <see cref="Span{T}"/> would exceed <see cref="int.MaxValue"/>.
     /// </exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<byte> AsBytes<T>(this Span<T> span)
         where T : unmanaged
@@ -139,7 +132,6 @@ public static class SpanExtensions
     /// <remarks>
     /// Supported only for platforms that support misaligned memory access or when the memory block is aligned by other means.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<TTo> Cast<TFrom, TTo>(this Span<TFrom> span)
         where TFrom : unmanaged
@@ -156,7 +148,6 @@ public static class SpanExtensions
     /// <param name="value">The reference to the target item to get the index for.</param>
     /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> does not belong to <paramref name="span"/>.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int IndexOf<T>(this Span<T> span, ref T value)
     {
@@ -180,7 +171,6 @@ public static class SpanExtensions
     /// <param name="span">The input <see cref="Span{T}"/> instance to read.</param>
     /// <param name="value">The <typeparamref name="T"/> value to look for.</param>
     /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="span"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Count<T>(this Span<T> span, T value)
         where T : IEquatable<T>
@@ -210,7 +200,6 @@ public static class SpanExtensions
     /// <param name="span">The source <see cref="Span{T}"/> to enumerate.</param>
     /// <returns>A wrapper type that will handle the reference/index enumeration for <paramref name="span"/>.</returns>
     /// <remarks>The returned <see cref="SpanEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SpanEnumerable<T> Enumerate<T>(this Span<T> span)
     {
@@ -235,7 +224,6 @@ public static class SpanExtensions
     /// <param name="separator">The separator <typeparamref name="T"/> item to use.</param>
     /// <returns>A wrapper type that will handle the tokenization for <paramref name="span"/>.</returns>
     /// <remarks>The returned <see cref="SpanTokenizer{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static SpanTokenizer<T> Tokenize<T>(this Span<T> span, T separator)
         where T : IEquatable<T>
@@ -251,7 +239,6 @@ public static class SpanExtensions
     /// <param name="span">The input <see cref="Span{T}"/> instance.</param>
     /// <returns>The Djb2 value for the input <see cref="Span{T}"/> instance.</returns>
     /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetDjb2HashCode<T>(this Span<T> span)
         where T : notnull

--- a/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 #if NETSTANDARD
 using System.Runtime.InteropServices;
@@ -24,7 +23,6 @@ public static class StringExtensions
     /// <param name="text">The input <see cref="string"/> instance.</param>
     /// <returns>A reference to the first element within <paramref name="text"/>, or the location it would have used, if <paramref name="text"/> is empty.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to perform checks in case the returned value is dereferenced.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref char DangerousGetReference(this string text)
     {
@@ -42,7 +40,6 @@ public static class StringExtensions
     /// <param name="i">The index of the element to retrieve within <paramref name="text"/>.</param>
     /// <returns>A reference to the element within <paramref name="text"/> at the index specified by <paramref name="i"/>.</returns>
     /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref char DangerousGetReferenceAt(this string text, int i)
     {
@@ -62,7 +59,6 @@ public static class StringExtensions
     /// <param name="text">The input <see cref="string"/> instance to read.</param>
     /// <param name="c">The character to look for.</param>
     /// <returns>The number of occurrences of <paramref name="c"/> in <paramref name="text"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Count(this string text, char c)
     {
@@ -90,7 +86,6 @@ public static class StringExtensions
     /// <param name="text">The source <see cref="string"/> to enumerate.</param>
     /// <returns>A wrapper type that will handle the value/index enumeration for <paramref name="text"/>.</returns>
     /// <remarks>The returned <see cref="ReadOnlySpanEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpanEnumerable<char> Enumerate(this string text)
     {
@@ -114,7 +109,6 @@ public static class StringExtensions
     /// <param name="separator">The separator character to use.</param>
     /// <returns>A wrapper type that will handle the tokenization for <paramref name="text"/>.</returns>
     /// <remarks>The returned <see cref="ReadOnlySpanTokenizer{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ReadOnlySpanTokenizer<char> Tokenize(this string text, char separator)
     {
@@ -128,7 +122,6 @@ public static class StringExtensions
     /// <param name="text">The source <see cref="string"/> to enumerate.</param>
     /// <returns>The Djb2 value for the input <see cref="string"/> instance.</returns>
     /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe int GetDjb2HashCode(this string text)
     {

--- a/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 #if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.Intrinsics.X86;
@@ -26,7 +25,6 @@ public static class BitHelper
     /// If the parameter is not valid, the result will just be inconsistent.
     /// Additionally, no conditional branches are used to retrieve the flag.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe bool HasFlag(uint value, int n)
     {
@@ -72,7 +70,6 @@ public static class BitHelper
     /// For best results, as shown in the sample code, both <paramref name="table"/> and <paramref name="min"/>
     /// should be compile-time constants, so that the JIT compiler will be able to produce more efficient code.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe bool HasLookupFlag(uint table, int x, int min = 0)
     {
@@ -113,7 +110,6 @@ public static class BitHelper
     /// This method contains no branches.
     /// For more background on this subject, see <see href="https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord"/>.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool HasZeroByte(uint value)
     {
@@ -126,7 +122,6 @@ public static class BitHelper
     /// </summary>
     /// <param name="value">The input value to check.</param>
     /// <returns>Whether <paramref name="value"/> has any bytes set to 0.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool HasZeroByte(ulong value)
     {
@@ -143,7 +138,6 @@ public static class BitHelper
     /// This method contains no branches.
     /// For more info, see <see href="https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord"/>.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool HasByteEqualTo(uint value, byte target)
     {
@@ -157,7 +151,6 @@ public static class BitHelper
     /// <param name="value">The input value to check.</param>
     /// <param name="target">The target byte to look for.</param>
     /// <returns>Whether <paramref name="value"/> has any bytes set to <paramref name="target"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool HasByteEqualTo(ulong value, byte target)
     {
@@ -191,7 +184,6 @@ public static class BitHelper
     /// Just like <see cref="HasFlag(uint,int)"/>, this method doesn't validate <paramref name="n"/>
     /// and does not contain branching instructions, so it's well suited for use in tight loops as well.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe uint SetFlag(uint value, int n, bool flag)
     {
@@ -229,7 +221,6 @@ public static class BitHelper
     /// that case, which would just be equivalent to assigning the <see cref="uint"/> value.
     /// Additionally, no conditional branches are used to retrieve the range.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint ExtractRange(uint value, byte start, byte length)
     {
@@ -272,7 +263,6 @@ public static class BitHelper
     /// Just like <see cref="ExtractRange(uint,byte,byte)"/>, this method doesn't validate the parameters
     /// and does not contain branching instructions, so it's well suited for use in tight loops as well.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint SetRange(uint value, byte start, byte length, uint flags)
     {
@@ -301,7 +291,6 @@ public static class BitHelper
     /// If the parameter is not valid, the result will just be inconsistent.
     /// Additionally, no conditional branches are used to retrieve the flag.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe bool HasFlag(ulong value, int n)
     {
@@ -323,7 +312,6 @@ public static class BitHelper
     /// For best results, as shown in the sample code, both <paramref name="table"/> and <paramref name="min"/>
     /// should be compile-time constants, so that the JIT compiler will be able to produce more efficient code.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe bool HasLookupFlag(ulong table, int x, int min = 0)
     {
@@ -367,7 +355,6 @@ public static class BitHelper
     /// Just like <see cref="HasFlag(ulong,int)"/>, this method doesn't validate <paramref name="n"/>
     /// and does not contain branching instructions, so it's well suited for use in tight loops as well.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ulong SetFlag(ulong value, int n, bool flag)
     {
@@ -396,7 +383,6 @@ public static class BitHelper
     /// that case, which would just be equivalent to assigning the <see cref="ulong"/> value.
     /// Additionally, no conditional branches are used to retrieve the range.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong ExtractRange(ulong value, byte start, byte length)
     {
@@ -439,7 +425,6 @@ public static class BitHelper
     /// Just like <see cref="ExtractRange(ulong,byte,byte)"/>, this method doesn't validate the parameters
     /// and does not contain branching instructions, so it's well suited for use in tight loops as well.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong SetRange(ulong value, byte start, byte length, ulong flags)
     {

--- a/CommunityToolkit.HighPerformance/Helpers/HashCode{T}.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/HashCode{T}.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance.Helpers.Internals;
@@ -36,7 +35,6 @@ public struct HashCode<T>
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> instance</param>
     /// <returns>The xxHash32 value for the input <see cref="ReadOnlySpan{T}"/> instance</returns>
     /// <remarks>The xxHash32 is only guaranteed to be deterministic within the scope of a single app execution</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Combine(ReadOnlySpan<T> span)
     {
@@ -51,7 +49,6 @@ public struct HashCode<T>
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> instance</param>
     /// <returns>The hash code for the input <see cref="ReadOnlySpan{T}"/> instance</returns>
     /// <remarks>The returned hash code is not processed through <see cref="HashCode"/> APIs.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int CombineValues(ReadOnlySpan<T> span)
     {

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/RuntimeHelpers.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/RuntimeHelpers.cs
@@ -6,7 +6,6 @@
 // See https://github.com/dotnet/corefx/blob/release/2.1/src/System.Memory/src/System/SpanHelpers.cs.
 
 using System;
-using System.Diagnostics.Contracts;
 #if !NETSTANDARD2_1_OR_GREATER
 using System.Reflection;
 #endif
@@ -27,7 +26,6 @@ internal static class RuntimeHelpers
     /// <typeparam name="TTo">The target type of items.</typeparam>
     /// <param name="length">The input length to convert.</param>
     /// <returns>The converted length for the specified argument and types.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe int ConvertLength<TFrom, TTo>(int length)
         where TFrom : unmanaged
@@ -60,7 +58,6 @@ internal static class RuntimeHelpers
     /// is only visible as a non-generic <see cref="Array"/> instance, because the C# compiler will
     /// not be able to emit the <see langword="ldlen"/> opcode instead of calling the right method.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static nint GetArrayNativeLength<T>(T[] array)
     {
@@ -72,7 +69,6 @@ internal static class RuntimeHelpers
     /// </summary>
     /// <param name="array">The input <see cref="Array"/> instance.</param>
     /// <returns>The total length of <paramref name="array"/> as a native integer.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static nint GetArrayNativeLength(Array array)
     {
@@ -85,7 +81,6 @@ internal static class RuntimeHelpers
     /// </summary>
     /// <typeparam name="T">The type of values in the array.</typeparam>
     /// <returns>The byte offset to the first <typeparamref name="T"/> element in a SZ array.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IntPtr GetArrayDataByteOffset<T>()
     {
@@ -98,7 +93,6 @@ internal static class RuntimeHelpers
     /// </summary>
     /// <typeparam name="T">The type of values in the array.</typeparam>
     /// <returns>The byte offset to the first <typeparamref name="T"/> element in a 2D array.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IntPtr GetArray2DDataByteOffset<T>()
     {
@@ -110,7 +104,6 @@ internal static class RuntimeHelpers
     /// </summary>
     /// <typeparam name="T">The type of values in the array.</typeparam>
     /// <returns>The byte offset to the first <typeparamref name="T"/> element in a 3D array.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IntPtr GetArray3DDataByteOffset<T>()
     {
@@ -131,7 +124,6 @@ internal static class RuntimeHelpers
     /// The <see cref="IntPtr"/> value representing the offset to the target field from the start of the object data
     /// for the parameter <paramref name="obj"/>, or the value of the raw pointer passed as a tracked reference.
     /// </returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe IntPtr GetObjectDataOrReferenceByteOffset<T>(object? obj, ref T data)
     {
@@ -153,7 +145,6 @@ internal static class RuntimeHelpers
     /// <param name="obj">The input <see cref="object"/> hosting the target field.</param>
     /// <param name="offset">The input byte offset for the <typeparamref name="T"/> reference to retrieve.</param>
     /// <returns>A <typeparamref name="T"/> reference matching the given parameters.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref T GetObjectDataAtOffsetOrPointerReference<T>(object? obj, IntPtr offset)
     {
@@ -170,7 +161,6 @@ internal static class RuntimeHelpers
     /// </summary>
     /// <typeparam name="T">The type to check.</typeparam>
     /// <returns>Whether or not <typeparamref name="T"/> respects the <see langword="unmanaged"/> constraint.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsReferenceOrContainsReferences<T>()
     {
@@ -182,7 +172,6 @@ internal static class RuntimeHelpers
     /// </summary>
     /// <param name="type">The current type to check.</param>
     /// <returns>Whether or not <paramref name="type"/> is a reference type or contains references.</returns>
-    [Pure]
     private static bool IsReferenceOrContainsReferences(Type type)
     {
         // Common case, for primitive types
@@ -259,7 +248,6 @@ internal static class RuntimeHelpers
         /// Computes the value for <see cref="ArrayDataByteOffset"/>.
         /// </summary>
         /// <returns>The value of <see cref="ArrayDataByteOffset"/> for the current runtime.</returns>
-        [Pure]
         private static IntPtr MeasureArrayDataByteOffset()
         {
             T[]? array = new T[1];
@@ -271,7 +259,6 @@ internal static class RuntimeHelpers
         /// Computes the value for <see cref="Array2DDataByteOffset"/>.
         /// </summary>
         /// <returns>The value of <see cref="Array2DDataByteOffset"/> for the current runtime.</returns>
-        [Pure]
         private static IntPtr MeasureArray2DDataByteOffset()
         {
             T[,]? array = new T[1, 1];
@@ -283,7 +270,6 @@ internal static class RuntimeHelpers
         /// Computes the value for <see cref="Array3DDataByteOffset"/>.
         /// </summary>
         /// <returns>The value of <see cref="Array3DDataByteOffset"/> for the current runtime.</returns>
-        [Pure]
         private static IntPtr MeasureArray3DDataByteOffset()
         {
             T[,,]? array = new T[1, 1, 1];

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/SpanHelper.Count.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/SpanHelper.Count.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
@@ -22,7 +21,6 @@ internal static partial class SpanHelper
     /// <param name="value">The <typeparamref name="T"/> value to look for.</param>
     /// <typeparam name="T">The type of value to look for.</typeparam>
     /// <returns>The number of occurrences of <paramref name="value"/> in the search space</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static nint Count<T>(ref T r0, nint length, T value)
         where T : IEquatable<T>
@@ -77,7 +75,6 @@ internal static partial class SpanHelper
     /// <summary>
     /// Implements <see cref="Count{T}"/> with a sequential search.
     /// </summary>
-    [Pure]
     private static nint CountSequential<T>(ref T r0, nint length, T value)
         where T : IEquatable<T>
     {
@@ -126,7 +123,6 @@ internal static partial class SpanHelper
     /// <summary>
     /// Implements <see cref="Count{T}"/> with a vectorized search.
     /// </summary>
-    [Pure]
     private static nint CountSimd<T>(ref T r0, nint length, T value)
         where T : unmanaged, IEquatable<T>
     {
@@ -288,7 +284,6 @@ internal static partial class SpanHelper
     /// </summary>
     /// <typeparam name="T">The type argument currently in use.</typeparam>
     /// <returns>The native <see cref="int"/> value representing the upper bound.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static unsafe nint GetUpperBound<T>()
         where T : unmanaged
@@ -334,7 +329,6 @@ internal static partial class SpanHelper
     /// <typeparam name="T">The input type to cast.</typeparam>
     /// <param name="value">The input <typeparamref name="T"/> value to cast to native <see cref="int"/>.</param>
     /// <returns>The native <see cref="int"/> cast of <paramref name="value"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static nint CastToNativeInt<T>(T value)
         where T : unmanaged

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/SpanHelper.Hash.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/SpanHelper.Hash.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
@@ -20,7 +19,6 @@ internal static partial class SpanHelper
     /// <param name="r0">The reference to the target memory area to hash.</param>
     /// <param name="length">The number of items to hash.</param>
     /// <returns>The Djb2 value for the input sequence of items.</returns>
-    [Pure]
     public static int GetDjb2HashCode<T>(ref T r0, nint length)
         where T : notnull
     {
@@ -83,7 +81,6 @@ internal static partial class SpanHelper
     /// The advantage of this method is that when SIMD instructions are available, it performs much
     /// faster than <see cref="GetDjb2HashCode{T}"/>, as it can parallelize much of the workload.
     /// </remarks>
-    [Pure]
     public static unsafe int GetDjb2LikeByteHash(ref byte r0, nint length)
     {
         int hash = 5381;

--- a/CommunityToolkit.HighPerformance/Helpers/ObjectMarshal.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/ObjectMarshal.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -27,7 +26,6 @@ public static class ObjectMarshal
     /// <remarks>The input parameters are not validated, and it's responsibility of the caller to ensure that
     /// the <paramref name="data"/> reference is actually pointing to a memory location within <paramref name="obj"/>.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IntPtr DangerousGetObjectDataByteOffset<T>(object obj, ref T data)
     {
@@ -51,7 +49,6 @@ public static class ObjectMarshal
     /// desired data, which would break the type system. Or, if the offset causes the retrieved reference to point
     /// to a memory location outside of the input <see cref="object"/> instance, that might lead to runtime crashes.
     /// </remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousGetObjectDataReferenceAt<T>(object obj, IntPtr offset)
     {
@@ -135,7 +132,6 @@ public static class ObjectMarshal
     /// <param name="obj">The input <see cref="object"/> instance, representing a boxed <typeparamref name="T"/> value.</param>
     /// <returns>The <typeparamref name="T"/> value boxed in <paramref name="obj"/>.</returns>
     /// <exception cref="InvalidCastException">Thrown when <paramref name="obj"/> is not of type <typeparamref name="T"/>.</exception>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T DangerousUnbox<T>(object obj)
         where T : struct

--- a/CommunityToolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
+++ b/CommunityToolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using static System.Math;
 
@@ -62,7 +61,6 @@ internal static class OverflowHelper
     /// <returns>The area resulting from the given parameters.</returns>
     /// <exception cref="OverflowException">Throw when the inputs don't fit in the expected range.</exception>
     /// <remarks>The input parameters are assumed to always be positive.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int ComputeInt32Area(int height, int width, int pitch)
     {

--- a/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -6,7 +6,6 @@ using System;
 using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if NETSTANDARD2_1_OR_GREATER
@@ -525,7 +524,6 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when one of the input parameters is out of range.
     /// </exception>
-    [Pure]
     public static Memory2D<T> DangerousCreate(object instance, ref T value, int height, int width, int pitch)
     {
         if (height < 0)
@@ -659,7 +657,6 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="Memory2D{T}"/> instance representing a slice of the current one.</returns>
-    [Pure]
     public Memory2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)
@@ -825,7 +822,6 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
     /// Copies the contents of the current <see cref="Memory2D{T}"/> instance into a new 2D array.
     /// </summary>
     /// <returns>A 2D array containing the data in the current <see cref="Memory2D{T}"/> instance.</returns>
-    [Pure]
     public T[,] ToArray() => Span.ToArray();
 
     /// <inheritdoc/>

--- a/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -6,7 +6,6 @@ using System;
 using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if NETSTANDARD2_1_OR_GREATER
@@ -537,7 +536,6 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when one of the input parameters is out of range.
     /// </exception>
-    [Pure]
     public static ReadOnlyMemory2D<T> DangerousCreate(object instance, ref T value, int height, int width, int pitch)
     {
         if (height < 0)
@@ -672,7 +670,6 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="ReadOnlyMemory2D{T}"/> instance representing a slice of the current one.</returns>
-    [Pure]
     public ReadOnlyMemory2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)
@@ -836,7 +833,6 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
     /// Copies the contents of the current <see cref="ReadOnlyMemory2D{T}"/> instance into a new 2D array.
     /// </summary>
     /// <returns>A 2D array containing the data in the current <see cref="ReadOnlyMemory2D{T}"/> instance.</returns>
-    [Pure]
     public T[,] ToArray() => Span.ToArray();
 
     /// <inheritdoc/>

--- a/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
+++ b/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Enumerables;
 using CommunityToolkit.HighPerformance.Memory.Internals;
@@ -24,7 +23,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// <param name="row">The target row to enumerate within the current <see cref="ReadOnlySpan2D{T}"/> instance.</param>
     /// <returns>A <see cref="ReadOnlyRefEnumerable{T}"/> with target items to enumerate.</returns>
     /// <remarks>The returned <see cref="ReadOnlyRefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlyRefEnumerable<T> GetRow(int row)
     {
@@ -52,7 +50,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// <param name="column">The target column to enumerate within the current <see cref="ReadOnlySpan2D{T}"/> instance.</param>
     /// <returns>A <see cref="ReadOnlyRefEnumerable{T}"/> with target items to enumerate.</returns>
     /// <remarks>The returned <see cref="ReadOnlyRefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlyRefEnumerable<T> GetColumn(int column)
     {
@@ -79,7 +76,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// <returns>
     /// An enumerator that can be used to traverse the items in the current <see cref="ReadOnlySpan2D{T}"/> instance
     /// </returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator GetEnumerator() => new(this);
 

--- a/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if !NETSTANDARD2_1_OR_GREATER
@@ -456,7 +455,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// <param name="pitch">The pitch of the 2D memory area to map (the distance between each row).</param>
     /// <returns>A <see cref="ReadOnlySpan2D{T}"/> instance with the specified parameters.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when one of the parameters are negative.</exception>
-    [Pure]
     public static ReadOnlySpan2D<T> DangerousCreate(in T value, int height, int width, int pitch)
     {
         if (width < 0)
@@ -740,7 +738,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// and is required to support the use of span within a fixed statement.
     /// </summary>
     /// <returns>A reference to the 0th element, or a <see langword="null"/> reference.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public unsafe ref T GetPinnableReference()
@@ -763,7 +760,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// Returns a reference to the first element within the current instance, with no bounds check.
     /// </summary>
     /// <returns>A reference to the first element within the current instance.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T DangerousGetReference()
     {
@@ -780,7 +776,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// <param name="i">The target row to get the element from.</param>
     /// <param name="j">The target column to get the element from.</param>
     /// <returns>A reference to the element at the specified indices.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T DangerousGetReferenceAt(int i, int j)
     {
@@ -806,7 +801,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="ReadOnlySpan2D{T}"/> instance representing a slice of the current one.</returns>
-    [Pure]
     public ReadOnlySpan2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)
@@ -850,7 +844,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// <param name="row">The index of the target row to retrieve.</param>
     /// <exception cref="ArgumentOutOfRangeException">Throw when <paramref name="row"/> is out of range.</exception>
     /// <returns>The resulting row <see cref="ReadOnlySpan{T}"/>.</returns>
-    [Pure]
     public ReadOnlySpan<T> GetRowSpan(int row)
     {
         if ((uint)row >= (uint)Height)
@@ -921,7 +914,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// Copies the contents of the current <see cref="Span2D{T}"/> instance into a new 2D array.
     /// </summary>
     /// <returns>A 2D array containing the data in the current <see cref="Span2D{T}"/> instance.</returns>
-    [Pure]
     public T[,] ToArray()
     {
         T[,] array = new T[Height, this.width];

--- a/CommunityToolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
+++ b/CommunityToolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Enumerables;
 using CommunityToolkit.HighPerformance.Memory.Internals;
@@ -24,7 +23,6 @@ public readonly ref partial struct Span2D<T>
     /// <param name="row">The target row to enumerate within the current <see cref="Span2D{T}"/> instance.</param>
     /// <returns>A <see cref="RefEnumerable{T}"/> with target items to enumerate.</returns>
     /// <remarks>The returned <see cref="RefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public RefEnumerable<T> GetRow(int row)
     {
@@ -52,7 +50,6 @@ public readonly ref partial struct Span2D<T>
     /// <param name="column">The target column to enumerate within the current <see cref="Span2D{T}"/> instance.</param>
     /// <returns>A <see cref="RefEnumerable{T}"/> with target items to enumerate.</returns>
     /// <remarks>The returned <see cref="RefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public RefEnumerable<T> GetColumn(int column)
     {
@@ -79,7 +76,6 @@ public readonly ref partial struct Span2D<T>
     /// <returns>
     /// An enumerator that can be used to traverse the items in the current <see cref="Span2D{T}"/> instance
     /// </returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator GetEnumerator() => new(this);
 

--- a/CommunityToolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/CommunityToolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if !NETSTANDARD2_1_OR_GREATER
@@ -527,7 +526,6 @@ public readonly ref partial struct Span2D<T>
     /// <param name="pitch">The pitch of the 2D memory area to map (the distance between each row).</param>
     /// <returns>A <see cref="Span2D{T}"/> instance with the specified parameters.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when one of the parameters are negative.</exception>
-    [Pure]
     public static Span2D<T> DangerousCreate(ref T value, int height, int width, int pitch)
     {
         if (width < 0)
@@ -896,7 +894,6 @@ public readonly ref partial struct Span2D<T>
     /// and is required to support the use of span within a fixed statement.
     /// </summary>
     /// <returns>A reference to the 0th element, or a <see langword="null"/> reference.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public unsafe ref T GetPinnableReference()
@@ -919,7 +916,6 @@ public readonly ref partial struct Span2D<T>
     /// Returns a reference to the first element within the current instance, with no bounds check.
     /// </summary>
     /// <returns>A reference to the first element within the current instance.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T DangerousGetReference()
     {
@@ -936,7 +932,6 @@ public readonly ref partial struct Span2D<T>
     /// <param name="i">The target row to get the element from.</param>
     /// <param name="j">The target column to get the element from.</param>
     /// <returns>A reference to the element at the specified indices.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T DangerousGetReferenceAt(int i, int j)
     {
@@ -962,7 +957,6 @@ public readonly ref partial struct Span2D<T>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="Span2D{T}"/> instance representing a slice of the current one.</returns>
-    [Pure]
     public Span2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)
@@ -1006,7 +1000,6 @@ public readonly ref partial struct Span2D<T>
     /// <param name="row">The index of the target row to retrieve.</param>
     /// <exception cref="ArgumentOutOfRangeException">Throw when <paramref name="row"/> is out of range.</exception>
     /// <returns>The resulting row <see cref="Span{T}"/>.</returns>
-    [Pure]
     public Span<T> GetRowSpan(int row)
     {
         if ((uint)row >= (uint)Height)
@@ -1077,7 +1070,6 @@ public readonly ref partial struct Span2D<T>
     /// Copies the contents of the current <see cref="Span2D{T}"/> instance into a new 2D array.
     /// </summary>
     /// <returns>A 2D array containing the data in the current <see cref="Span2D{T}"/> instance.</returns>
-    [Pure]
     public T[,] ToArray()
     {
         T[,] array = new T[Height, this.width];

--- a/CommunityToolkit.HighPerformance/Streams/MemoryStream.cs
+++ b/CommunityToolkit.HighPerformance/Streams/MemoryStream.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -22,7 +21,6 @@ internal static partial class MemoryStream
     /// <param name="isReadOnly">Indicates whether or not <paramref name="memory"/> can be written to.</param>
     /// <returns>A <see cref="Stream"/> wrapping the underlying data for <paramref name="memory"/>.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="memory"/> has an invalid data store.</exception>
-    [Pure]
     public static Stream Create(ReadOnlyMemory<byte> memory, bool isReadOnly)
     {
         if (memory.IsEmpty)
@@ -54,7 +52,6 @@ internal static partial class MemoryStream
     /// <param name="memoryOwner">The input <see cref="IMemoryOwner{T}"/> instance.</param>
     /// <returns>A <see cref="Stream"/> wrapping the underlying data for <paramref name="memoryOwner"/>.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="memoryOwner"/> has an invalid data store.</exception>
-    [Pure]
     public static Stream Create(IMemoryOwner<byte> memoryOwner)
     {
         Memory<byte> memory = memoryOwner.Memory;

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -166,7 +165,6 @@ public sealed partial class ObservablePropertyGenerator : ISourceGenerator
     /// <param name="propertyChangedNames">The collection of discovered property changed names.</param>
     /// <param name="propertyChangingNames">The collection of discovered property changing names.</param>
     /// <returns>A generated <see cref="PropertyDeclarationSyntax"/> instance for the input field.</returns>
-    [Pure]
     private static PropertyDeclarationSyntax CreatePropertyDeclaration(
         GeneratorExecutionContext context,
         SyntaxTriviaList leadingTrivia,
@@ -443,7 +441,6 @@ public sealed partial class ObservablePropertyGenerator : ISourceGenerator
     /// </summary>
     /// <param name="fieldSymbol">The input <see cref="IFieldSymbol"/> instance to process.</param>
     /// <returns>The generated property name for <paramref name="fieldSymbol"/>.</returns>
-    [Pure]
     public static string GetGeneratedPropertyName(IFieldSymbol fieldSymbol)
     {
         string propertyName = fieldSymbol.Name;
@@ -534,7 +531,6 @@ public sealed partial class ObservablePropertyGenerator : ISourceGenerator
     /// <param name="type">The type of cached property change argument (either <see cref="PropertyChangedEventArgs"/> or <see cref="PropertyChangingEventArgs"/>).</param>
     /// <param name="propertyName">The name of the cached property name.</param>
     /// <returns>A <see cref="FieldDeclarationSyntax"/> instance for the input cached property name.</returns>
-    [Pure]
     private static FieldDeclarationSyntax CreateFieldDeclaration(INamedTypeSymbol type, string propertyName)
     {
         // Create a static field with a cached property changed/changing argument for a specified property.

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservableValidatorValidateAllPropertiesGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservableValidatorValidateAllPropertiesGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -169,7 +168,6 @@ public sealed partial class ObservableValidatorValidateAllPropertiesGenerator : 
     /// <param name="validationSymbol">The type symbol for the <c>ValidationAttribute</c> type.</param>
     /// <param name="observablePropertySymbol">The type symbol for the <c>ObservablePropertyAttribute</c> type.</param>
     /// <returns>The sequence of <see cref="StatementSyntax"/> instances to validate declared properties.</returns>
-    [Pure]
     private static IEnumerable<StatementSyntax> EnumerateValidationStatements(INamedTypeSymbol classSymbol, INamedTypeSymbol validationSymbol, INamedTypeSymbol observablePropertySymbol)
     {
         foreach (ISymbol? memberSymbol in classSymbol.GetMembers())

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/TransitiveMembersGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/TransitiveMembersGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -101,7 +100,6 @@ public abstract partial class TransitiveMembersGenerator : ISourceGenerator
     /// Loads the source syntax tree for the current generator.
     /// </summary>
     /// <returns>The syntax tree with the elements to emit in the generated code.</returns>
-    [Pure]
     private SyntaxTree LoadSourceSyntaxTree()
     {
         string filename = $"CommunityToolkit.Mvvm.SourceGenerators.EmbeddedResources.{this.attributeTypeName.Replace("Attribute", string.Empty)}.cs";

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AttributeDataExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AttributeDataExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -26,7 +25,6 @@ internal static class AttributeDataExtensions
     /// <param name="name">The name of the argument to check.</param>
     /// <param name="value">The expected value for the target named argument.</param>
     /// <returns>Whether or not <paramref name="attributeData"/> contains an argument named <paramref name="name"/> with the expected value.</returns>
-    [Pure]
     public static bool HasNamedArgument<T>(this AttributeData attributeData, string name, T? value)
     {
         foreach (KeyValuePair<string, TypedConstant> properties in attributeData.NamedArguments)
@@ -73,7 +71,6 @@ internal static class AttributeDataExtensions
     /// <typeparam name="T">The type of constructor arguments to retrieve.</typeparam>
     /// <param name="attributeData">The target <see cref="AttributeData"/> instance to get the arguments from.</param>
     /// <returns>A sequence of all constructor arguments of the specified type from <paramref name="attributeData"/>.</returns>
-    [Pure]
     public static IEnumerable<T> GetConstructorArguments<T>(this AttributeData attributeData)
     {
         static IEnumerable<T> Enumerate(IEnumerable<TypedConstant> constants)
@@ -108,7 +105,6 @@ internal static class AttributeDataExtensions
     /// </summary>
     /// <param name="attributeData">The input <see cref="AttributeData"/> instance to process.</param>
     /// <returns>An <see cref="AttributeSyntax"/> replicating the data in <paramref name="attributeData"/>.</returns>
-    [Pure]
     public static AttributeSyntax AsAttributeSyntax(this AttributeData attributeData)
     {
         IdentifierNameSyntax attributeType = IdentifierName(attributeData.AttributeClass!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/INamedTypeSymbolExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/INamedTypeSymbolExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -18,7 +17,6 @@ internal static class INamedTypeSymbolExtensions
     /// </summary>
     /// <param name="symbol">The input <see cref="INamedTypeSymbol"/> instance.</param>
     /// <returns>The full metadata name for <paramref name="symbol"/>.</returns>
-    [Pure]
     public static string GetFullMetadataName(this INamedTypeSymbol symbol)
     {
         static StringBuilder BuildFrom(ISymbol? symbol, StringBuilder builder)
@@ -43,7 +41,6 @@ internal static class INamedTypeSymbolExtensions
     /// </summary>
     /// <param name="symbol">The input <see cref="INamedTypeSymbol"/> instance.</param>
     /// <returns>The full metadata name for <paramref name="symbol"/> that is also a valid filename.</returns>
-    [Pure]
     public static string GetFullMetadataNameForFileName(this INamedTypeSymbol symbol)
     {
         return symbol.GetFullMetadataName().Replace('`', '-').Replace('+', '.');
@@ -55,7 +52,6 @@ internal static class INamedTypeSymbolExtensions
     /// <param name="typeSymbol">The target <see cref="INamedTypeSymbol"/> instance to check.</param>
     /// <param name="targetTypeSymbol">The type symbol of the type to check for inheritance.</param>
     /// <returns>Whether or not <paramref name="typeSymbol"/> inherits from <paramref name="targetTypeSymbol"/>.</returns>
-    [Pure]
     public static bool InheritsFrom(this INamedTypeSymbol typeSymbol, INamedTypeSymbol targetTypeSymbol)
     {
         INamedTypeSymbol? baseType = typeSymbol.BaseType;

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/MemberDeclarationSyntaxExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/MemberDeclarationSyntaxExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22,7 +21,6 @@ internal static class MemberDeclarationSyntaxExtensions
     /// <param name="oldKind">The target modifier kind to replace.</param>
     /// <param name="newKind">The new modifier kind to add or replace.</param>
     /// <returns>A <see cref="MemberDeclarationSyntax"/> instance with the target modifier.</returns>
-    [Pure]
     public static MemberDeclarationSyntax ReplaceModifier(this MemberDeclarationSyntax memberDeclaration, SyntaxKind oldKind, SyntaxKind newKind)
     {
         int index = memberDeclaration.Modifiers.IndexOf(oldKind);
@@ -41,7 +39,6 @@ internal static class MemberDeclarationSyntaxExtensions
     /// <param name="memberDeclaration">The input <see cref="MemberDeclarationSyntax"/> instance.</param>
     /// <param name="kind">The modifier kind to remove.</param>
     /// <returns>A <see cref="MemberDeclarationSyntax"/> instance without the specified modifier.</returns>
-    [Pure]
     public static MemberDeclarationSyntax RemoveModifier(this MemberDeclarationSyntax memberDeclaration, SyntaxKind kind)
     {
         int index = memberDeclaration.Modifiers.IndexOf(kind);

--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -131,7 +130,6 @@ public sealed partial class ICommandGenerator : ISourceGenerator
     /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
     /// <param name="attributeData">The <see cref="AttributeData"/> instance the method was annotated with.</param>
     /// <returns>The <see cref="MemberDeclarationSyntax"/> instances for the input command.</returns>
-    [Pure]
     private static IEnumerable<MemberDeclarationSyntax> CreateCommandMembers(
         GeneratorExecutionContext context,
         INamedTypeSymbol classDeclarationSymbol,
@@ -283,7 +281,6 @@ public sealed partial class ICommandGenerator : ISourceGenerator
     /// <param name="context">The input <see cref="GeneratorExecutionContext"/> instance to use.</param>
     /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
     /// <returns>The generated field and property names for <paramref name="methodSymbol"/>.</returns>
-    [Pure]
     private static (string FieldName, string PropertyName) GetGeneratedFieldAndPropertyNames(GeneratorExecutionContext context, IMethodSymbol methodSymbol)
     {
         string propertyName = methodSymbol.Name;

--- a/CommunityToolkit.Mvvm.SourceGenerators/Messaging/IMessengerRegisterAllGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Messaging/IMessengerRegisterAllGenerator.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -221,7 +220,6 @@ public sealed partial class IMessengerRegisterAllGenerator : ISourceGenerator
     /// <param name="classSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
     /// <param name="iRecipientSymbol">The type symbol for the <c>IRecipient&lt;T&gt;</c> interface.</param>
     /// <returns>The sequence of <see cref="StatementSyntax"/> instances to register message handleers.</returns>
-    [Pure]
     private static IEnumerable<StatementSyntax> EnumerateRegistrationStatements(INamedTypeSymbol classSymbol, INamedTypeSymbol iRecipientSymbol)
     {
         foreach (INamedTypeSymbol? interfaceSymbol in classSymbol.AllInterfaces)
@@ -255,7 +253,6 @@ public sealed partial class IMessengerRegisterAllGenerator : ISourceGenerator
     /// <param name="classSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
     /// <param name="iRecipientSymbol">The type symbol for the <c>IRecipient&lt;T&gt;</c> interface.</param>
     /// <returns>The sequence of <see cref="StatementSyntax"/> instances to register message handleers.</returns>
-    [Pure]
     private static IEnumerable<StatementSyntax> EnumerateRegistrationStatementsWithTokens(INamedTypeSymbol classSymbol, INamedTypeSymbol iRecipientSymbol)
     {
         foreach (INamedTypeSymbol? interfaceSymbol in classSymbol.AllInterfaces)

--- a/CommunityToolkit.Mvvm/ComponentModel/ObservableValidator.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/ObservableValidator.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -482,14 +481,12 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     }
 
     /// <inheritdoc cref="INotifyDataErrorInfo.GetErrors(string)"/>
-    [Pure]
     public IEnumerable<ValidationResult> GetErrors(string? propertyName = null)
     {
         // Get entity-level errors when the target property is null or empty
         if (string.IsNullOrEmpty(propertyName))
         {
             // Local function to gather all the entity-level errors
-            [Pure]
             [MethodImpl(MethodImplOptions.NoInlining)]
             IEnumerable<ValidationResult> GetAllErrors()
             {
@@ -514,7 +511,6 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     }
 
     /// <inheritdoc/>
-    [Pure]
     IEnumerable INotifyDataErrorInfo.GetErrors(string? propertyName) => GetErrors(propertyName);
 
     /// <summary>

--- a/CommunityToolkit.Mvvm/Messaging/IMessenger.cs
+++ b/CommunityToolkit.Mvvm/Messaging/IMessenger.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 
 namespace CommunityToolkit.Mvvm.Messaging;
 
@@ -69,7 +68,6 @@ public interface IMessenger
     /// <param name="token">The token used to identify the target channel to check.</param>
     /// <returns>Whether or not <paramref name="recipient"/> has already been registered for the specified message.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="recipient"/> or <paramref name="token"/> are <see langword="null"/>.</exception>
-    [Pure]
     bool IsRegistered<TMessage, TToken>(object recipient, TToken token)
         where TMessage : class
         where TToken : IEquatable<TToken>;

--- a/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.cs
+++ b/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -70,7 +69,6 @@ public static class IMessengerExtensions
     /// <returns>Whether or not <paramref name="recipient"/> has already been registered for the specified message.</returns>
     /// <remarks>This method will use the default channel to check for the requested registration.</remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="messenger"/> or <paramref name="recipient"/> are <see langword="null"/>.</exception>
-    [Pure]
     public static bool IsRegistered<TMessage>(this IMessenger messenger, object recipient)
         where TMessage : class
     {

--- a/CommunityToolkit.Mvvm/Messaging/Internals/System/Collections.Generic/Dictionary2.cs
+++ b/CommunityToolkit.Mvvm/Messaging/Internals/System/Collections.Generic/Dictionary2.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic;
@@ -259,7 +258,6 @@ internal class Dictionary2<TKey, TValue> : IDictionary2<TKey, TValue>
     }
 
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator GetEnumerator() => new(this);
 

--- a/CommunityToolkit.Mvvm/Messaging/Internals/System/Runtime.CompilerServices/ConditionalWeakTable2{TKey,TValue}.Proxy.cs
+++ b/CommunityToolkit.Mvvm/Messaging/Internals/System/Runtime.CompilerServices/ConditionalWeakTable2{TKey,TValue}.Proxy.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 
 namespace System.Runtime.CompilerServices;
 
@@ -49,7 +48,6 @@ internal sealed class ConditionalWeakTable2<TKey, TValue>
     }
 
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator GetEnumerator() => new(this);
 

--- a/CommunityToolkit.Mvvm/Messaging/Internals/System/Runtime.CompilerServices/ConditionalWeakTable2{TKey,TValue}.cs
+++ b/CommunityToolkit.Mvvm/Messaging/Internals/System/Runtime.CompilerServices/ConditionalWeakTable2{TKey,TValue}.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 
 namespace System.Runtime.CompilerServices;
 
@@ -92,7 +91,6 @@ internal sealed class ConditionalWeakTable2<TKey, TValue>
     }
 
     /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator GetEnumerator() => new(this);
 

--- a/CommunityToolkit.Mvvm/Messaging/Messages/AsyncCollectionRequestMessage{T}.cs
+++ b/CommunityToolkit.Mvvm/Messaging/Messages/AsyncCollectionRequestMessage{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -100,7 +99,6 @@ public class AsyncCollectionRequestMessage<T> : IAsyncEnumerable<T>
     /// </summary>
     /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken"/> value to stop the operation.</param>
     /// <returns>The collection of received response items.</returns>
-    [Pure]
     public async Task<IReadOnlyCollection<T>> GetResponsesAsync(CancellationToken cancellationToken = default)
     {
         if (cancellationToken.CanBeCanceled)
@@ -119,7 +117,6 @@ public class AsyncCollectionRequestMessage<T> : IAsyncEnumerable<T>
     }
 
     /// <inheritdoc/>
-    [Pure]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {

--- a/CommunityToolkit.Mvvm/Messaging/Messages/AsyncRequestMessage{T}.cs
+++ b/CommunityToolkit.Mvvm/Messaging/Messages/AsyncRequestMessage{T}.cs
@@ -5,7 +5,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -72,7 +71,6 @@ public class AsyncRequestMessage<T>
     }
 
     /// <inheritdoc cref="Task{T}.GetAwaiter"/>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public TaskAwaiter<T> GetAwaiter()

--- a/CommunityToolkit.Mvvm/Messaging/Messages/CollectionRequestMessage{T}.cs
+++ b/CommunityToolkit.Mvvm/Messaging/Messages/CollectionRequestMessage{T}.cs
@@ -5,7 +5,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
 namespace CommunityToolkit.Mvvm.Messaging.Messages;
@@ -33,7 +32,6 @@ public class CollectionRequestMessage<T> : IEnumerable<T>
     }
 
     /// <inheritdoc/>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public IEnumerator<T> GetEnumerator()

--- a/CommunityToolkit.Mvvm/Properties/Configuration.cs
+++ b/CommunityToolkit.Mvvm/Properties/Configuration.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 
 /// <summary>
 /// A container for all shared <see cref="AppContext"/> configuration switches for the MVVM Toolkit.
@@ -26,7 +25,6 @@ internal static class Configuration
     /// </summary>
     /// <param name="propertyName">The property name to retrieve the value for.</param>
     /// <returns>The value of the specified configuration setting.</returns>
-    [Pure]
     private static bool GetConfigurationValue(string propertyName)
     {
         if (AppContext.TryGetSwitch(propertyName, out bool isEnabled))

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_HashCodeExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_HashCodeExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.Helpers;
@@ -92,7 +91,6 @@ public class Test_HashCodeExtensions
     /// <typeparam name="T">The type of items to put in the array.</typeparam>
     /// <param name="count">The number of array items to create.</param>
     /// <returns>An array of random <typeparamref name="T"/> elements.</returns>
-    [Pure]
     private static T[] CreateRandomData<T>(int count)
         where T : unmanaged
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.Count.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.Count.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.UnitTests.Buffers.Internals;
@@ -176,7 +175,6 @@ public partial class Test_ReadOnlySpanExtensions
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> instance to read.</param>
     /// <param name="value">The value to look for.</param>
     /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="span"/>.</returns>
-    [Pure]
     private static int CountWithForeach<T>(ReadOnlySpan<T> span, T value)
         where T : IEquatable<T>
     {
@@ -200,7 +198,6 @@ public partial class Test_ReadOnlySpanExtensions
     /// <param name="count">The number of array items to create.</param>
     /// <param name="value">The value to look for.</param>
     /// <returns>An array of random <typeparamref name="T"/> elements.</returns>
-    [Pure]
     private static UnmanagedSpanOwner<T> CreateRandomData<T>(int count, T value)
         where T : unmanaged
     {
@@ -233,7 +230,6 @@ public partial class Test_ReadOnlySpanExtensions
     /// <param name="count">The number of array items to create.</param>
     /// <param name="value">The value to use to populate the array.</param>
     /// <returns>An array of <typeparamref name="T"/> elements.</returns>
-    [Pure]
     private static UnmanagedSpanOwner<T> CreateFilledData<T>(int count, T value)
         where T : unmanaged
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_HashCode{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_HashCode{T}.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -107,7 +106,6 @@ public class Test_HashCodeOfT
     /// <typeparam name="T">The type of items to put in the array.</typeparam>
     /// <param name="count">The number of array items to create.</param>
     /// <returns>An array of random <typeparamref name="T"/> elements.</returns>
-    [Pure]
     private static UnmanagedSpanOwner<T> CreateRandomData<T>(int count)
         where T : unmanaged
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.ForEach.In.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.ForEach.In.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using CommunityToolkit.HighPerformance.Helpers;
@@ -54,7 +53,6 @@ public partial class Test_ParallelHelper
     /// </summary>
     /// <param name="count">The number of array items to create.</param>
     /// <returns>An array of random <see cref="int"/> elements.</returns>
-    [Pure]
     private static UnmanagedSpanOwner<int> CreateRandomData(int count)
     {
         Random? random = new(count);

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.ForEach.In2D.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.ForEach.In2D.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using CommunityToolkit.HighPerformance.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -60,7 +59,6 @@ public partial class Test_ParallelHelper
     /// <param name="height">The height of the array to create.</param>
     /// <param name="width">The width of the array to create.</param>
     /// <returns>An array of random <see cref="int"/> elements.</returns>
-    [Pure]
     private static int[,] CreateRandomData2D(int height, int width)
     {
         Random? random = new((height * 33) + width);

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Streams/Test_MemoryStream.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Streams/Test_MemoryStream.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -259,7 +258,6 @@ public partial class Test_MemoryStream
     /// </summary>
     /// <param name="count">The number of array items to create.</param>
     /// <returns>The returned random array.</returns>
-    [Pure]
     internal static byte[] CreateRandomData(int count)
     {
         Random? random = new(DateTime.Now.Ticks.GetHashCode());


### PR DESCRIPTION
This PR removes all `[Pure]` attribute usages from all .NET Community Toolkit libraries.
The underlying APIs are no longer used in .NET in general, so there's no point using these attributes.
Removing them also reduces the binary size a bit, so that's a small win as well.