### PR TITLE
Remove CanExecute checks from Execute logic

### DIFF
--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -280,36 +280,31 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCo
     /// <inheritdoc/>
     public Task ExecuteAsync(object? parameter)
     {
-        if (CanExecute(parameter))
+        Task executionTask;
+
+        if (this.execute is not null)
         {
-            Task executionTask;
+            // Non cancelable command delegate
+            executionTask = ExecutionTask = this.execute();
+        }
+        else
+        {
+            // Cancel the previous operation, if one is pending
+            this.cancellationTokenSource?.Cancel();
 
-            if (this.execute is not null)
-            {
-                // Non cancelable command delegate
-                executionTask = ExecutionTask = this.execute();
-            }
-            else
-            {
-                // Cancel the previous operation, if one is pending
-                this.cancellationTokenSource?.Cancel();
+            CancellationTokenSource cancellationTokenSource = this.cancellationTokenSource = new();
 
-                CancellationTokenSource cancellationTokenSource = this.cancellationTokenSource = new();
-
-                // Invoke the cancelable command delegate with a new linked token
-                executionTask = ExecutionTask = this.cancelableExecute!(cancellationTokenSource.Token);
-            }
-
-            // If concurrent executions are disabled, notify the can execute change as well
-            if (!this.allowConcurrentExecutions)
-            {
-                CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-            }
-
-            return executionTask;
+            // Invoke the cancelable command delegate with a new linked token
+            executionTask = ExecutionTask = this.cancelableExecute!(cancellationTokenSource.Token);
         }
 
-        return Task.CompletedTask;
+        // If concurrent executions are disabled, notify the can execute change as well
+        if (!this.allowConcurrentExecutions)
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        return executionTask;
     }
 
     /// <inheritdoc/>

--- a/CommunityToolkit.Mvvm/Input/RelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/RelayCommand.cs
@@ -74,9 +74,6 @@ public sealed class RelayCommand : IRelayCommand
     /// <inheritdoc/>
     public void Execute(object? parameter)
     {
-        if (CanExecute(parameter))
-        {
-            this.execute();
-        }
+        this.execute();
     }
 }

--- a/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -94,10 +94,7 @@ public sealed class RelayCommand<T> : IRelayCommand<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Execute(T? parameter)
     {
-        if (CanExecute(parameter))
-        {
-            this.execute(parameter);
-        }
+        this.execute(parameter);
     }
 
     /// <inheritdoc/>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -112,11 +112,13 @@ public class Test_AsyncRelayCommand
 
         command.Execute(null);
 
-        Assert.AreEqual(ticks, 0);
+        // It is the caller's responsibility to ensure that CanExecute is true
+        // before calling Execute. This check verifies the logic is still called.
+        Assert.AreEqual(ticks, 1);
 
         command.Execute(new object());
 
-        Assert.AreEqual(ticks, 0);
+        Assert.AreEqual(ticks, 2);
     }
 
     [TestMethod]
@@ -288,11 +290,6 @@ public class Test_AsyncRelayCommand
 
         Assert.IsFalse(command.CanBeCanceled);
         Assert.IsFalse(command.IsCancellationRequested);
-
-        Task newTask = command.ExecuteAsync(null);
-
-        // Execution failed, so a completed task was returned
-        Assert.AreSame(newTask, Task.CompletedTask);
 
         tcs.SetResult(null);
 

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -105,11 +105,12 @@ public class Test_AsyncRelayCommandOfT
 
         command.Execute("2");
 
-        Assert.AreEqual(ticks, 0);
+        // Like in the RelayCommand test, ensure Execute is unconditionally invoked
+        Assert.AreEqual(ticks, 2);
 
         command.Execute("42");
 
-        Assert.AreEqual(ticks, 0);
+        Assert.AreEqual(ticks, 42);
     }
 
     [TestMethod]
@@ -230,11 +231,6 @@ public class Test_AsyncRelayCommandOfT
 
         Assert.IsFalse(command.CanBeCanceled);
         Assert.IsFalse(command.IsCancellationRequested);
