### PR TITLE
Add new [AlsoBroadcastChange] attribute

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -26,3 +26,4 @@ MVVMTK0018 | CommunityToolkit.Mvvm.SourceGenerators.ObservableObjectGenerator | 
 MVVMTK0019 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/error
 MVVMTK0020 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/error
 MVVMTK0021 | CommunityToolkit.Mvvm.SourceGenerators.ObservableRecipientGenerator | Error | See https://aka.ms/mvvmtoolkit/error
+MVVMTK0022 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/error

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/Models/PropertyInfo.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/Models/PropertyInfo.cs
@@ -21,6 +21,7 @@ namespace CommunityToolkit.Mvvm.SourceGenerators.ComponentModel.Models;
 /// <param name="PropertyChangingNames">The sequence of property changing properties to notify.</param>
 /// <param name="PropertyChangedNames">The sequence of property changed properties to notify.</param>
 /// <param name="NotifiedCommandNames">The sequence of commands to notify.</param>
+/// <param name="AlsoBroadcastChange">Whether or not the generated property also broadcasts changes.</param>
 /// <param name="ValidationAttributes">The sequence of validation attributes for the generated property.</param>
 internal sealed record PropertyInfo(
     string TypeName,
@@ -30,6 +31,7 @@ internal sealed record PropertyInfo(
     ImmutableArray<string> PropertyChangingNames,
     ImmutableArray<string> PropertyChangedNames,
     ImmutableArray<string> NotifiedCommandNames,
+    bool AlsoBroadcastChange,
     ImmutableArray<AttributeInfo> ValidationAttributes)
 {
     /// <summary>
@@ -47,6 +49,7 @@ internal sealed record PropertyInfo(
             hashCode.AddRange(obj.PropertyChangingNames);
             hashCode.AddRange(obj.PropertyChangedNames);
             hashCode.AddRange(obj.NotifiedCommandNames);
+            hashCode.Add(obj.AlsoBroadcastChange);
             hashCode.AddRange(obj.ValidationAttributes, AttributeInfo.Comparer.Default);
         }
 
@@ -61,6 +64,7 @@ internal sealed record PropertyInfo(
                 x.PropertyChangingNames.SequenceEqual(y.PropertyChangingNames) &&
                 x.PropertyChangedNames.SequenceEqual(y.PropertyChangedNames) &&
                 x.NotifiedCommandNames.SequenceEqual(y.NotifiedCommandNames) &&
+                x.AlsoBroadcastChange == y.AlsoBroadcastChange &&
                 x.ValidationAttributes.SequenceEqual(y.ValidationAttributes, AttributeInfo.Comparer.Default);
         }
     }

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
@@ -39,12 +39,13 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
             fieldSymbols
             .Where(static item => item.HasAttributeWithFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute"));
 
-        // Get diagnostics for fields using [AlsoNotifyChangeFor] and [AlsoNotifyCanExecuteFor], but not [ObservableProperty]
+        // Get diagnostics for fields using [AlsoNotifyChangeFor], [AlsoNotifyCanExecuteFor] and [AlsoBroadcastChange], but not [ObservableProperty]
         IncrementalValuesProvider<Diagnostic> fieldSymbolsWithOrphanedDependentAttributeWithErrors =
             fieldSymbols
             .Where(static item =>
                 (item.HasAttributeWithFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.AlsoNotifyChangeForAttribute") ||
-                 item.HasAttributeWithFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.AlsoNotifyCanExecuteForAttribute")) &&
+                 item.HasAttributeWithFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.AlsoNotifyCanExecuteForAttribute") ||
+                 item.HasAttributeWithFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.AlsoBroadcastChangeAttribute")) &&
                  !item.HasAttributeWithFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute"))
             .Select(static (item, _) => Execute.GetDiagnosticForFieldWithOrphanedDependentAttributes(item));
 

--- a/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -347,4 +347,20 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Cannot apply [ObservableRecipient] to a type that already inherits this attribute from a base type.",
         helpLinkUri: "https://aka.ms/mvvmtoolkit");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when <c>[AlsoBroadcastChange]</c> is applied to a field in an invalid type.
+    /// <para>
+    /// Format: <c>"The field {0}.{1} cannot be annotated with [AlsoBroadcastChange], as its containing type doesn't inherit from ObservableRecipient, nor does it use [ObservableRecipient]"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidContainingTypeForAlsoBroadcastChangeFieldError = new DiagnosticDescriptor(
+        id: "MVVMTK0022",
+        title: "Invalid containing type for [ObservableProperty] field",
+        messageFormat: "The field {0}.{1} cannot be annotated with [AlsoBroadcastChange], as its containing type doesn't inherit from ObservableRecipient, nor does it use [ObservableRecipient]",
+        category: typeof(ObservablePropertyGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Fields annotated with [AlsoBroadcastChange] must be contained in a type that inherits from ObservableRecipient or that is annotated with [ObservableRecipient] (including base types).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit");
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -319,17 +319,17 @@ internal static class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> indicating when <c>[ObservableProperty]</c> is applied to a field in an invalid type.
     /// <para>
-    /// Format: <c>"The field {0}.{1} needs to be annotated with [ObservableProperty] in order to enable using [AlsoNotifyChangeFor] and [AlsoNotifyCanExecuteFor]"</c>.
+    /// Format: <c>"The field {0}.{1} needs to be annotated with [ObservableProperty] in order to enable using [AlsoNotifyChangeFor], [AlsoNotifyCanExecuteFor] and [AlsoBroadcastChange]"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor FieldWithOrphanedDependentObservablePropertyAttributesError = new DiagnosticDescriptor(
         id: "MVVMTK0020",
         title: "Invalid use of attributes dependent on [ObservableProperty]",
-        messageFormat: "The field {0}.{1} needs to be annotated with [ObservableProperty] in order to enable using [AlsoNotifyChangeFor] and [AlsoNotifyCanExecuteFor]",
+        messageFormat: "The field {0}.{1} needs to be annotated with [ObservableProperty] in order to enable using [AlsoNotifyChangeFor], [AlsoNotifyCanExecuteFor] and [AlsoBroadcastChange]",
         category: typeof(ObservablePropertyGenerator).FullName,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Fields not annotated with [ObservableProperty] cannot use [AlsoNotifyChangeFor] and [AlsoNotifyCanExecuteFor].",
+        description: "Fields not annotated with [ObservableProperty] cannot use [AlsoNotifyChangeFor], [AlsoNotifyCanExecuteFor] and [AlsoBroadcastChange].",
         helpLinkUri: "https://aka.ms/mvvmtoolkit");
 
     /// <summary>

--- a/CommunityToolkit.Mvvm/ComponentModel/Attributes/AlsoBroadcastChangeAttribute.cs
+++ b/CommunityToolkit.Mvvm/ComponentModel/Attributes/AlsoBroadcastChangeAttribute.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace CommunityToolkit.Mvvm.ComponentModel;
+
+/// <summary>
+/// An attribute that can be used to support <see cref="ObservablePropertyAttribute"/> in generated properties, when applied to fields
+/// contained in a type that is either inheriting from <see cref="ObservableRecipient"/>, or annotated with <see cref="ObservableRecipientAttribute"/>.
+/// When this attribute is used, the generated property setter will also call <see cref="ObservableRecipient.Broadcast{T}(T, T, string?)"/>.
+/// This allows generated properties to opt-in into broadcasting behavior without having to fallback into a full explicit observable property.
+/// <para>
+/// This attribute can be used as follows:
+/// <code>
+/// partial class MyViewModel : ObservableRecipient
+/// {
+///     [ObservableProperty]
+///     [AlsoBroadcastChange]
+///     private string username;
+/// }
+/// </code>
+/// </para>
+/// And with this, code analogous to this will be generated:
+/// <code>
+/// partial class MyViewModel
+/// {
+///     public string Username
+///     {
+///         get => username;
+///         set => SetProperty(ref username, value, broadcast: true);
+///     }
+/// }
+/// </code>
+/// </summary>
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
+public sealed class AlsoBroadcastChangeAttribute : Attribute
+{
+}

--- a/tests/CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests/Test_SourceGeneratorAttributes.cs
+++ b/tests/CommunityToolkit.Mvvm.KeepSourceGeneratorAttributes.UnitTests/Test_SourceGeneratorAttributes.cs
@@ -21,7 +21,7 @@ public class Test_SourceGeneratorAttributes
         Assert.Fail();
 #endif
         Assert.AreEqual(3, typeof(TestModel).GetCustomAttributes().Count(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
-        Assert.AreEqual(3, typeof(TestModel).GetField(nameof(TestModel.name))!.GetCustomAttributes().Count(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
+        Assert.AreEqual(4, typeof(TestModel).GetField(nameof(TestModel.name))!.GetCustomAttributes().Count(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
         Assert.AreEqual(1, typeof(TestModel).GetMethod(nameof(TestModel.Test))!.GetCustomAttributes().Count(a => a.GetType().FullName!.Contains("CommunityToolkit.Mvvm")));
     }
 
@@ -33,6 +33,7 @@ public class Test_SourceGeneratorAttributes
         [ObservableProperty]
         [AlsoNotifyChangeFor("")]
         [AlsoNotifyCanExecuteFor("")]
+        [AlsoBroadcastChange]
         public string? name;
 
         [ICommand]

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -999,6 +999,47 @@ public class Test_SourceGeneratorsDiagnostics
     }
 
     [TestMethod]
+    public void FieldWithOrphanedDependentObservablePropertyAttributesError_AlsoBroadcastChange()
+    {
+        string source = @"
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class MyViewModel
+                {
+                    [AlsoBroadcastChange]
+                    public int number;
+                }
+            }";
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0020");
+    }
+
+    [TestMethod]
+    public void FieldWithOrphanedDependentObservablePropertyAttributesError_MultipleUsesStillGenerateOnlyASingleDiagnostic()
+    {
+        string source = @"
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class MyViewModel
+                {
+                    [AlsoNotifyChangeFor("")]
+                    [AlsoNotifyChangeFor("")]
+                    [AlsoNotifyChangeFor("")]
+                    [AlsoNotifyCanExecuteFor("")]
+                    [AlsoNotifyCanExecuteFor("")]
+                    [AlsoBroadcastChange]
+                    public int number;
+                }
+            }";
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0020");
+    }
+
+    [TestMethod]
     public void InvalidAttributeCombinationForObservableRecipientAttributeError()
     {
         string source = @"
@@ -1018,6 +1059,25 @@ public class Test_SourceGeneratorsDiagnostics
             }";
 
         VerifyGeneratedDiagnostics<ObservableRecipientGenerator>(source, "MVVMTK0021");
+    }
+
+    [TestMethod]
+    public void InvalidContainingTypeForAlsoBroadcastChangeFieldError_ObservableObject()
+    {
+        string source = @"
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class MyViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    [AlsoBroadcastChange]
+                    public int number;
+                }
+            }";
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0022");
     }
 
     /// <summary>


### PR DESCRIPTION
**Closes #125**

This PR adds a new `[AlsoBroadcastChange]` attribute that lets users opt-in into broadcasting for generated properties.

### API breakdown

```csharp
namespace CommunityToolkit.Mvvm.ComponentModel;

[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
[Conditional("MVVMTOOLKIT_KEEP_SOURCE_GENERATOR_ATTRIBUTES")]
public sealed class AlsoBroadcastChangeAttribute : Attribute
{
}
```