### PR TITLE
Strip source generator attributes by default

### DIFF
--- a/CommunityToolkit.Mvvm/ComponentModel/Attributes/AlsoNotifyCanExecuteForAttribute.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/Attributes/AlsoNotifyCanExecuteForAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using CommunityToolkit.Mvvm.Input;
 
@@ -49,6 +50,7 @@ namespace CommunityToolkit.Mvvm.ComponentModel;
 /// </code>
 /// </summary>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
 public sealed class AlsoNotifyCanExecuteForAttribute : Attribute
 {
     /// <summary>

--- a/CommunityToolkit.Mvvm/ComponentModel/Attributes/AlsoNotifyChangeForAttribute.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/Attributes/AlsoNotifyChangeForAttribute.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 
 namespace CommunityToolkit.Mvvm.ComponentModel;
@@ -68,6 +69,7 @@ namespace CommunityToolkit.Mvvm.ComponentModel;
 /// </code>
 /// </summary>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
 public sealed class AlsoNotifyChangeForAttribute : Attribute
 {
     /// <summary>

--- a/CommunityToolkit.Mvvm/ComponentModel/Attributes/INotifyPropertyChangedAttribute.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/Attributes/INotifyPropertyChangedAttribute.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace CommunityToolkit.Mvvm.ComponentModel;
 
@@ -24,6 +25,7 @@ namespace CommunityToolkit.Mvvm.ComponentModel;
 /// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
 public sealed class INotifyPropertyChangedAttribute : Attribute
 {
     /// <summary>

--- a/CommunityToolkit.Mvvm/ComponentModel/Attributes/ObservableObjectAttribute.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/Attributes/ObservableObjectAttribute.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace CommunityToolkit.Mvvm.ComponentModel;
 
@@ -26,6 +27,7 @@ namespace CommunityToolkit.Mvvm.ComponentModel;
 /// And with this, the same APIs from <see cref="ObservableObject"/> will be available on this type as well.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
 public sealed class ObservableObjectAttribute : Attribute
 {
 }

--- a/CommunityToolkit.Mvvm/ComponentModel/Attributes/ObservablePropertyAttribute.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/Attributes/ObservablePropertyAttribute.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace CommunityToolkit.Mvvm.ComponentModel;
 
@@ -51,6 +52,7 @@ namespace CommunityToolkit.Mvvm.ComponentModel;
 /// source field name will be converted to uppercase (eg. <c>isEnabled</c> to <c>IsEnabled</c>).
 /// </remarks>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
 public sealed class ObservablePropertyAttribute : Attribute
 {
 }

--- a/CommunityToolkit.Mvvm/ComponentModel/Attributes/ObservableRecipientAttribute.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/Attributes/ObservableRecipientAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 
 namespace CommunityToolkit.Mvvm.ComponentModel;
 
@@ -40,6 +41,7 @@ namespace CommunityToolkit.Mvvm.ComponentModel;
 /// If this condition is not met, the code will fail to build.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
 public sealed class ObservableRecipientAttribute : Attribute
 {
 }

--- a/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
+++ b/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Windows.Input;
 
 namespace CommunityToolkit.Mvvm.Input;
@@ -60,6 +61,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
 public sealed class ICommandAttribute : Attribute
 {
     /// <summary>

--- a/dotnet Community Toolkit.sln
+++ b/dotnet Community Toolkit.sln
@@ -74,6 +74,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityToolkit.Mvvm.Disab
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Mvvm.Internals.UnitTests", "tests\CommunityToolkit.Mvvm.Internals.UnitTests\CommunityToolkit.Mvvm.Internals.UnitTests.csproj", "{743D74BA-12AE-4639-AD77-B9DDA9C03255}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests", "tests\CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests\CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests.csproj", "{AFB55517-3B50-47E3-B9CA-F1C2770479B6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -348,6 +350,26 @@ Global
 		{743D74BA-12AE-4639-AD77-B9DDA9C03255}.Release|x64.Build.0 = Release|Any CPU
 		{743D74BA-12AE-4639-AD77-B9DDA9C03255}.Release|x86.ActiveCfg = Release|Any CPU
 		{743D74BA-12AE-4639-AD77-B9DDA9C03255}.Release|x86.Build.0 = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|ARM.Build.0 = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|x64.Build.0 = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Debug|x86.Build.0 = Debug|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|ARM.ActiveCfg = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|ARM.Build.0 = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|ARM64.Build.0 = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|x64.ActiveCfg = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|x64.Build.0 = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|x86.ActiveCfg = Release|Any CPU
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -365,6 +387,7 @@ Global
 		{6640D447-C28D-4DBB-91F4-3ADCE0CA64AD} = {B30036C4-D514-4E5B-A323-587A061772CE}
 		{9E09DA49-4389-4ECE-8B68-EBDB1221DA90} = {6640D447-C28D-4DBB-91F4-3ADCE0CA64AD}
 		{743D74BA-12AE-4639-AD77-B9DDA9C03255} = {B30036C4-D514-4E5B-A323-587A061772CE}
+		{AFB55517-3B50-47E3-B9CA-F1C2770479B6} = {6640D447-C28D-4DBB-91F4-3ADCE0CA64AD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5403B0C4-F244-4F73-A35C-FE664D0F4345}

--- a/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/Test_DisableINotifyPropertyChanging.cs
+++ b/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/Test_DisableINotifyPropertyChanging.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace CommunityToolkit.Mvvm.UnitTests.Configuration;
+namespace CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests;
 
 [TestClass]
 public class Test_DisableINotifyPropertyChanging

--- a/tests/CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests/CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests/CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\CommunityToolkit.Mvvm\CommunityToolkit.Mvvm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests/Test_SourceGeneratorAttributes.cs
+++ b/tests/CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests/Test_SourceGeneratorAttributes.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests;
+
+[TestClass]
+public class Test_SourceGeneratorAttributes
+{
+    [TestMethod]
+    public void Test_AttributeMetadata()
+    {
+#if !MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES
+        Assert.Fail();
+#endif
+        Assert.AreEqual(3, typeof(TestModel).GetCustomAttributes().Count(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+        Assert.AreEqual(3, typeof(TestModel).GetField(nameof(TestModel.name))!.GetCustomAttributes().Count(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+        Assert.AreEqual(1, typeof(TestModel).GetMethod(nameof(TestModel.Test))!.GetCustomAttributes().Count(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+    }
+
+    [INotifyPropertyChanged]
+    [ObservableObject]
+    [ObservableRecipient]
+    public class TestModel
+    {
+        [ObservableProperty]
+        [AlsoNotifyChangeFor("")]
+        [AlsoNotifyCanExecuteFor("")]
+        public string? name;
+
+        [ICommand]
+        public void Test()
+        {
+        }
+    }
+}

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_SourceGeneratorAttributes.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_SourceGeneratorAttributes.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommunityToolkit.Mvvm.UnitTests;
+
+[TestClass]
+public partial class Test_SourceGeneratorAttributes
+{
+    [TestMethod]
+    public void Test_AttributeMetadata()
+    {
+#if MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES
+        Assert.Fail();
+#endif
+        Assert.IsFalse(typeof(INotifyPropertyChangedModel).GetCustomAttributes().Any(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+        Assert.IsFalse(typeof(TestModel).GetCustomAttributes().Any(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+        Assert.IsFalse(typeof(TestModel).GetField(nameof(TestModel.name))!.GetCustomAttributes().Any(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+        Assert.IsFalse(typeof(TestModel).GetMethod(nameof(TestModel.Test))!.GetCustomAttributes().Any(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+        Assert.IsFalse(typeof(ObservableRecipientModel).GetCustomAttributes().Any(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+    }
+
+    [INotifyPropertyChanged]
+    public partial class INotifyPropertyChangedModel
+    {
+    }
+
+    [ObservableObject]
+    public partial class TestModel
+    {
+        [ObservableProperty]
+        [AlsoNotifyChangeFor(nameof(Name))]
+        [AlsoNotifyCanExecuteFor(nameof(TestCommand))]
+        public string? name;
+
+        [ICommand]
+        public void Test()
+        {
+        }
+    }
+
+    [ObservableRecipient]
+    public partial class ObservableRecipientModel : ObservableObject
+    {
+    }
+}


### PR DESCRIPTION
**Contributes to #8**
**Closes #38**

This PR makes it so that source generator attributes in the MVVM Toolkit are stripped by default.
The "MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES" build constant can be defined to keep them.