-
-        Task newTask = command.ExecuteAsync(null);
-
-        // Execution failed, so a completed task was returned
-        Assert.AreSame(newTask, Task.CompletedTask);
 
         tcs.SetResult(null);
 

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
@@ -49,7 +49,10 @@ public partial class Test_ICommandAttribute
 
         for (int i = 0; i < 10; i++)
         {
-            tasks.Add(model.AddValueToListAndDelayCommand.ExecuteAsync(i));
+            if (model.AddValueToListAndDelayCommand.CanExecute(i))
+            {
+                tasks.Add(model.AddValueToListAndDelayCommand.ExecuteAsync(i));
+            }
         }
 
         // All values should already be in the list, as commands are executed
@@ -63,10 +66,17 @@ public partial class Test_ICommandAttribute
 
         for (int i = 10; i < 20; i++)
         {
-            tasks.Add(model.AddValueToListAndDelayWithDefaultConcurrencyCommand.ExecuteAsync(i));
+            if (model.AddValueToListAndDelayWithDefaultConcurrencyCommand.CanExecute(i))
+            {
+                tasks.Add(model.AddValueToListAndDelayWithDefaultConcurrencyCommand.ExecuteAsync(i));
+            }
         }
 
-        Assert.AreEqual(10, tasks.Count);
+        model.Tcs.SetResult(null);
+
+        await Task.WhenAll(tasks);
+
+        Assert.AreEqual(1, tasks.Count);
 
         // Only the first item should have been added
         CollectionAssert.AreEqual(model.Values, Enumerable.Range(0, 11).ToArray());
@@ -102,9 +112,12 @@ public partial class Test_ICommandAttribute
 
         model.Flag = false;
 
+        Assert.IsFalse(model.IncrementCounter_NoParameters_PropertyCommand.CanExecute(null));
+
+        // This and all test above also verify the logic is unconditionally invoked if CanExecute is ignored
         model.IncrementCounter_NoParameters_PropertyCommand.Execute(null);
 
-        Assert.AreEqual(model.Counter, 1);
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -120,9 +133,11 @@ public partial class Test_ICommandAttribute
 
         model.SetGeneratedFlag(false);
 
+        Assert.IsFalse(model.IncrementCounter_NoParameters_GeneratedPropertyCommand.CanExecute(null));
+
         model.IncrementCounter_NoParameters_GeneratedPropertyCommand.Execute(null);
 
-        Assert.AreEqual(model.Counter, 1);
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -138,9 +153,11 @@ public partial class Test_ICommandAttribute
 
         model.Flag = false;
 
+        Assert.IsFalse(model.IncrementCounter_WithParameter_PropertyCommand.CanExecute(null));
+
         model.IncrementCounter_WithParameter_PropertyCommand.Execute(null);
 
-        Assert.AreEqual(model.Counter, 1);
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -156,9 +173,11 @@ public partial class Test_ICommandAttribute
 
         model.SetGeneratedFlag(false);
 
+        Assert.IsFalse(model.IncrementCounter_WithParameter_GeneratedPropertyCommand.CanExecute(null));
+
         model.IncrementCounter_WithParameter_GeneratedPropertyCommand.Execute(null);
 
-        Assert.AreEqual(model.Counter, 1);
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -174,9 +193,11 @@ public partial class Test_ICommandAttribute
 
         model.Flag = false;
 
+        Assert.IsFalse(model.IncrementCounter_WithParameter_PropertyCommand.CanExecute(null));
+
         model.IncrementCounter_WithParameter_PropertyCommand.Execute(null);
 
-        Assert.AreEqual(model.Counter, 1);
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -192,9 +213,11 @@ public partial class Test_ICommandAttribute
 
         model.Flag = false;
 
-        model.IncrementCounter_WithParameter_PropertyCommand.Execute(null);
+        Assert.IsFalse(model.IncrementCounter_WithParameters_MethodWithNoParametersCommand.CanExecute(null));
 
-        Assert.AreEqual(model.Counter, 1);
+        model.IncrementCounter_WithParameters_MethodWithNoParametersCommand.Execute(null);
+
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -206,9 +229,11 @@ public partial class Test_ICommandAttribute
 
         Assert.AreEqual(model.Counter, 1);
 
