### PR TITLE
Switch async commands to default to no concurrent execution

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
@@ -183,10 +183,10 @@ partial class ICommandGenerator
                 commandCreationArguments.Add(Argument(canExecuteExpression));
             }
 
-            // Disable concurrent executions, if requested
-            if (!commandInfo.AllowConcurrentExecutions)
+            // Enable concurrent executions, if requested
+            if (commandInfo.AllowConcurrentExecutions)
             {
-                commandCreationArguments.Add(Argument(LiteralExpression(SyntaxKind.FalseLiteralExpression)));
+                commandCreationArguments.Add(Argument(LiteralExpression(SyntaxKind.TrueLiteralExpression)));
             }
 
             // Construct the generated property as follows (the explicit delegate cast is needed to avoid overload resolution conflicts):
@@ -366,7 +366,7 @@ partial class ICommandGenerator
         /// <param name="attributeData">The <see cref="AttributeData"/> instance the method was annotated with.</param>
         /// <param name="commandClassType">The command class type name.</param>
         /// <param name="diagnostics">The current collection of gathered diagnostics.</param>
-        /// <param name="allowConcurrentExecutions">Whether or not concurrent executions have been disabled.</param>
+        /// <param name="allowConcurrentExecutions">Whether or not concurrent executions have been enabled.</param>
         /// <returns>Whether or not a value for <paramref name="allowConcurrentExecutions"/> could be retrieved successfully.</returns>
         private static bool TryGetAllowConcurrentExecutionsSwitch(
             IMethodSymbol methodSymbol,
@@ -375,11 +375,10 @@ partial class ICommandGenerator
             ImmutableArray<Diagnostic>.Builder diagnostics,
             out bool allowConcurrentExecutions)
         {
-            // Try to get the custom switch for concurrent executions. If the switch is not present, the
-            // default value is set to true, to avoid breaking backwards compatibility with the first release.
+            // Try to get the custom switch for concurrent executions (the default is false)
             if (!attributeData.TryGetNamedArgument("AllowConcurrentExecutions", out allowConcurrentExecutions))
             {
-                allowConcurrentExecutions = true;
+                allowConcurrentExecutions = false;
 
                 return true;
             }

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -72,7 +72,7 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
     public event EventHandler? CanExecuteChanged;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class that can always execute.
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class.
     /// </summary>
     /// <param name="execute">The execution logic.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> is <see langword="null"/>.</exception>
@@ -84,7 +84,7 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class that can always execute.
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class.
     /// </summary>
     /// <param name="execute">The execution logic.</param>
     /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
@@ -98,7 +98,7 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class that can always execute.
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class.
     /// </summary>
     /// <param name="cancelableExecute">The cancelable execution logic.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="cancelableExecute"/> is <see langword="null"/>.</exception>
@@ -110,7 +110,7 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class that can always execute.
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class.
     /// </summary>
     /// <param name="cancelableExecute">The cancelable execution logic.</param>
     /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -81,7 +81,6 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
         ArgumentNullException.ThrowIfNull(execute);
 
         this.execute = execute;
-        this.allowConcurrentExecutions = true;
     }
 
     /// <summary>
@@ -108,7 +107,6 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
         ArgumentNullException.ThrowIfNull(cancelableExecute);
 
         this.cancelableExecute = cancelableExecute;
-        this.allowConcurrentExecutions = true;
     }
 
     /// <summary>
@@ -138,7 +136,6 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
 
         this.execute = execute;
         this.canExecute = canExecute;
-        this.allowConcurrentExecutions = true;
     }
 
     /// <summary>
@@ -171,7 +168,6 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand
 
         this.cancelableExecute = cancelableExecute;
         this.canExecute = canExecute;
-        this.allowConcurrentExecutions = true;
     }
 
     /// <summary>

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -48,7 +48,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
     public event EventHandler? CanExecuteChanged;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class that can always execute.
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
     /// </summary>
     /// <param name="execute">The execution logic.</param>
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
@@ -61,7 +61,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class that can always execute.
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
     /// </summary>
     /// <param name="execute">The execution logic.</param>
     /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
@@ -76,7 +76,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class that can always execute.
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
     /// </summary>
     /// <param name="cancelableExecute">The cancelable execution logic.</param>
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
@@ -89,7 +89,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class that can always execute.
+    /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
     /// </summary>
     /// <param name="cancelableExecute">The cancelable execution logic.</param>
     /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -58,7 +58,6 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
         ArgumentNullException.ThrowIfNull(execute);
 
         this.execute = execute;
