### PR TITLE
Fix [ObservableRecipient] with inherited base attributes

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservableRecipientGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservableRecipientGenerator.cs
@@ -82,8 +82,8 @@ public sealed class ObservableRecipientGenerator : TransitiveMembersGenerator<Ob
         // In order to use [ObservableRecipient], the target type needs to inherit from ObservableObject,
         // or be annotated with [ObservableObject] or [INotifyPropertyChanged] (with additional helpers).
         if (!typeSymbol.InheritsFrom("global::CommunityToolkit.Mvvm.ComponentModel.ObservableObject") &&
-            !typeSymbol.GetAttributes().Any(static a => a.AttributeClass?.HasFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.ObservableObjectAttribute") == true) &&
-            !typeSymbol.GetAttributes().Any(static a =>
+            !typeSymbol.HasOrInheritsAttribute(static a => a.AttributeClass?.HasFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.ObservableObjectAttribute") == true) &&
+            !typeSymbol.HasOrInheritsAttribute(static a =>
                 a.AttributeClass?.HasFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.INotifyPropertyChangedAttribute") == true &&
                 !a.HasNamedArgument("IncludeAdditionalHelperMethods", false)))
         {

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/INamedTypeSymbolExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/INamedTypeSymbolExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -58,6 +60,25 @@ internal static class INamedTypeSymbolExtensions
             }
 
             baseType = baseType.BaseType;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether or not a given <see cref="INamedTypeSymbol"/> has or inherits a specified attribute.
+    /// </summary>
+    /// <param name="typeSymbol">The target <see cref="INamedTypeSymbol"/> instance to check.</param>
+    /// <param name="predicate">The predicate used to match available attributes.</param>
+    /// <returns>Whether or not <paramref name="typeSymbol"/> has an attribute matching <paramref name="predicate"/>.</returns>
+    public static bool HasOrInheritsAttribute(this INamedTypeSymbol typeSymbol, Func<AttributeData, bool> predicate)
+    {
+        for (INamedTypeSymbol? currentType = typeSymbol; currentType is not null; currentType = currentType.BaseType)
+        {
+            if (currentType.GetAttributes().Any(predicate))
+            {
+                return true;
+            }
         }
 
         return false;

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservableRecipientAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservableRecipientAttribute.cs
@@ -260,4 +260,25 @@ public partial class Test_ObservableRecipientAttribute
             OnDeactivatedResult = true;
         }
     }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/109
+    [TestMethod]
+    public void Test_ObservableRecipientAttribute_WorksWithBaseClassWithObservableObjectAttribute()
+    {
+        ViewModelWithOnlyObservableRecipientAttribute model = new();
+
+        // This test method really only needs the two classes below to compile at all
+        Assert.IsTrue(model is INotifyPropertyChanged); // From [ObservableObject]
+        Assert.IsFalse(model.IsActive); // From [ObservableRecipient]
+    }
+
+    [ObservableObject]
+    public partial class BaseViewModelWithObservableObjectAttribute
+    {
+    }
+
+    [ObservableRecipient]
+    public partial class ViewModelWithOnlyObservableRecipientAttribute : BaseViewModelWithObservableObjectAttribute
+    {
+    }
 }


### PR DESCRIPTION
**Fixes #109**

This PR makes this code compile and run correctly:

```csharp
[ObservableObject]
public partial class BaseViewModel
{
}

[ObservableRecipient]
public partial class MyViewModel : BaseViewModel
{
}
```