### PR TITLE
Add <inheritdoc/> to generated observable properties

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -258,6 +258,7 @@ partial class ObservablePropertyGenerator
 
             // Construct the generated property as follows:
             //
+            // /// <inheritdoc cref="<FIELD_NAME>"/>
             // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
             // [global::System.Diagnostics.DebuggerNonUserCode]
             // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
@@ -277,7 +278,8 @@ partial class ObservablePropertyGenerator
                         Attribute(IdentifierName("global::System.CodeDom.Compiler.GeneratedCode"))
                         .AddArgumentListArguments(
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservablePropertyGenerator).FullName))),
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservablePropertyGenerator).Assembly.GetName().Version.ToString())))))),
+                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservablePropertyGenerator).Assembly.GetName().Version.ToString()))))))
+                    .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{propertyInfo.FieldName}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())),
                     AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.DebuggerNonUserCode")))),
                     AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage")))))
                 .AddAttributeLists(validationAttributes.ToArray())

--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
@@ -119,7 +119,7 @@ partial class ICommandGenerator
 
             // Construct the generated field as follows:
             //
-            // <summary>The backing field for <see cref="<COMMAND_PROPERTY_NAME>"/></summary>
+            // /// <summary>The backing field for <see cref="<COMMAND_PROPERTY_NAME>"/></summary>
             // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
             // private <COMMAND_TYPE>? <COMMAND_FIELD_NAME>;
             FieldDeclarationSyntax fieldDeclaration =
@@ -191,7 +191,7 @@ partial class ICommandGenerator
 
             // Construct the generated property as follows (the explicit delegate cast is needed to avoid overload resolution conflicts):
             //
-            // <summary>Gets an <see cref="<COMMAND_INTERFACE_TYPE>" instance wrapping <see cref="<METHOD_NAME>"/> and <see cref="<OPTIONAL_CAN_EXECUTE>"/>.</summary>
+            // /// <summary>Gets an <see cref="<COMMAND_INTERFACE_TYPE>" instance wrapping <see cref="<METHOD_NAME>"/> and <see cref="<OPTIONAL_CAN_EXECUTE>"/>.</summary>
             // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
             // [global::System.Diagnostics.DebuggerNonUserCode]
             // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]


### PR DESCRIPTION
This PR adds `<inheritdoc cref="<FIELD_NAME>"/>` to generated properties.
This allows users to annotate fields and then have IntelliSense display that into on the observable properties.