### PR TITLE
Remove class constraint from Guard.Is[Not]Null APIs

### DIFF
--- a/CommunityToolkit.Diagnostics/Guard.cs
+++ b/CommunityToolkit.Diagnostics/Guard.cs
@@ -24,7 +24,6 @@ public static partial class Guard
     /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is not <see langword="null"/>.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void IsNull<T>(T? value, [CallerArgumentExpression("value")] string name = "")
-        where T : class
     {
         if (value is null)
         {
@@ -63,7 +62,6 @@ public static partial class Guard
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void IsNotNull<T>([NotNull] T? value, [CallerArgumentExpression("value")] string name = "")
-        where T : class
     {
         if (value is not null)
         {

--- a/CommunityToolkit.Diagnostics/Guard.cs
+++ b/CommunityToolkit.Diagnostics/Guard.cs
@@ -40,7 +40,6 @@ public static partial class Guard
     /// <param name="value">The input value to test.</param>
     /// <param name="name">The name of the input parameter being tested.</param>
     /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is not <see langword="null"/>.</exception>
-    /// <remarks>The method is generic to avoid boxing the parameters, if they are value types.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void IsNull<T>(T? value, [CallerArgumentExpression("value")] string name = "")
         where T : struct
@@ -78,7 +77,6 @@ public static partial class Guard
     /// <param name="value">The input value to test.</param>
     /// <param name="name">The name of the input parameter being tested.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
-    /// <remarks>The method is generic to avoid boxing the parameters, if they are value types.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void IsNotNull<T>([NotNull] T? value, [CallerArgumentExpression("value")] string name = "")
         where T : struct

--- a/CommunityToolkit.Diagnostics/Internals/Guard.ThrowHelper.cs
+++ b/CommunityToolkit.Diagnostics/Internals/Guard.ThrowHelper.cs
@@ -38,9 +38,8 @@ partial class Guard
         /// <typeparam name="T">The type of the input value.</typeparam>
         [DoesNotReturn]
         public static void ThrowArgumentExceptionForIsNull<T>(T value, string name)
-            where T : class
         {
-            throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be null, was {AssertString(value)} ({value.GetType().ToTypeString()}).", name);
+            throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be null, was {AssertString(value)} ({value!.GetType().ToTypeString()}).", name);
         }
 
         /// <summary>

--- a/tests/CommunityToolkit.Diagnostics.UnitTests/Test_Guard.cs
+++ b/tests/CommunityToolkit.Diagnostics.UnitTests/Test_Guard.cs
@@ -15,6 +15,14 @@ public partial class Test_Guard
     {
         Guard.IsNull<object>(null, nameof(Test_Guard_IsNull_Ok));
         Guard.IsNull<int>(null, nameof(Test_Guard_IsNull_Ok));
+
+        static void Test<T>(T? obj)
+        {
+            Guard.IsNull(obj, nameof(Test_Guard_IsNull_Ok));
+        }
+
+        Test<string>(null);
+        Test<int?>(null);
     }
 
     [TestMethod]
@@ -28,14 +36,47 @@ public partial class Test_Guard
     [ExpectedException(typeof(ArgumentException))]
     public void Test_Guard_IsNull_StructFail()
     {
-        Guard.IsNull<int>(7, nameof(Test_Guard_IsNull_StructFail));
+        Guard.IsNull(7, nameof(Test_Guard_IsNull_StructFail));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Test_Guard_IsNull_GenericClassFail()
+    {
+        static void Test<T>(T? obj)
+        {
+            Guard.IsNull(obj, nameof(Test_Guard_IsNull_GenericClassFail));
+        }
+
+        Test("Hi!");
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Test_Guard_IsNull_GenericStructFail()
+    {
+        static void Test<T>(T? obj)
+        {
+            Guard.IsNull(obj, nameof(Test_Guard_IsNull_GenericStructFail));
+        }
+
+        Test(42);
     }
 
     [TestMethod]
     public void Test_Guard_IsNotNull_Ok()
     {
         Guard.IsNotNull(new object(), nameof(Test_Guard_IsNotNull_Ok));
-        Guard.IsNotNull<int>(7, nameof(Test_Guard_IsNotNull_Ok));
+        Guard.IsNotNull(7, nameof(Test_Guard_IsNotNull_Ok));
+
+        static void Test<T>(T? obj)
+        {
+            Guard.IsNotNull(obj, nameof(Test_Guard_IsNotNull_Ok));
+        }
+
+        Test("Hi!");
+        Test(42);
+        Test<int?>(42);
     }
 
     [TestMethod]
@@ -50,6 +91,30 @@ public partial class Test_Guard
     public void Test_Guard_IsNotNull_StructFail()
     {
         Guard.IsNotNull<int>(null, nameof(Test_Guard_IsNotNull_StructFail));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Test_Guard_IsNotNull_GenericClassFail()
+    {
+        static void Test<T>(T? obj)
+        {
+            Guard.IsNotNull(obj, nameof(Test_Guard_IsNotNull_GenericClassFail));
+        }
+
+        Test<string>(null);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Test_Guard_IsNotNull_GenericStructFail()
+    {
+        static void Test<T>(T? obj)
+        {
+            Guard.IsNotNull(obj, nameof(Test_Guard_IsNotNull_GenericClassFail));
+        }
+
+        Test<int?>(null);
     }
 
     [TestMethod]


### PR DESCRIPTION
**Closes #43**

This PR removes the `where T : class` constraint from the `Guard.Is[Not]Null` APIs.

## API diff

```diff
 namespace CommunityToolkit.Diagnostics;

 public static class Guard
 {
     public static void IsNull<T>(T? value, [CallerArgumentExpression("value")] string name = "")
-        where T : class

     public static void IsNotNull<T>([NotNull] T? value, [CallerArgumentExpression("value")] string name = "")
-        where T : class
 }
```