### PR TITLE
Allow Task<T>-returns on methods with [ICommand]

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
@@ -309,8 +309,9 @@ partial class ICommandGenerator
         {
             string propertyName = methodSymbol.Name;
 
-            if (methodSymbol.ReturnType.HasFullyQualifiedName("global::System.Threading.Tasks.Task") &&
-                methodSymbol.Name.EndsWith("Async"))
+            if (methodSymbol.Name.EndsWith("Async") &&
+                (methodSymbol.ReturnType.HasFullyQualifiedName("global::System.Threading.Tasks.Task") ||
+                 methodSymbol.ReturnType.InheritsFromFullyQualifiedName("global::System.Threading.Tasks.Task")))
             {
                 propertyName = propertyName.Substring(0, propertyName.Length - "Async".Length);
             }
@@ -372,7 +373,9 @@ partial class ICommandGenerator
                 return true;
             }
 
-            if (methodSymbol.ReturnType.HasFullyQualifiedName("global::System.Threading.Tasks.Task"))
+            // Map all Task-returning methods
+            if (methodSymbol.ReturnType.HasFullyQualifiedName("global::System.Threading.Tasks.Task") ||
+                methodSymbol.ReturnType.InheritsFromFullyQualifiedName("global::System.Threading.Tasks.Task"))
             {
                 // Map <void, Task> to IAsyncRelayCommand, AsyncRelayCommand, Func<Task>
                 if (methodSymbol.Parameters.Length == 0)

--- a/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
+++ b/CommunityToolkit.Mvvm/Input/Attributes/ICommandAttribute.cs
@@ -51,11 +51,15 @@ namespace CommunityToolkit.Mvvm.Input;
 /// <code>
 /// Task Method();
 /// Task Method(CancellationToken);
+/// Task&lt;T&gt; Method();
+/// Task&lt;T&gt; Method(CancellationToken);
 /// </code>
 /// Will both generate an <see cref="IAsyncRelayCommand"/> property (using an <see cref="AsyncRelayCommand{T}"/> instance).
 /// <code>
 /// Task Method(T?);
 /// Task Method(T?, CancellationToken);
+/// Task&lt;T&gt; Method(T?);
+/// Task&lt;T&gt; Method(T?, CancellationToken);
 /// </code>
 /// Will both generate an <see cref="IAsyncRelayCommand{T}"/> property (using an <see cref="AsyncRelayCommand{T}"/> instance).
 /// </para>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ICommandAttribute.cs
@@ -441,6 +441,27 @@ public partial class Test_ICommandAttribute
         Assert.IsTrue(model.Result2 is OperationCanceledException);
     }
 
+    [TestMethod]
+    public async Task Test_ICommandAttribute_TaskOfTReturns()
+    {
+        GenericTaskCommands model = new();
+
+        Task greetCommandTask = model.GreetCommand.ExecuteAsync(null);
+        Task greetWithTokenTask = model.GreetWithTokenCommand.ExecuteAsync(null);
+        Task greetWithParamTask = model.GreetWithParamCommand.ExecuteAsync(null);
+        Task greetWithParamAndCommandTask = model.GreetWithParamAndTokenCommand.ExecuteAsync(null);
+
+        Assert.IsInstanceOfType(greetCommandTask, typeof(Task<string>));
+        Assert.IsInstanceOfType(greetWithTokenTask, typeof(Task<string>));
+        Assert.IsInstanceOfType(greetWithParamTask, typeof(Task<string>));
+        Assert.IsInstanceOfType(greetWithParamAndCommandTask, typeof(Task<string>));
+
+        Assert.AreEqual("Hello world", await (Task<string>)greetCommandTask);
+        Assert.AreEqual("Hello world", await (Task<string>)greetWithTokenTask);
+        Assert.AreEqual("Hello world", await (Task<string>)greetWithParamTask);
+        Assert.AreEqual("Hello world", await (Task<string>)greetWithParamAndCommandTask);
+    }
+
     #region Region
     public class Region
     {
@@ -729,6 +750,41 @@ public partial class Test_ICommandAttribute
             {
                 Result2 = e;
             }
+        }
+    }
+
+    public partial class GenericTaskCommands
+    {
+        [ICommand]
+        private async Task<string> GreetAsync()
+        {
+            await Task.Yield();
+
+            return "Hello world";
+        }
+
+        [ICommand]
+        private async Task<string> GreetWithTokenAsync(CancellationToken token)
+        {
+            await Task.Yield();
+
+            return "Hello world";
+        }
+
+        [ICommand]
+        private async Task<string> GreetWithParamAsync(object _)
+        {
+            await Task.Yield();
+
+            return "Hello world";
+        }
+
+        [ICommand]
+        private async Task<string> GreetWithParamAndTokenAsync(object _, CancellationToken token)
+        {
+            await Task.Yield();
+
+            return "Hello world";
         }
     }
 }


### PR DESCRIPTION
**Closes #159**

This PR allows `[ICommand]` to also be used on methods returning `Task<T>`.