### PR TITLE
Remove [DebuggerNonUserCode] from visible members

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -276,7 +276,6 @@ partial class ObservablePropertyGenerator
             //
             // /// <inheritdoc cref="<FIELD_NAME>"/>
             // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
-            // [global::System.Diagnostics.DebuggerNonUserCode]
             // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
             // <VALIDATION_ATTRIBUTES>
             // public <FIELD_TYPE><NULLABLE_ANNOTATION?> <PROPERTY_NAME>
@@ -296,7 +295,6 @@ partial class ObservablePropertyGenerator
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservablePropertyGenerator).FullName))),
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservablePropertyGenerator).Assembly.GetName().Version.ToString()))))))
                     .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{propertyInfo.FieldName}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())),
-                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.DebuggerNonUserCode")))),
                     AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage")))))
                 .AddAttributeLists(validationAttributes.ToArray())
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/TransitiveMembersGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/TransitiveMembersGenerator.Execute.cs
@@ -68,12 +68,6 @@ partial class TransitiveMembersGenerator<TInfo>
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(generatorType.Assembly.GetName().Version.ToString())))))))
                     .WithLeadingTrivia(member.GetLeadingTrivia());
 
-                // [DebuggerNonUserCode] is not supported over interfaces, events or fields
-                if (member.Kind() is not SyntaxKind.InterfaceDeclaration and not SyntaxKind.EventFieldDeclaration and not SyntaxKind.FieldDeclaration)
-                {
-                    member = member.AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.DebuggerNonUserCode")))));
-                }
-
                 // [ExcludeFromCodeCoverage] is not supported on interfaces and fields
                 if (member.Kind() is not SyntaxKind.InterfaceDeclaration and not SyntaxKind.FieldDeclaration)
                 {

--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
@@ -207,7 +207,6 @@ partial class ICommandGenerator
             //
             // /// <summary>Gets an <see cref="<COMMAND_INTERFACE_TYPE>" instance wrapping <see cref="<METHOD_NAME>"/> and <see cref="<OPTIONAL_CAN_EXECUTE>"/>.</summary>
             // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
-            // [global::System.Diagnostics.DebuggerNonUserCode]
             // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
             // public <COMMAND_TYPE> <COMMAND_PROPERTY_NAME> => <COMMAND_FIELD_NAME> ??= new <RELAY_COMMAND_TYPE>(<COMMAND_CREATION_ARGUMENTS>);
             PropertyDeclarationSyntax propertyDeclaration =
@@ -225,7 +224,6 @@ partial class ICommandGenerator
                         $"/// <summary>Gets an <see cref=\"{commandInterfaceTypeXmlName}\"/> instance wrapping <see cref=\"{commandInfo.MethodName}\"/>.</summary>")),
                         SyntaxKind.OpenBracketToken,
                         TriviaList())),
-                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.DebuggerNonUserCode")))),
                     AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage")))))
                 .WithExpressionBody(
                     ArrowExpressionClause(
@@ -265,7 +263,6 @@ partial class ICommandGenerator
                 //
                 // /// <summary>Gets an <see cref="global::System.Windows.Input.ICommand" instance that can be used to cancel <see cref="<COMMAND_PROPERTY_NAME>"/>.</summary>
                 // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
-                // [global::System.Diagnostics.DebuggerNonUserCode]
                 // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                 // public global::System.Windows.Input.ICommand <CANCEL_COMMAND_PROPERTY_NAME> => <CANCEL_COMMAND_FIELD_NAME> ??= global::CommunityToolkit.Mvvm.Input.IAsyncRelayCommandExtensions.CreateCancelCommand(<COMMAND_PROPERTY_NAME>);
                 PropertyDeclarationSyntax cancelCommandPropertyDeclaration =
@@ -283,7 +280,6 @@ partial class ICommandGenerator
                             $"/// <summary>Gets an <see cref=\"global::System.Windows.Input.ICommand\"/> instance that can be used to cancel <see cref=\"{commandInfo.PropertyName}\"/>.</summary>")),
                             SyntaxKind.OpenBracketToken,
                             TriviaList())),
-                        AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.DebuggerNonUserCode")))),
                         AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage")))))
                     .WithExpressionBody(
                         ArrowExpressionClause(


### PR DESCRIPTION
**Closes #107**

This PR removes `[DebuggerNonUserCode]` from generated memebers that should be used by developers.
This fixes the IntelliSense issues and it's consistent with the other generators built-in into .NET.