### PR TITLE
Disable generation of header files if no targets are present

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservableValidatorValidateAllPropertiesGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservableValidatorValidateAllPropertiesGenerator.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using System.Text;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using CommunityToolkit.Mvvm.SourceGenerators.Input.Models;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -42,7 +43,7 @@ public sealed partial class ObservableValidatorValidateAllPropertiesGenerator : 
             .Select(static (item, _) => item.Length > 0);
 
         // Generate the header file with the attributes
-        context.RegisterImplementationSourceOutput(isHeaderFileNeeded, static (context, item) =>
+        context.RegisterConditionalImplementationSourceOutput(isHeaderFileNeeded, static context =>
         {
             CompilationUnitSyntax compilationUnit = Execute.GetSyntax();
 

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/IncrementalGeneratorInitializationContextExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/IncrementalGeneratorInitializationContextExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -61,5 +62,26 @@ internal static class IncrementalGeneratorInitializationContextExtensions
             dataWithSupportedInfo
             .Where(static item => item.IsGeneratorSupported)
             .Select(static (item, _) => item.Data);
+    }
+
+    /// <summary>
+    /// Conditionally invokes <see cref="IncrementalGeneratorInitializationContext.RegisterImplementationSourceOutput{TSource}(IncrementalValueProvider{TSource}, System.Action{SourceProductionContext, TSource})"/>
+    /// if the value produced by the input <see cref="IncrementalValueProvider{TValue}"/> is <see langword="true"/>.
+    /// </summary>
+    /// <param name="context">The input <see cref="IncrementalGeneratorInitializationContext"/> value being used.</param>
+    /// <param name="source">The source <see cref="IncrementalValueProvider{TValues}"/> instance.</param>
+    /// <param name="action">The conditional <see cref="Action{T}"/> to invoke.</param>
+    public static void RegisterConditionalImplementationSourceOutput(
+        this IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<bool> source,
+        Action<SourceProductionContext> action)
+    {
+        context.RegisterImplementationSourceOutput(source, (context, flag) =>
+        {
+            if (flag)
+            {
+                action(context);
+            }
+        });
     }
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Messaging/IMessengerRegisterAllGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Messaging/IMessengerRegisterAllGenerator.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using CommunityToolkit.Mvvm.SourceGenerators.Input.Models;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -48,7 +49,7 @@ public sealed partial class IMessengerRegisterAllGenerator : IIncrementalGenerat
             .Select(static (item, _) => item.Length > 0);
 
         // Generate the header file with the attributes
-        context.RegisterImplementationSourceOutput(isHeaderFileNeeded, static (context, item) =>
+        context.RegisterConditionalImplementationSourceOutput(isHeaderFileNeeded, static context =>
         {
             CompilationUnitSyntax compilationUnit = Execute.GetSyntax();
 


### PR DESCRIPTION
This PR disables the generation of the header files for partial class declarations with attributes, if no targets are present.
Without this, the header files for `ObservableValidator` and `IRecipient<TMessage>` were always generated instead.