### PR TITLE
Fix async command event notifications

### DIFF
--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -292,8 +292,6 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
 
                 CancellationTokenSource cancellationTokenSource = this.cancellationTokenSource = new();
 
-                PropertyChanged?.Invoke(this, IsCancellationRequestedChangedEventArgs);
-
                 // Invoke the cancelable command delegate with a new linked token
                 executionTask = ExecutionTask = this.cancelableExecute!(cancellationTokenSource.Token);
             }

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -207,9 +207,18 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
 
             PropertyChanged?.Invoke(this, ExecutionTaskChangedEventArgs);
             PropertyChanged?.Invoke(this, IsRunningChangedEventArgs);
-            PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
 
-            if (value?.IsCompleted ?? true)
+            bool isAlreadyCompletedOrNull = value?.IsCompleted ?? true;
+
+            if (this.cancellationTokenSource is not null)
+            {
+                PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
+                PropertyChanged?.Invoke(this, IsCancellationRequestedChangedEventArgs);
+            }
+
+            // The branch is on a condition evaluated before raising the events above if
+            // needed, to avoid race conditions with a task completing right after them.
+            if (isAlreadyCompletedOrNull)
             {
                 return;
             }
@@ -222,7 +231,11 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
                 {
                     @this.PropertyChanged?.Invoke(@this, ExecutionTaskChangedEventArgs);
                     @this.PropertyChanged?.Invoke(@this, IsRunningChangedEventArgs);
-                    @this.PropertyChanged?.Invoke(@this, CanBeCanceledChangedEventArgs);
+
+                    if (@this.cancellationTokenSource is not null)
+                    {
+                        @this.PropertyChanged?.Invoke(@this, CanBeCanceledChangedEventArgs);
+                    }
                 }
             }
 
@@ -231,13 +244,13 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
     }
 
     /// <inheritdoc/>
-    public bool CanBeCanceled => this.cancelableExecute is not null && IsRunning;
+    public bool CanBeCanceled => IsRunning && this.cancellationTokenSource is { IsCancellationRequested: false };
 
     /// <inheritdoc/>
-    public bool IsCancellationRequested => this.cancellationTokenSource?.IsCancellationRequested == true;
+    public bool IsCancellationRequested => this.cancellationTokenSource is { IsCancellationRequested: true };
 
     /// <inheritdoc/>
-    public bool IsRunning => ExecutionTask?.IsCompleted == false;
+    public bool IsRunning => ExecutionTask is { IsCompleted: false };
 
     /// <inheritdoc/>
     public void NotifyCanExecuteChanged()
@@ -251,7 +264,7 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
     {
         bool canExecute = this.canExecute?.Invoke() != false;
 
-        return canExecute && (this.allowConcurrentExecutions || ExecutionTask?.IsCompleted != false);
+        return canExecute && (this.allowConcurrentExecutions || ExecutionTask is not { IsCompleted: false });
     }
 
     /// <inheritdoc/>
@@ -300,9 +313,12 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
     /// <inheritdoc/>
     public void Cancel()
     {
-        this.cancellationTokenSource?.Cancel();
+        if (this.cancellationTokenSource is CancellationTokenSource { IsCancellationRequested: false } cancellationTokenSource)
+        {
+            cancellationTokenSource.Cancel();
 
-        PropertyChanged?.Invoke(this, IsCancellationRequestedChangedEventArgs);
-        PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
+            PropertyChanged?.Invoke(this, CanBeCanceledChangedEventArgs);
+            PropertyChanged?.Invoke(this, IsCancellationRequestedChangedEventArgs);
+        }
     }
 }

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -295,8 +295,6 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
 
                 CancellationTokenSource cancellationTokenSource = this.cancellationTokenSource = new();
 
-                PropertyChanged?.Invoke(this, AsyncRelayCommand.IsCancellationRequestedChangedEventArgs);
-
                 // Invoke the cancelable command delegate with a new linked token
                 executionTask = ExecutionTask = this.cancelableExecute!(parameter, cancellationTokenSource.Token);
             }

