### PR TITLE
Switch NBGV from install to update

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
     inputs:
       command: custom
       custom: tool
-      arguments: install -g nbgv
+      arguments: update -g nbgv
 
   # Set Build Version
   - script: nbgv cloud


### PR DESCRIPTION
This avoids issues if the tool is already installed (which is currently the case in the pipeline image).