-        this.allowConcurrentExecutions = true;
     }
 
     /// <summary>
@@ -87,7 +86,6 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
         ArgumentNullException.ThrowIfNull(cancelableExecute);
 
         this.cancelableExecute = cancelableExecute;
-        this.allowConcurrentExecutions = true;
     }
 
     /// <summary>
@@ -119,7 +117,6 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
 
         this.execute = execute;
         this.canExecute = canExecute;
-        this.allowConcurrentExecutions = true;
     }
 
     /// <summary>
@@ -154,7 +151,6 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>
 
         this.cancelableExecute = cancelableExecute;
         this.canExecute = canExecute;
-        this.allowConcurrentExecutions = true;
     }
 
     /// <summary>

--- a/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
+++ b/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
@@ -78,5 +78,5 @@ public sealed class ICommandAttribute : Attribute
     /// when an execution is invoked while a previous one is still running. It is the same as creating an instance of
     /// these command types with a constructor such as <see cref="AsyncRelayCommand(Func{System.Threading.Tasks.Task}, bool)"/>.
     /// </summary>
-    public bool AllowConcurrentExecutions { get; init; } = true;
+    public bool AllowConcurrentExecutions { get; init; }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -134,11 +134,26 @@ public class Test_AsyncRelayCommandOfT
     }
 
     [TestMethod]
-    public async Task Test_AsyncRelayCommandOfT_WithConcurrencyControl()
+    public async Task Test_AsyncRelayCommandOfT_AllowConcurrentExecutions_Disabled()
+    {
+        await Test_AsyncRelayCommandOfT_AllowConcurrentExecutions_TestLogic(static task => new(async _ => await task, allowConcurrentExecutions: false));
+    }
+
+    [TestMethod]
+    public async Task Test_AsyncRelayCommandOfT_AllowConcurrentExecutions_Default()
+    {
+        await Test_AsyncRelayCommandOfT_AllowConcurrentExecutions_TestLogic(static task => new(async _ => await task));
+    }
+
+    /// <summary>
+    /// Shared logic for <see cref="Test_AsyncRelayCommandOfT_AllowConcurrentExecutions_Disabled"/> and <see cref="Test_AsyncRelayCommandOfT_AllowConcurrentExecutions_Default"/>.
+    /// </summary>
+    /// <param name="factory">A factory to create the <see cref="AsyncRelayCommand{T}"/> instance to test.</param>
+    private static async Task Test_AsyncRelayCommandOfT_AllowConcurrentExecutions_TestLogic(Func<Task, AsyncRelayCommand<string>> factory)
     {
         TaskCompletionSource<object?> tcs = new();
 
-        AsyncRelayCommand<string> command = new(async s => await tcs.Task, allowConcurrentExecutions: false);
+        AsyncRelayCommand<string> command = factory(tcs.Task);
 
         Assert.IsTrue(command.CanExecute(null));
         Assert.IsTrue(command.CanExecute("1"));

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
@@ -57,6 +57,23 @@ public partial class Test_ICommandAttribute
         CollectionAssert.AreEqual(model.Values, Enumerable.Range(0, 10).ToArray());
 
         await Task.WhenAll(tasks);
+
+        tasks.Clear();
+
+        for (int i = 10; i < 20; i++)
+        {
+            tasks.Add(model.AddValueToListAndDelayWithDefaultConcurrencyCommand.ExecuteAsync(i));
+        }
+
+        Assert.AreEqual(10, tasks.Count);
+
+        // Only the first item should have been added
+        CollectionAssert.AreEqual(model.Values, Enumerable.Range(0, 11).ToArray());
+
+        for (int i = 1; i < tasks.Count; i++)
+        {
+            Assert.AreSame(Task.CompletedTask, tasks[i]);
+        }
     }
 
     [TestMethod]
@@ -366,12 +383,20 @@ public partial class Test_ICommandAttribute
             Counter += 1;
         }
 
-        [ICommand]
+        [ICommand(AllowConcurrentExecutions = true)]
         private async Task AddValueToListAndDelayAsync(int value)
         {
             Values.Add(value);
 
             await Task.Delay(100);
+        }
+
+        [ICommand]
+        private async Task AddValueToListAndDelayWithDefaultConcurrencyAsync(int value)
+        {
+            Values.Add(value);
+
+            await Task.Delay(1000);
         }
 
         #region Test region


### PR DESCRIPTION
**Closes #123**

This PR changes the default value of `allowConcurrentExecutions` for async relay commands to `false`.