--- a/CommunityToolkit.Mvvm/Input/Interfaces/IAsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/Interfaces/IAsyncRelayCommand.cs
@@ -19,8 +19,32 @@ public interface IAsyncRelayCommand : IRelayCommand, INotifyPropertyChanged
     Task? ExecutionTask { get; }
 
     /// <summary>
-    /// Gets a value indicating whether running operations for this command can be canceled.
+    /// Gets a value indicating whether a running operation for this command can currently be canceled.
     /// </summary>
+    /// <remarks>
+    /// The exact sequence of events that types implementing this interface should raise is as follows:
+    /// <list type="bullet">
+    /// <item>
+    /// The command is initially not running: <see cref="IsRunning"/>, <see cref="CanBeCanceled"/>
+    /// and <see cref="IsCancellationRequested"/> are <see langword="false"/>.
+    /// </item>
+    /// <item>
+    /// The command starts running: <see cref="IsRunning"/> and <see cref="CanBeCanceled"/> switch to
+    /// <see langword="true"/>. <see cref="IsCancellationRequested"/> is set to <see langword="false"/>.
+    /// </item>
+    /// <item>
+    /// If the operation is canceled: <see cref="CanBeCanceled"/> switches to <see langword="false"/>
+    /// and <see cref="IsCancellationRequested"/> switches to <see langword="true"/>.
+    /// </item>
+    /// <item>
+    /// The operation completes: <see cref="IsRunning"/> and <see cref="CanBeCanceled"/> switch
+    /// to <see langword="false"/>. The state of <see cref="IsCancellationRequested"/> is undefined.
+    /// </item>
+    /// </list>
+    /// This only applies if the underlying logic for the command actually supports cancelation. If that is
+    /// not the case, then <see cref="CanBeCanceled"/> and <see cref="IsCancellationRequested"/> will always remain
+    /// <see langword="false"/> regardless of the current state of the command.
+    /// </remarks>
     bool CanBeCanceled { get; }
 
     /// <summary>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -151,18 +151,18 @@ public class Test_AsyncRelayCommand
 
         // Validate the various event args for all the properties that were updated when executing the command
         Assert.AreEqual(args.Count, 4);
-        Assert.AreEqual(args[0].PropertyName, nameof(IAsyncRelayCommand.IsCancellationRequested));
-        Assert.AreEqual(args[1].PropertyName, nameof(IAsyncRelayCommand.ExecutionTask));
-        Assert.AreEqual(args[2].PropertyName, nameof(IAsyncRelayCommand.IsRunning));
-        Assert.AreEqual(args[3].PropertyName, nameof(IAsyncRelayCommand.CanBeCanceled));
+        Assert.AreEqual(args[0].PropertyName, nameof(IAsyncRelayCommand.ExecutionTask));
+        Assert.AreEqual(args[1].PropertyName, nameof(IAsyncRelayCommand.IsRunning));
+        Assert.AreEqual(args[2].PropertyName, nameof(IAsyncRelayCommand.CanBeCanceled));
+        Assert.AreEqual(args[3].PropertyName, nameof(IAsyncRelayCommand.IsCancellationRequested));
 
         command.Cancel();
 
         // Verify that these two properties raised notifications correctly when canceling the command too.
         // We need to ensure all command properties support notifications so that users can bind to them.
         Assert.AreEqual(args.Count, 6);
-        Assert.AreEqual(args[4].PropertyName, nameof(IAsyncRelayCommand.IsCancellationRequested));
-        Assert.AreEqual(args[5].PropertyName, nameof(IAsyncRelayCommand.CanBeCanceled));
+        Assert.AreEqual(args[4].PropertyName, nameof(IAsyncRelayCommand.CanBeCanceled));
+        Assert.AreEqual(args[5].PropertyName, nameof(IAsyncRelayCommand.IsCancellationRequested));
 
         Assert.IsTrue(command.IsCancellationRequested);
 


### PR DESCRIPTION
This PR includes a few tweaks to async commands:

- Fixed documentation for `IAsyncRelayCommand.CanBeCanceled`.
- `IAsyncRelayCommand.Cancel()` now only raises events if it actually cancels an operation.
- Fix `IAsyncRelayCommand.CanBeCanceled` remaining `false` after canceling.