-        model.IncrementCounter_WithParameter_PropertyCommand.Execute(new User());
+        Assert.IsFalse(model.IncrementCounter_WithParameters_MethodWithMatchingParameterCommand.CanExecute(new User()));
 
-        Assert.AreEqual(model.Counter, 1);
+        model.IncrementCounter_WithParameters_MethodWithMatchingParameterCommand.Execute(new User());
+
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -224,9 +249,11 @@ public partial class Test_ICommandAttribute
 
         model.Flag = false;
 
+        Assert.IsFalse(model.IncrementCounter_Async_NoParameters_PropertyCommand.CanExecute(null));
+
         await model.IncrementCounter_Async_NoParameters_PropertyCommand.ExecuteAsync(null);
 
-        Assert.AreEqual(model.Counter, 1);
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -242,9 +269,11 @@ public partial class Test_ICommandAttribute
 
         model.Flag = false;
 
+        Assert.IsFalse(model.IncrementCounter_Async_WithParameter_PropertyCommand.CanExecute(null));
+
         await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(null);
 
-        Assert.AreEqual(model.Counter, 1);
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -260,9 +289,11 @@ public partial class Test_ICommandAttribute
 
         model.Flag = false;
 
+        Assert.IsFalse(model.IncrementCounter_Async_WithParameter_PropertyCommand.CanExecute(null));
+
         await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(null);
 
-        Assert.AreEqual(model.Counter, 1);
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -278,9 +309,11 @@ public partial class Test_ICommandAttribute
 
         model.Flag = false;
 
-        await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(null);
+        Assert.IsFalse(model.IncrementCounter_Async_WithParameters_MethodWithNoParametersCommand.CanExecute(null));
 
-        Assert.AreEqual(model.Counter, 1);
+        await model.IncrementCounter_Async_WithParameters_MethodWithNoParametersCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -292,9 +325,11 @@ public partial class Test_ICommandAttribute
 
         Assert.AreEqual(model.Counter, 1);
 
-        await model.IncrementCounter_Async_WithParameter_PropertyCommand.ExecuteAsync(new User());
+        Assert.IsFalse(model.IncrementCounter_Async_WithParameters_MethodWithMatchingParameterCommand.CanExecute(new User()));
 
-        Assert.AreEqual(model.Counter, 1);
+        await model.IncrementCounter_Async_WithParameters_MethodWithMatchingParameterCommand.ExecuteAsync(new User());
+
+        Assert.AreEqual(model.Counter, 2);
     }
 
     [TestMethod]
@@ -397,6 +432,8 @@ public partial class Test_ICommandAttribute
 
         public List<int> Values { get; } = new();
 
+        public TaskCompletionSource<object?> Tcs { get; } = new();
+
         /// <summary>This is a single line summary.</summary>
         [ICommand]
         private void IncrementCounter()
@@ -437,7 +474,7 @@ public partial class Test_ICommandAttribute
         {
             Values.Add(value);
 
-            await Task.Delay(1000);
+            _ = await Tcs.Task;
         }
 
         [ICommand(IncludeCancelCommand = true)]

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommand.cs
@@ -70,10 +70,11 @@ public class Test_RelayCommand
 
         command.Execute(null);
 
-        Assert.AreEqual(ticks, 0);
+        // Logic is unconditionally invoked, the caller should check CanExecute first
+        Assert.AreEqual(ticks, 1);
 
         command.Execute(new object());
 
-        Assert.AreEqual(ticks, 0);
+        Assert.AreEqual(ticks, 2);
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommand{T}.cs
@@ -59,7 +59,8 @@ public class Test_RelayCommandOfT
 
         command.Execute(null);
 
-        Assert.AreEqual(text, "Hello");
+        // Logic is unconditionally invoked, the caller should check CanExecute first
+        Assert.IsNull(text);
     }
 
     [TestMethod]


### PR DESCRIPTION
This PR removes the `CanExecute` checks from the `Execute` methods of all command types.

Video of this working as expected on UWP:

https://user-images.githubusercontent.com/10199417/156785664-29f39251-834f-4e7c-921c-f3c45c920b63.mp4