### PR TITLE
Dev/cancel commands

### DIFF
--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -20,7 +20,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// action, and providing an <see cref="ExecutionTask"/> property that notifies changes when
 /// <see cref="ExecuteAsync"/> is invoked and when the returned <see cref="Task"/> completes.
 /// </summary>
-public sealed class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCommand
+public sealed class AsyncRelayCommand : CommandBase, IAsyncRelayCommand, ICancellationAwareCommand
 {
     /// <summary>
     /// The cached <see cref="PropertyChangedEventArgs"/> for <see cref="ExecutionTask"/>.
@@ -71,9 +71,6 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCo
 
     /// <inheritdoc/>
     public event PropertyChangedEventHandler? PropertyChanged;
-
-    /// <inheritdoc/>
-    public event EventHandler? CanExecuteChanged;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class.
@@ -257,14 +254,8 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCo
     bool ICancellationAwareCommand.IsCancellationSupported => this.execute is null;
 
     /// <inheritdoc/>
-    public void NotifyCanExecuteChanged()
-    {
-        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool CanExecute(object? parameter)
+    public override bool CanExecute(object? parameter)
     {
         bool canExecute = this.canExecute?.Invoke() != false;
 
@@ -272,7 +263,7 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCo
     }
 
     /// <inheritdoc/>
-    public void Execute(object? parameter)
+    public override void Execute(object? parameter)
     {
         _ = ExecuteAsync(parameter);
     }
@@ -303,7 +294,7 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCo
             // If concurrent executions are disabled, notify the can execute change as well
             if (!this.allowConcurrentExecutions)
             {
-                CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+                ((IRelayCommand)this).NotifyCanExecuteChanged();
             }
 
             return executionTask;

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -91,10 +91,8 @@ public sealed class AsyncRelayCommand : CommandBase, IAsyncRelayCommand, ICancel
     /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> is <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<Task> execute, bool allowConcurrentExecutions)
+        : this(execute)
     {
-        ArgumentNullException.ThrowIfNull(execute);
-
-        this.execute = execute;
         this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
@@ -117,10 +115,8 @@ public sealed class AsyncRelayCommand : CommandBase, IAsyncRelayCommand, ICancel
     /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="cancelableExecute"/> is <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<CancellationToken, Task> cancelableExecute, bool allowConcurrentExecutions)
+        : this(cancelableExecute)
     {
-        ArgumentNullException.ThrowIfNull(cancelableExecute);
-
-        this.cancelableExecute = cancelableExecute;
         this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
@@ -131,11 +127,10 @@ public sealed class AsyncRelayCommand : CommandBase, IAsyncRelayCommand, ICancel
     /// <param name="canExecute">The execution status logic.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<Task> execute, Func<bool> canExecute)
+        : this(execute)
     {
-        ArgumentNullException.ThrowIfNull(execute);
         ArgumentNullException.ThrowIfNull(canExecute);
 
-        this.execute = execute;
         this.canExecute = canExecute;
     }
 
@@ -147,12 +142,8 @@ public sealed class AsyncRelayCommand : CommandBase, IAsyncRelayCommand, ICancel
     /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<Task> execute, Func<bool> canExecute, bool allowConcurrentExecutions)
+        : this(execute, canExecute)
     {
-        ArgumentNullException.ThrowIfNull(execute);
-        ArgumentNullException.ThrowIfNull(canExecute);
-
-        this.execute = execute;
-        this.canExecute = canExecute;
         this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
@@ -163,11 +154,10 @@ public sealed class AsyncRelayCommand : CommandBase, IAsyncRelayCommand, ICancel
     /// <param name="canExecute">The execution status logic.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="cancelableExecute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<CancellationToken, Task> cancelableExecute, Func<bool> canExecute)
+        : this(cancelableExecute)
     {
-        ArgumentNullException.ThrowIfNull(cancelableExecute);
         ArgumentNullException.ThrowIfNull(canExecute);
 
-        this.cancelableExecute = cancelableExecute;
         this.canExecute = canExecute;
     }
 
@@ -179,12 +169,8 @@ public sealed class AsyncRelayCommand : CommandBase, IAsyncRelayCommand, ICancel
     /// <param name="allowConcurrentExecutions">Whether or not to allow concurrent executions of the command.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="cancelableExecute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<CancellationToken, Task> cancelableExecute, Func<bool> canExecute, bool allowConcurrentExecutions)
+        : this(cancelableExecute, canExecute)
     {
-        ArgumentNullException.ThrowIfNull(cancelableExecute);
-        ArgumentNullException.ThrowIfNull(canExecute);
-
-        this.cancelableExecute = cancelableExecute;
-        this.canExecute = canExecute;
         this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -271,7 +271,7 @@ public sealed class AsyncRelayCommand : CommandBase, IAsyncRelayCommand, ICancel
                 // Cancel the previous operation, if one is pending
                 this.cancellationTokenSource?.Cancel();
 
-                CancellationTokenSource cancellationTokenSource = this.cancellationTokenSource = new();
+                this.cancellationTokenSource = new();
 
                 // Invoke the cancelable command delegate with a new linked token
                 executionTask = ExecutionTask = this.cancelableExecute!(cancellationTokenSource.Token);

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -69,10 +69,8 @@ public sealed class AsyncRelayCommand<T> : CommandBase, IAsyncRelayCommand<T>, I
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> is <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<T?, Task> execute, bool allowConcurrentExecutions)
+        : this(execute)
     {
-        ArgumentNullException.ThrowIfNull(execute);
-
-        this.execute = execute;
         this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
@@ -97,10 +95,8 @@ public sealed class AsyncRelayCommand<T> : CommandBase, IAsyncRelayCommand<T>, I
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="cancelableExecute"/> is <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<T?, CancellationToken, Task> cancelableExecute, bool allowConcurrentExecutions)
+        : this(cancelableExecute)
     {
-        ArgumentNullException.ThrowIfNull(cancelableExecute);
-
-        this.cancelableExecute = cancelableExecute;
         this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
@@ -112,11 +108,10 @@ public sealed class AsyncRelayCommand<T> : CommandBase, IAsyncRelayCommand<T>, I
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<T?, Task> execute, Predicate<T?> canExecute)
+        : this(execute)
     {
-        ArgumentNullException.ThrowIfNull(execute);
         ArgumentNullException.ThrowIfNull(canExecute);
 
-        this.execute = execute;
         this.canExecute = canExecute;
     }
 
@@ -129,12 +124,8 @@ public sealed class AsyncRelayCommand<T> : CommandBase, IAsyncRelayCommand<T>, I
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<T?, Task> execute, Predicate<T?> canExecute, bool allowConcurrentExecutions)
+        : this(execute, canExecute)
     {
-        ArgumentNullException.ThrowIfNull(execute);
-        ArgumentNullException.ThrowIfNull(canExecute);
-
-        this.execute = execute;
-        this.canExecute = canExecute;
         this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 
@@ -146,11 +137,10 @@ public sealed class AsyncRelayCommand<T> : CommandBase, IAsyncRelayCommand<T>, I
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="cancelableExecute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<T?, CancellationToken, Task> cancelableExecute, Predicate<T?> canExecute)
+        :this(cancelableExecute)
     {
-        ArgumentNullException.ThrowIfNull(cancelableExecute);
         ArgumentNullException.ThrowIfNull(canExecute);
 
-        this.cancelableExecute = cancelableExecute;
         this.canExecute = canExecute;
     }
 
@@ -163,12 +153,8 @@ public sealed class AsyncRelayCommand<T> : CommandBase, IAsyncRelayCommand<T>, I
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="cancelableExecute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public AsyncRelayCommand(Func<T?, CancellationToken, Task> cancelableExecute, Predicate<T?> canExecute, bool allowConcurrentExecutions)
+        : this(cancelableExecute, canExecute)
     {
-        ArgumentNullException.ThrowIfNull(cancelableExecute);
-        ArgumentNullException.ThrowIfNull(canExecute);
-
-        this.cancelableExecute = cancelableExecute;
-        this.canExecute = canExecute;
         this.allowConcurrentExecutions = allowConcurrentExecutions;
     }
 

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -18,7 +18,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// A generic command that provides a more specific version of <see cref="AsyncRelayCommand"/>.
 /// </summary>
 /// <typeparam name="T">The type of parameter being passed as input to the callbacks.</typeparam>
-public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationAwareCommand
+public sealed class AsyncRelayCommand<T> : CommandBase, IAsyncRelayCommand<T>, ICancellationAwareCommand
 {
     /// <summary>
     /// The <see cref="Func{TResult}"/> to invoke when <see cref="Execute(T)"/> is used.
@@ -47,9 +47,6 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
 
     /// <inheritdoc/>
     public event PropertyChangedEventHandler? PropertyChanged;
-
-    /// <inheritdoc/>
-    public event EventHandler? CanExecuteChanged;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
@@ -239,12 +236,6 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
     bool ICancellationAwareCommand.IsCancellationSupported => this.execute is null;
 
     /// <inheritdoc/>
-    public void NotifyCanExecuteChanged()
-    {
-        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool CanExecute(T? parameter)
     {
@@ -255,7 +246,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool CanExecute(object? parameter)
+    public override bool CanExecute(object? parameter)
     {
         if (default(T) is not null &&
             parameter is null)
@@ -274,7 +265,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
     }
 
     /// <inheritdoc/>
-    public void Execute(object? parameter)
+    public override void Execute(object? parameter)
     {
         _ = ExecuteAsync((T?)parameter);
     }
@@ -306,7 +297,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
             // If concurrent executions are disabled, notify the can execute change as well
             if (!this.allowConcurrentExecutions)
             {
-                CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+                ((IRelayCommand)this).NotifyCanExecuteChanged();
             }
 
             return executionTask;

--- a/CommunityToolkit.Mvvm/Input/Internals/CancelCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/Internals/CancelCommand.cs
@@ -11,7 +11,7 @@ namespace CommunityToolkit.Mvvm.Input.Internals;
 /// <summary>
 /// A <see cref="ICommand"/> implementation wrapping <see cref="IAsyncRelayCommand"/> to support cancellation.
 /// </summary>
-internal sealed class CancelCommand : ICommand
+internal sealed class CancelCommand : CommandBase, ICommand
 {
     /// <summary>
     /// The wrapped <see cref="IAsyncRelayCommand"/> instance.
@@ -30,16 +30,13 @@ internal sealed class CancelCommand : ICommand
     }
 
     /// <inheritdoc/>
-    public event EventHandler? CanExecuteChanged;
-
-    /// <inheritdoc/>
-    public bool CanExecute(object? parameter)
+    public override bool CanExecute(object? parameter)
     {
         return this.command.CanBeCanceled;
     }
 
     /// <inheritdoc/>
-    public void Execute(object? parameter)
+    public override void Execute(object? parameter)
     {
         this.command.Cancel();
     }
@@ -49,7 +46,7 @@ internal sealed class CancelCommand : ICommand
     {
         if (e.PropertyName is null or nameof(IAsyncRelayCommand.CanBeCanceled))
         {
-            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+            ((IRelayCommand)this).NotifyCanExecuteChanged();
         }
     }
 }

--- a/CommunityToolkit.Mvvm/Input/Internals/CommandBase.cs
+++ b/CommunityToolkit.Mvvm/Input/Internals/CommandBase.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+namespace CommunityToolkit.Mvvm.Input.Internals;
+
+public abstract class CommandBase : IRelayCommand
+{
+    /// <inheritdoc/>
+    private event EventHandler? canExecuteChanged;
+
+    /// <summary>
+    /// It's "virtual" for cases when extended event handling is needed.
+    /// For example at WPF, to punt the implementation off to the CommandManager class:
+    /// <see  add { CommandManager.RequerySuggested += value; }/>
+    /// <see  remove { CommandManager.RequerySuggested -= value; }/>
+    /// </summary>
+    public virtual event EventHandler? CanExecuteChanged
+    {
+        add { canExecuteChanged += value; }
+        remove { canExecuteChanged -= value; }
+    }
+
+    /// <inheritdoc/>
+    void IRelayCommand.NotifyCanExecuteChanged()
+    {
+        canExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <inheritdoc/>
+    public abstract bool CanExecute(object? parameter);
+
+    /// <inheritdoc/>
+    public abstract void Execute(object? parameter);
+}

--- a/CommunityToolkit.Mvvm/Input/Internals/DisabledCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/Internals/DisabledCommand.cs
@@ -10,10 +10,10 @@ namespace CommunityToolkit.Mvvm.Input.Internals;
 /// <summary>
 /// A reusable <see cref="ICommand"/> instance that is always disabled.
 /// </summary>
-internal sealed class DisabledCommand : ICommand
+internal sealed class DisabledCommand : CommandBase
 {
     /// <inheritdoc/>
-    public event EventHandler? CanExecuteChanged
+    public override event EventHandler? CanExecuteChanged
     {
         add { }
         remove { }
@@ -31,13 +31,13 @@ internal sealed class DisabledCommand : ICommand
     public static DisabledCommand Instance { get; } = new();
 
     /// <inheritdoc/>
-    public bool CanExecute(object? parameter)
+    public override bool CanExecute(object? parameter)
     {
         return false;
     }
 
     /// <inheritdoc/>
-    public void Execute(object? parameter)
+    public override void Execute(object? parameter)
     {
     }
 }

--- a/CommunityToolkit.Mvvm/Input/RelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/RelayCommand.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using CommunityToolkit.Mvvm.Input.Internals;
 
 namespace CommunityToolkit.Mvvm.Input;
 
@@ -16,7 +17,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// method is <see langword="true"/>. This type does not allow you to accept command parameters
 /// in the <see cref="Execute"/> and <see cref="CanExecute"/> callback methods.
 /// </summary>
-public sealed class RelayCommand : IRelayCommand
+public sealed class RelayCommand : CommandBase, IRelayCommand
 {
     /// <summary>
     /// The <see cref="Action"/> to invoke when <see cref="Execute"/> is used.
@@ -27,9 +28,6 @@ public sealed class RelayCommand : IRelayCommand
     /// The optional action to invoke when <see cref="CanExecute"/> is used.
     /// </summary>
     private readonly Func<bool>? canExecute;
-
-    /// <inheritdoc/>
-    public event EventHandler? CanExecuteChanged;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RelayCommand"/> class that can always execute.
@@ -59,20 +57,14 @@ public sealed class RelayCommand : IRelayCommand
     }
 
     /// <inheritdoc/>
-    public void NotifyCanExecuteChanged()
-    {
-        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool CanExecute(object? parameter)
+    public override bool CanExecute(object? parameter)
     {
         return this.canExecute?.Invoke() != false;
     }
 
     /// <inheritdoc/>
-    public void Execute(object? parameter)
+    public override void Execute(object? parameter)
     {
         if (CanExecute(parameter))
         {

--- a/CommunityToolkit.Mvvm/Input/RelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/RelayCommand.cs
@@ -48,11 +48,10 @@ public sealed class RelayCommand : CommandBase, IRelayCommand
     /// <param name="canExecute">The execution status logic.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public RelayCommand(Action execute, Func<bool> canExecute)
+        : this(execute)
     {
-        ArgumentNullException.ThrowIfNull(execute);
         ArgumentNullException.ThrowIfNull(canExecute);
 
-        this.execute = execute;
         this.canExecute = canExecute;
     }
 

--- a/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -55,11 +55,10 @@ public sealed class RelayCommand<T> : CommandBase, IRelayCommand<T>
     /// <remarks>See notes in <see cref="RelayCommand{T}(Action{T})"/>.</remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="execute"/> or <paramref name="canExecute"/> are <see langword="null"/>.</exception>
     public RelayCommand(Action<T?> execute, Predicate<T?> canExecute)
+        : this(execute)
     {
-        ArgumentNullException.ThrowIfNull(execute);
         ArgumentNullException.ThrowIfNull(canExecute);
 
-        this.execute = execute;
         this.canExecute = canExecute;
     }
 

--- a/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using CommunityToolkit.Mvvm.Input.Internals;
 
 namespace CommunityToolkit.Mvvm.Input;
 
@@ -17,7 +18,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// in the <see cref="Execute(T)"/> and <see cref="CanExecute(T)"/> callback methods.
 /// </summary>
 /// <typeparam name="T">The type of parameter being passed as input to the callbacks.</typeparam>
-public sealed class RelayCommand<T> : IRelayCommand<T>
+public sealed class RelayCommand<T> : CommandBase, IRelayCommand<T>
 {
     /// <summary>
     /// The <see cref="Action"/> to invoke when <see cref="Execute(T)"/> is used.
@@ -28,9 +29,6 @@ public sealed class RelayCommand<T> : IRelayCommand<T>
     /// The optional action to invoke when <see cref="CanExecute(T)"/> is used.
     /// </summary>
     private readonly Predicate<T?>? canExecute;
-
-    /// <inheritdoc/>
-    public event EventHandler? CanExecuteChanged;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RelayCommand{T}"/> class that can always execute.
@@ -66,12 +64,6 @@ public sealed class RelayCommand<T> : IRelayCommand<T>
     }
 
     /// <inheritdoc/>
-    public void NotifyCanExecuteChanged()
-    {
-        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool CanExecute(T? parameter)
     {
@@ -79,7 +71,7 @@ public sealed class RelayCommand<T> : IRelayCommand<T>
     }
 
     /// <inheritdoc/>
-    public bool CanExecute(object? parameter)
+    public override bool CanExecute(object? parameter)
     {
         if (default(T) is not null &&
             parameter is null)
@@ -101,7 +93,7 @@ public sealed class RelayCommand<T> : IRelayCommand<T>
     }
 
     /// <inheritdoc/>
-    public void Execute(object? parameter)
+    public override void Execute(object? parameter)
     {
         Execute((T?)parameter);
     }

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -554,6 +554,66 @@ public class Test_SourceGeneratorsDiagnostics
         VerifyGeneratedDiagnostics<ICommandGenerator>(source, "MVVMTK0012");
     }
 
+    [TestMethod]
+    public void InvalidICommandIncludeCancelCommandSettings_SynchronousMethod()
+    {
+        string source = @"
+            using CommunityToolkit.Mvvm.Input;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel
+                {
+                    [ICommand(IncludeCancelCommand = true)]
+                    private void GreetUser(User user)
+                    {
+                    }
+                }
+            }";
+
+        VerifyGeneratedDiagnostics<ICommandGenerator>(source, "MVVMTK0013");
+    }
+
+    [TestMethod]
+    public void InvalidICommandIncludeCancelCommandSettings_AsynchronousMethodWithNoCancellationToken()
+    {
+        string source = @"
+            using CommunityToolkit.Mvvm.Input;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel
+                {
+                    [ICommand(IncludeCancelCommand = true)]
+                    private async Task DoWorkAsync()
+                    {
+                    }
+                }
+            }";
+
+        VerifyGeneratedDiagnostics<ICommandGenerator>(source, "MVVMTK0013");
+    }
+
+    [TestMethod]
+    public void InvalidICommandIncludeCancelCommandSettings_AsynchronousMethodWithParameterAndNoCancellationToken()
+    {
+        string source = @"
+            using CommunityToolkit.Mvvm.Input;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel
+                {
+                    [ICommand(IncludeCancelCommand = true)]
+                    private async Task GreetUserAsync(User user)
+                    {
+                    }
+                }
+            }";
+
+        VerifyGeneratedDiagnostics<ICommandGenerator>(source, "MVVMTK0013");
+    }
+
     /// <summary>
     /// Verifies the output of a source generator.
     /// </summary>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.UnitTests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -359,5 +360,69 @@ public class Test_AsyncRelayCommandOfT
         Assert.IsFalse(command.CanExecute(""));
 
         tcs.SetResult(null);
+    }
+
+    [TestMethod]
+    public void Test_AsyncRelayCommandOfT_GetCancelCommand_DisabledCommand()
+    {
+        TaskCompletionSource<object?> tcs = new();
+
+        AsyncRelayCommand<string> command = new(s => tcs.Task);
+
+        ICommand cancelCommand = command.CreateCancelCommand();
+
+        Assert.IsNotNull(cancelCommand);
+        Assert.IsFalse(cancelCommand.CanExecute(null));
+
+        // No-op
+        cancelCommand.Execute(null);
+
+        Assert.AreEqual("CommunityToolkit.Mvvm.Input.Internals.DisabledCommand", cancelCommand.GetType().ToString());
+
+        ICommand cancelCommand2 = command.CreateCancelCommand();
+
+        Assert.IsNotNull(cancelCommand2);
+        Assert.IsFalse(cancelCommand2.CanExecute(null));
+
+        Assert.AreSame(cancelCommand, cancelCommand2);
+    }
+
+    [TestMethod]
+    public void Test_AsyncRelayCommandOfT_GetCancelCommand_WithToken()
+    {
+        TaskCompletionSource<object?> tcs = new();
+
+        AsyncRelayCommand<string> command = new((s, token) => tcs.Task);
+
+        ICommand cancelCommand = command.CreateCancelCommand();
+
+        Assert.IsNotNull(cancelCommand);
+        Assert.IsFalse(cancelCommand.CanExecute(null));
+
+        // No-op
+        cancelCommand.Execute(null);
+
+        Assert.AreEqual("CommunityToolkit.Mvvm.Input.Internals.CancelCommand", cancelCommand.GetType().ToString());
+
+        List<(object? Sender, EventArgs Args)> cancelCommandCanExecuteChangedArgs = new();
+
+        cancelCommand.CanExecuteChanged += (s, e) => cancelCommandCanExecuteChangedArgs.Add((s, e));
+
+        command.Execute(null);
+
+        Assert.AreEqual(1, cancelCommandCanExecuteChangedArgs.Count);
+        Assert.AreSame(cancelCommand, cancelCommandCanExecuteChangedArgs[0].Sender);
+        Assert.AreSame(EventArgs.Empty, cancelCommandCanExecuteChangedArgs[0].Args);
+
+        Assert.IsTrue(cancelCommand.CanExecute(null));
+
+        cancelCommand.Execute(null);
+
+        Assert.IsFalse(cancelCommand.CanExecute(null));
+        Assert.AreEqual(2, cancelCommandCanExecuteChangedArgs.Count);
+        Assert.AreSame(cancelCommand, cancelCommandCanExecuteChangedArgs[1].Sender);
+        Assert.AreSame(EventArgs.Empty, cancelCommandCanExecuteChangedArgs[1].Args);
+        Assert.IsFalse(command.CanBeCanceled);
+        Assert.IsTrue(command.IsCancellationRequested);
     }
 }


### PR DESCRIPTION
This PR removes redundant code elements from *RelayCommand classes.
The PR is towards the "Dev/cancel commands" branch, because these classes there touched at last, although the redundant elements are older.

@Sergio0694 thank you for taking a look at the CancelCommand topic.