### PR TITLE
Fix nullability annotations in generated properties

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/Models/PropertyInfo.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/Models/PropertyInfo.cs
@@ -14,8 +14,7 @@ namespace CommunityToolkit.Mvvm.SourceGenerators.ComponentModel.Models;
 /// <summary>
 /// A model representing an generated property
 /// </summary>
-/// <param name="TypeName">The type name for the generated property.</param>
-/// <param name="IsNullableReferenceType">Whether or not the property is of a nullable reference type.</param>
+/// <param name="TypeNameWithNullabilityAnnotations">The type name for the generated property, including nullability annotations.</param>
 /// <param name="FieldName">The field name.</param>
 /// <param name="PropertyName">The generated property name.</param>
 /// <param name="PropertyChangingNames">The sequence of property changing properties to notify.</param>
@@ -24,8 +23,7 @@ namespace CommunityToolkit.Mvvm.SourceGenerators.ComponentModel.Models;
 /// <param name="AlsoBroadcastChange">Whether or not the generated property also broadcasts changes.</param>
 /// <param name="ValidationAttributes">The sequence of validation attributes for the generated property.</param>
 internal sealed record PropertyInfo(
-    string TypeName,
-    bool IsNullableReferenceType,
+    string TypeNameWithNullabilityAnnotations,
     string FieldName,
     string PropertyName,
     ImmutableArray<string> PropertyChangingNames,
@@ -42,8 +40,7 @@ internal sealed record PropertyInfo(
         /// <inheritdoc/>
         protected override void AddToHashCode(ref HashCode hashCode, PropertyInfo obj)
         {
-            hashCode.Add(obj.TypeName);
-            hashCode.Add(obj.IsNullableReferenceType);
+            hashCode.Add(obj.TypeNameWithNullabilityAnnotations);
             hashCode.Add(obj.FieldName);
             hashCode.Add(obj.PropertyName);
             hashCode.AddRange(obj.PropertyChangingNames);
@@ -57,8 +54,7 @@ internal sealed record PropertyInfo(
         protected override bool AreEqual(PropertyInfo x, PropertyInfo y)
         {
             return
-                x.TypeName == y.TypeName &&
-                x.IsNullableReferenceType == y.IsNullableReferenceType &&
+                x.TypeNameWithNullabilityAnnotations == y.TypeNameWithNullabilityAnnotations &&
                 x.FieldName == y.FieldName &&
                 x.PropertyName == y.PropertyName &&
                 x.PropertyChangingNames.SequenceEqual(y.PropertyChangingNames) &&

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -49,8 +49,7 @@ partial class ObservablePropertyGenerator
             }
 
             // Get the property type and name
-            string typeName = fieldSymbol.Type.GetFullyQualifiedName();
-            bool isNullableReferenceType = fieldSymbol.Type is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated };
+            string typeNameWithNullabilityAnnotations = fieldSymbol.Type.GetFullyQualifiedNameWithNullabilityAnnotations();
             string fieldName = fieldSymbol.Name;
             string propertyName = GetGeneratedPropertyName(fieldSymbol);
 
@@ -124,8 +123,7 @@ partial class ObservablePropertyGenerator
             diagnostics = builder.ToImmutable();
 
             return new(
-                typeName,
-                isNullableReferenceType,
+                typeNameWithNullabilityAnnotations,
                 fieldName,
                 propertyName,
                 propertyChangingNames.ToImmutable(),
@@ -406,10 +404,8 @@ partial class ObservablePropertyGenerator
         {
             ImmutableArray<StatementSyntax>.Builder setterStatements = ImmutableArray.CreateBuilder<StatementSyntax>();
 
-            // Get the property type syntax (adding the nullability annotation, if needed)
-            TypeSyntax propertyType = propertyInfo.IsNullableReferenceType
-                ? NullableType(IdentifierName(propertyInfo.TypeName))
-                : IdentifierName(propertyInfo.TypeName);
+            // Get the property type syntax
+            TypeSyntax propertyType = IdentifierName(propertyInfo.TypeNameWithNullabilityAnnotations);
 
             // In case the backing field is exactly named "value", we need to add the "this." prefix to ensure that comparisons and assignments
             // with it in the generated setter body are executed correctly and without conflicts with the implicit value parameter.
@@ -602,10 +598,8 @@ partial class ObservablePropertyGenerator
         /// <returns>The generated <see cref="MemberDeclarationSyntax"/> instances for the <c>OnPropertyChanging</c> and <c>OnPropertyChanged</c> methods.</returns>
         public static ImmutableArray<MemberDeclarationSyntax> GetOnPropertyChangeMethodsSyntax(PropertyInfo propertyInfo)
         {
-            // Get the parameter type syntax (adding the nullability annotation, if needed)
-            TypeSyntax parameterType = propertyInfo.IsNullableReferenceType
-                ? NullableType(IdentifierName(propertyInfo.TypeName))
-                : IdentifierName(propertyInfo.TypeName);
+            // Get the property type syntax
+            TypeSyntax parameterType = IdentifierName(propertyInfo.TypeNameWithNullabilityAnnotations);
 
             // Construct the generated method as follows:
             //

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/ISymbolExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/ISymbolExtensions.cs
@@ -23,6 +23,16 @@ internal static class ISymbolExtensions
     }
 
     /// <summary>
+    /// Gets the fully qualified name for a given symbol, including nullability annotations
+    /// </summary>
+    /// <param name="symbol">The input <see cref="ISymbol"/> instance.</param>
+    /// <returns>The fully qualified name for <paramref name="symbol"/>.</returns>
+    public static string GetFullyQualifiedNameWithNullabilityAnnotations(this ISymbol symbol)
+    {
+        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier));
+    }
+
+    /// <summary>
     /// Checks whether or not a given type symbol has a specified full name.
     /// </summary>
     /// <param name="symbol">The input <see cref="ISymbol"/> instance to check.</param>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -509,11 +509,9 @@ public partial class Test_ObservablePropertyAttribute
         //Assert.AreEqual(NullabilityState.NotNull, rightInfo2.ReadState);
         //Assert.AreEqual(NullabilityState.NotNull, rightInfo2.WriteState);
 
-        // The commented out lines are to work around a weird behavior of the NullabilityInfo API there.
-        // Arguably we're pushing them a bit far here, but it's fine. Even with those cases commented out,
-        // the test is already more than enough, plus we can also double check the behavior by looking at
-        // the generated code. Thoe lines can be uncommented once the behavior is either clarified, or if
-        // it happens to be a bug which is then fixed in a future version of .NET, once we upgrade as well.
+        // The commented out lines are to work around a bug in the NullabilityInfo API in .NET 6.
+        // This has been fixed for .NET 7: https://github.com/dotnet/runtime/pull/63556. The test
+        // cases above can be uncommented when the .NET 7 target (or a more recent version) is added.
     }
 #endif
 

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;


### PR DESCRIPTION
**Closes #155**

This PR fixes the generated properties to preserve the same nullability context as the source fields.