### PR TITLE
Fix AsyncRelayCommand with allowConcurrentExecutions == false not raising CanExecuteChanged

### DIFF
--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -328,7 +328,7 @@ public class Test_AsyncRelayCommand
 
     // See https://github.com/CommunityToolkit/dotnet/issues/108
     [TestMethod]
-    public void Test_AsyncRelayCommand_ExecuteDoesNotRaisesCanExecuteChanged()
+    public void Test_AsyncRelayCommand_ExecuteDoesNotRaiseCanExecuteChanged()
     {
         TaskCompletionSource<object?> tcs = new();
 
@@ -374,7 +374,7 @@ public class Test_AsyncRelayCommand
     }
 
     [TestMethod]
-    public void Test_AsyncRelayCommand_ExecuteDoesNotRaisesCanExecuteChanged_WithCancellation()
+    public void Test_AsyncRelayCommand_ExecuteDoesNotRaiseCanExecuteChanged_WithCancellation()
     {
         TaskCompletionSource<object?> tcs = new();
 

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -224,7 +224,7 @@ public class Test_AsyncRelayCommandOfT
         Assert.IsTrue(success);
     }
 
-    public void Test_AsyncRelayCommand_ExecuteDoesNotRaisesCanExecuteChanged()
+    public void Test_AsyncRelayCommand_ExecuteDoesNotRaiseCanExecuteChanged()
     {
         TaskCompletionSource<object?> tcs = new();
 
@@ -270,7 +270,7 @@ public class Test_AsyncRelayCommandOfT
     }
 
     [TestMethod]
-    public void Test_AsyncRelayCommand_ExecuteDoesNotRaisesCanExecuteChanged_WithCancellation()
+    public void Test_AsyncRelayCommand_ExecuteDoesNotRaiseCanExecuteChanged_WithCancellation()
     {
         TaskCompletionSource<object?> tcs = new();
 

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -223,4 +223,95 @@ public class Test_AsyncRelayCommandOfT
 
         Assert.IsTrue(success);
     }
+
+    public void Test_AsyncRelayCommand_ExecuteDoesNotRaisesCanExecuteChanged()
+    {
+        TaskCompletionSource<object?> tcs = new();
+
+        AsyncRelayCommand<string> command = new(s => tcs.Task, allowConcurrentExecutions: true);
+
+        (object? Sender, EventArgs? Args) args = default;
+
+        command.CanExecuteChanged += (s, e) => args = (s, e);
+
+        Assert.IsTrue(command.CanExecute(""));
+
+        command.Execute("");
+
+        Assert.IsNull(args.Sender);
+        Assert.IsNull(args.Args);
+
+        Assert.IsTrue(command.CanExecute(""));
+
+        tcs.SetResult(null);
+    }
+
+    [TestMethod]
+    public void Test_AsyncRelayCommand_ExecuteWithoutConcurrencyRaisesCanExecuteChanged()
+    {
+        TaskCompletionSource<object?> tcs = new();
+
+        AsyncRelayCommand<string> command = new(s => tcs.Task, allowConcurrentExecutions: false);
+
+        (object? Sender, EventArgs? Args) args = default;
+
+        command.CanExecuteChanged += (s, e) => args = (s, e);
+
+        Assert.IsTrue(command.CanExecute(""));
+
+        command.Execute("");
+
+        Assert.AreSame(command, args.Sender);
+        Assert.AreSame(EventArgs.Empty, args.Args);
+
+        Assert.IsFalse(command.CanExecute(""));
+
+        tcs.SetResult(null);
+    }
+
+    [TestMethod]
+    public void Test_AsyncRelayCommand_ExecuteDoesNotRaisesCanExecuteChanged_WithCancellation()
+    {
+        TaskCompletionSource<object?> tcs = new();
+
+        AsyncRelayCommand<string> command = new((s, token) => tcs.Task, allowConcurrentExecutions: true);
+
+        (object? Sender, EventArgs? Args) args = default;
+
+        command.CanExecuteChanged += (s, e) => args = (s, e);
+
+        Assert.IsTrue(command.CanExecute(""));
+
+        command.Execute("");
+
+        Assert.IsNull(args.Sender);
+        Assert.IsNull(args.Args);
+
+        Assert.IsTrue(command.CanExecute(""));
+
+        tcs.SetResult(null);
+    }
+
+    [TestMethod]
+    public void Test_AsyncRelayCommand_ExecuteWithoutConcurrencyRaisesCanExecuteChanged_WithToken()
+    {
+        TaskCompletionSource<object?> tcs = new();
+
+        AsyncRelayCommand<string> command = new((s, token) => tcs.Task, allowConcurrentExecutions: false);
+
+        (object? Sender, EventArgs? Args) args = default;
+
+        command.CanExecuteChanged += (s, e) => args = (s, e);
+
+        Assert.IsTrue(command.CanExecute(""));
+
+        command.Execute("");
+
+        Assert.AreSame(command, args.Sender);
+        Assert.AreSame(EventArgs.Empty, args.Args);
+
+        Assert.IsFalse(command.CanExecute(""));
+
+        tcs.SetResult(null);
+    }
 }


### PR DESCRIPTION
**Closes #108**

This PR fixes `AsyncRelayCommand` and `AsyncRelayCommand<T>` not raising `CanExecuteChanged` when invoked if `allowConcurrentExecutions` is set to `false` (which they should, given the command wouldn't be executable at that point).