### PR TITLE
Update base version number to reflect upcoming version

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.0-build.{height}",
+  "version": "8.0.0-build.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/dev$", // we release out of dev


### PR DESCRIPTION
We should have our latest nightly builds show-up as the latest versions, so once we figure out a version number, we should update our version.json to match the upcoming release.