### PR TITLE
Fix IRecipient generator for partial recipient declarations

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/Messaging/IMessengerRegisterAllGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Messaging/IMessengerRegisterAllGenerator.cs
@@ -27,7 +27,7 @@ public sealed partial class IMessengerRegisterAllGenerator : IIncrementalGenerat
         IncrementalValuesProvider<INamedTypeSymbol> typeSymbols =
             context.SyntaxProvider
             .CreateSyntaxProvider(
-                static (node, _) => node is ClassDeclarationSyntax,
+                static (node, _) => node is ClassDeclarationSyntax { BaseList.Types.Count: > 0 },
                 static (context, _) => (INamedTypeSymbol)context.SemanticModel.GetDeclaredSymbol(context.Node)!);
 
         // Get the target IRecipient<TMessage> interfaces and filter out other types

--- a/CommunityToolkit.Mvvm.SourceGenerators/Messaging/Models/RecipientInfo.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Messaging/Models/RecipientInfo.cs
@@ -23,11 +23,6 @@ internal sealed record RecipientInfo(
     ImmutableArray<string> MessageTypes)
 {
     /// <summary>
-    /// Gets an <see cref="IEqualityComparer{T}"/> implementation only matching by <see cref="FilenameHint"/>.
-    /// </summary>
-    public static IEqualityComparer<RecipientInfo> EqualityComparerByFilenameHint { get; } = new FilenameHintComparer();
-
-    /// <summary>
     /// An <see cref="IEqualityComparer{T}"/> implementation for <see cref="RecipientInfo"/>.
     /// </summary>
     public sealed class Comparer : Comparer<RecipientInfo, Comparer>
@@ -47,24 +42,6 @@ internal sealed record RecipientInfo(
                 x.FilenameHint == y.FilenameHint &&
                 x.TypeName == y.TypeName &&
                 x.MessageTypes.SequenceEqual(y.MessageTypes);
-        }
-    }
-
-    /// <summary>
-    /// An <see cref="IEqualityComparer{T}"/> implementation only matching by <see cref="FilenameHint"/>.
-    /// </summary>
-    private sealed class FilenameHintComparer : IEqualityComparer<RecipientInfo>
-    {
-        /// <inheritdoc/>
-        public bool Equals(RecipientInfo x, RecipientInfo y)
-        {
-            return x.FilenameHint == y.FilenameHint;
-        }
-
-        /// <inheritdoc/>
-        public int GetHashCode(RecipientInfo obj)
-        {
-            return obj.FilenameHint.GetHashCode();
         }
     }
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Messaging/Models/RecipientInfo.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Messaging/Models/RecipientInfo.cs
@@ -23,6 +23,11 @@ internal sealed record RecipientInfo(
     ImmutableArray<string> MessageTypes)
 {
     /// <summary>
+    /// Gets an <see cref="IEqualityComparer{T}"/> implementation only matching by <see cref="FilenameHint"/>.
+    /// </summary>
+    public static IEqualityComparer<RecipientInfo> EqualityComparerByFilenameHint { get; } = new FilenameHintComparer();
+
+    /// <summary>
     /// An <see cref="IEqualityComparer{T}"/> implementation for <see cref="RecipientInfo"/>.
     /// </summary>
     public sealed class Comparer : Comparer<RecipientInfo, Comparer>
@@ -42,6 +47,24 @@ internal sealed record RecipientInfo(
                 x.FilenameHint == y.FilenameHint &&
                 x.TypeName == y.TypeName &&
                 x.MessageTypes.SequenceEqual(y.MessageTypes);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IEqualityComparer{T}"/> implementation only matching by <see cref="FilenameHint"/>.
+    /// </summary>
+    private sealed class FilenameHintComparer : IEqualityComparer<RecipientInfo>
+    {
+        /// <inheritdoc/>
+        public bool Equals(RecipientInfo x, RecipientInfo y)
+        {
+            return x.FilenameHint == y.FilenameHint;
+        }
+
+        /// <inheritdoc/>
+        public int GetHashCode(RecipientInfo obj)
+        {
+            return obj.FilenameHint.GetHashCode();
         }
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_IRecipientGenerator.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_IRecipientGenerator.cs
@@ -16,11 +16,11 @@ public partial class Test_IRecipientGenerator
     [TestMethod]
     public void Test_IRecipientGenerator_GeneratedRegistration()
     {
-        StrongReferenceMessenger? messenger = new();
-        RecipientWithSomeMessages? recipient = new();
+        StrongReferenceMessenger messenger = new();
+        RecipientWithSomeMessages recipient = new();
 
-        MessageA? messageA = new();
-        MessageB? messageB = new();
+        MessageA messageA = new();
+        MessageB messageB = new();
 
         Action<IMessenger, object, int> registrator = Messaging.__Internals.__IMessengerExtensions.CreateAllMessagesRegistratorWithToken<int>(recipient);
 
@@ -41,6 +41,15 @@ public partial class Test_IRecipientGenerator
 
         Assert.AreSame(recipient.A, messageA);
         Assert.AreSame(recipient.B, messageB);
+    }
+
+    [TestMethod]
+    public void Test_IRecipientGenerator_TypeWithMultipleClassDeclarations()
+    {
+        RecipientWithMultipleClassDeclarations recipient = new();
+
+        // This test really just needs to verify this compiles and executes normally
+        _ = Messaging.__Internals.__IMessengerExtensions.CreateAllMessagesRegistratorWithToken<int>(recipient);
     }
 
     public sealed class RecipientWithSomeMessages :
@@ -67,6 +76,19 @@ public partial class Test_IRecipientGenerator
     }
 
     public sealed class MessageB
+    {
+    }
+
+    public sealed partial class RecipientWithMultipleClassDeclarations : IRecipient<MessageA>
+    {
+        public void Receive(MessageA message)
+        {
+        }
+    }
+
+    // This empty partial type declarations needs to be present to ensure the generator
+    // correctly handles cases where the source type has multiple class declarations.
+    partial class RecipientWithMultipleClassDeclarations
     {
     }
 }


### PR DESCRIPTION
This PR fixes a build failure if a recipient type had multiple partial definitions, such as:

```csharp
public partial class MyRecipient : IRecipient<MyMessage>
{
    public void Receive(MessageA message)
    {
    }
}

partial class MyRecipient
{
}
```