### PR TITLE
Propagate task exceptions to TaskScheduler.UnobservedTaskException

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/EmbeddedResources/INotifyPropertyChanged.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/EmbeddedResources/INotifyPropertyChanged.cs
@@ -389,13 +389,7 @@ public abstract class INotifyPropertyChanged : global::System.ComponentModel.INo
 
         async void MonitorTask()
         {
-            try
-            {
-                await newValue!;
-            }
-            catch
-            {
-            }
+            await global::CommunityToolkit.Mvvm.ComponentModel.__Internals.__TaskExtensions.GetAwaitableWithoutEndValidation(newValue!);
 
             if (ReferenceEquals(taskNotifier.Task, newValue))
             {

--- a/CommunityToolkit.Mvvm.SourceGenerators/EmbeddedResources/ObservableObject.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/EmbeddedResources/ObservableObject.cs
@@ -437,13 +437,7 @@ public abstract class ObservableObject : global::System.ComponentModel.INotifyPr
 
         async void MonitorTask()
         {
-            try
-            {
-                await newValue!;
-            }
-            catch
-            {
-            }
+            await global::CommunityToolkit.Mvvm.ComponentModel.__Internals.__TaskExtensions.GetAwaitableWithoutEndValidation(newValue!);
 
             if (ReferenceEquals(taskNotifier.Task, newValue))
             {

--- a/CommunityToolkit.Mvvm/ComponentModel/ObservableObject.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/ObservableObject.cs
@@ -19,6 +19,9 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel.__Internals;
+
+#pragma warning disable CS0618
 
 namespace CommunityToolkit.Mvvm.ComponentModel;
 
@@ -525,14 +528,8 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
         // which would result in a confusing behavior for users.
         async void MonitorTask()
         {
-            try
-            {
-                // Await the task and ignore any exceptions
-                await newValue!;
-            }
-            catch
-            {
-            }
+            // Await the task and ignore any exceptions
+            await newValue!.GetAwaitableWithoutEndValidation();
 
             // Only notify if the property hasn't changed
             if (ReferenceEquals(taskNotifier.Task, newValue))

--- a/CommunityToolkit.Mvvm/ComponentModel/__Internals/__TaskExtensions.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/__Internals/__TaskExtensions.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace CommunityToolkit.Mvvm.ComponentModel.__Internals;
+
+/// <summary>
+/// An internal helper used to support <see cref="ObservableObject"/> and generated code from its template.
+/// This type is not intended to be used directly by user code.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Obsolete("This type is not intended to be used directly by user code")]
+public static class __TaskExtensions
+{
+    /// <summary>
+    /// Gets an awaitable object that skips end validation.
+    /// </summary>
+    /// <param name="task">The input <see cref="Task"/> to get the awaitable for.</param>
+    /// <returns>A <see cref="TaskAwaitableWithoutEndValidation"/> object wrapping <paramref name="task"/>.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This method is not intended to be called directly by user code")]
+    public static TaskAwaitableWithoutEndValidation GetAwaitableWithoutEndValidation(this Task task)
+    {
+        return new(task);
+    }
+
+    /// <summary>
+    /// A custom task awaitable object that skips end validation.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This type is not intended to be called directly by user code")]
+    public readonly struct TaskAwaitableWithoutEndValidation
+    {
+        /// <summary>
+        /// The wrapped <see cref="Task"/> instance to create an awaiter for.
+        /// </summary>
+        private readonly Task task;
+
+        /// <summary>
+        /// Creates a new <see cref="TaskAwaitableWithoutEndValidation"/> instance with the specified parameters.
+        /// </summary>
+        /// <param name="task">The wrapped <see cref="Task"/> instance to create an awaiter for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TaskAwaitableWithoutEndValidation(Task task)
+        {
+            this.task = task;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="Awaiter"/> instance for the current underlying task.
+        /// </summary>
+        /// <returns>An <see cref="Awaiter"/> instance for the current underlying task.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Awaiter GetAwaiter()
+        {
+            return new(this.task);
+        }
+
+        /// <summary>
+        /// An awaiter object for <see cref="TaskAwaitableWithoutEndValidation"/>.
+        /// </summary>
+        public readonly struct Awaiter : ICriticalNotifyCompletion
+        {
+            /// <summary>
+            /// The underlying <see cref="TaskAwaiter"/> inistance.
+            /// </summary>
+            private readonly TaskAwaiter taskAwaiter;
+
+            /// <summary>
+            /// Creates a new <see cref="Awaiter"/> instance with the specified parameters.
+            /// </summary>
+            /// <param name="task">The wrapped <see cref="Task"/> instance to create an awaiter for.</param>
+            public Awaiter(Task task)
+            {
+                this.taskAwaiter = task.GetAwaiter();
+            }
+
+            /// <summary>
+            /// Gets whether the operation has completed or not.
+            /// </summary>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            public bool IsCompleted
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => taskAwaiter.IsCompleted;
+            }
+
+            /// <summary>
+            /// Ends the await operation.
+            /// </summary>
+            /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void GetResult()
+            {
+            }
+
+            /// <inheritdoc/>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void OnCompleted(Action continuation)
+            {
+                this.taskAwaiter.OnCompleted(continuation);
+            }
+
+            /// <inheritdoc/>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                this.taskAwaiter.UnsafeOnCompleted(continuation);
+            }
+        }
+    }
+}

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -7,6 +7,9 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel.__Internals;
+
+#pragma warning disable CS0618
 
 namespace CommunityToolkit.Mvvm.Input;
 
@@ -213,13 +216,7 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
 
             static async void MonitorTask(AsyncRelayCommand @this, Task task)
             {
-                try
-                {
-                    await task;
-                }
-                catch
-                {
-                }
+                await task.GetAwaitableWithoutEndValidation();
 
                 if (ReferenceEquals(@this.executionTask, task))
                 {

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -7,6 +7,9 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel.__Internals;
+
+#pragma warning disable CS0618
 
 namespace CommunityToolkit.Mvvm.Input;
 
@@ -197,13 +200,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
 
             static async void MonitorTask(AsyncRelayCommand<T> @this, Task task)
             {
-                try
-                {
-                    await task;
-                }
-                catch
-                {
-                }
+                await task.GetAwaitableWithoutEndValidation();
 
                 if (ReferenceEquals(@this.executionTask, task))
                 {

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Helpers/TaskSchedulerTestHelper.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Helpers/TaskSchedulerTestHelper.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace CommunityToolkit.Mvvm.UnitTests.Helpers;
+
+/// <summary>
+/// A helper class to validate scenarios related to <see cref="TaskScheduler"/>.
+/// </summary>
+internal static class TaskSchedulerTestHelper
+{
+    /// <summary>
+    /// A custom <see cref="Delegate"/> for callbacks to <see cref="IsExceptionBubbledUpToUnobservedTaskExceptionAsync(TestCallback)"/>.
+    /// </summary>
+    /// <param name="throwAction">An <see cref="Action"/> instance that throws a test exception to track.</param>
+    /// <param name="completeAction">An <see cref="Action"/> that signals whenever the test has completed.</param>
+    public delegate void TestCallback(Action throwAction, Action completeAction);
+
+    /// <summary>
+    /// Checks whether a given test exception is correctly bubbled up to <see cref="TaskScheduler.UnobservedTaskException"/>.
+    /// </summary>
+    /// <param name="callback">The <see cref="TestCallback"/> instance to use to run the test.</param>
+    /// <returns>Whether or not the test exception was correctly bubbled up to <see cref="TaskScheduler.UnobservedTaskException"/>.</returns>
+    public static async Task<bool> IsExceptionBubbledUpToUnobservedTaskExceptionAsync(TestCallback callback)
+    {
+        TaskCompletionSource<object?> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        string guid = Guid.NewGuid().ToString();
+        bool exceptionFound = false;
+
+        void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            e.SetObserved();
+
+            foreach (Exception exception in e.Exception!.InnerExceptions)
+            {
+                if (exception is TestException testException &&
+                    testException.Message == guid)
+                {
+                    exceptionFound = true;
+
+                    return;
+                }
+            }
+        }
+
+        EventHandler<UnobservedTaskExceptionEventArgs> handler = TaskScheduler_UnobservedTaskException;
+
+        TaskScheduler.UnobservedTaskException += handler;
+
+        try
+        {
+            // Enqueue a continuation that will throw and ignore the returned task. This has
+            // to be a separate method to ensure the returned task isn't kept alive for longer.
+            callback(
+                () => throw new TestException(guid),
+                () => tcs.SetResult(null));
+
+            // Await for the continuation to actually run
+            _ = await tcs.Task;
+
+            // Some additional time to ensure the exception is propagated
+            await Task.Delay(200);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= handler;
+        }
+
+        return exceptionFound;
+    }
+
+    /// <summary>
+    /// A custom exception to support <see cref="IsExceptionBubbledUpToUnobservedTaskExceptionAsync(TestCallback)"/>.
+    /// </summary>
+    private sealed class TestException : Exception
+    {
+        /// <summary>
+        /// Creates a new <see cref="TestException"/> instance with the specified parameters.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        public TestException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.UnitTests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.Mvvm.UnitTests;
@@ -297,5 +298,31 @@ public class Test_AsyncRelayCommand
         await task;
 
         Assert.IsFalse(command.IsRunning);
+    }
+
+    [TestMethod]
+    public async Task Test_AsyncRelayCommand_ThrowingTaskBubblesToUnobservedTaskException()
+    {
+        static async Task TestMethodAsync(Action action)
+        {
+            await Task.Delay(100);
+
+            action();
+        }
+
+        async void TestCallback(Action throwAction, Action completeAction)
+        {
+            AsyncRelayCommand command = new(() => TestMethodAsync(throwAction));
+
+            command.Execute(null);
+
+            await Task.Delay(200);
+
+            completeAction();
+        }
+
+        bool success = await TaskSchedulerTestHelper.IsExceptionBubbledUpToUnobservedTaskExceptionAsync(TestCallback);
+
+        Assert.IsTrue(success);
     }
 }


### PR DESCRIPTION
**Contributes to #22**

This PR adds a new internal `__TaskExtensions.GetAwaitableWithoutEndValidation` extensions (note: needs to be public as source generated code is using it too) that allows us to await a task without throwing exceptions. This has two main advantages:

- The code is now much more efficient, as we're no longer throwing/catching it, just ignoring it.
- Exceptions will now no longer be marked as observed, so they'll bubble up to `TaskScheduler.UnobservedTaskException`.

With this change, the MVVM Toolkit will essentially no longer interfere with task exceptions being observed, so users will be able to just monitor and log them through `TaskScheduler.UnobservedTaskException` as expected, unless manually observed.