### PR TITLE
Remove obsolete APIs

### DIFF
--- a/CommunityToolkit.Common/Extensions/StringExtensions.cs
+++ b/CommunityToolkit.Common/Extensions/StringExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
@@ -139,24 +138,6 @@ public static class StringExtensions
     /// <param name="length">The maximum length.</param>
     /// <returns>Truncated string.</returns>
     public static string Truncate(this string? value, int length) => Truncate(value, length, false);
-
-    /// <summary>
-    /// Provide better linking for resourced strings.
-    /// </summary>
-    /// <param name="format">The format of the string being linked.</param>
-    /// <param name="args">The object which will receive the linked String.</param>
-    /// <returns>Truncated string.</returns>
-    [Obsolete("This method will be removed in a future version of the Toolkit. Use the native C# string interpolation syntax instead, see: https://docs.microsoft.com/dotnet/csharp/language-reference/tokens/interpolated")]
-    public static string AsFormat(this string format, params object[] args)
-    {
-        // Note: this extension was originally added to help developers using {x:Bind} in XAML, but
-        // due to a known limitation in the UWP/WinUI XAML compiler, using either this method or the
-        // standard string.Format method from the BCL directly doesn't always work. Since this method
-        // doesn't actually provide any benefit over the built-in one, it has been marked as obsolete.
-        // For more details, see the WinUI issue on the XAML compiler limitation here:
-        // https://github.com/microsoft/microsoft-ui-xaml/issues/2654.
-        return string.Format(format, args);
-    }
 
     /// <summary>
     /// Truncates a string to the specified length.

--- a/CommunityToolkit.Diagnostics/Guard.String.cs
+++ b/CommunityToolkit.Diagnostics/Guard.String.cs
@@ -114,7 +114,7 @@ partial class Guard
             return;
         }
 
-        ThrowHelper.ThrowArgumentExceptionForIsNotEmpty(text, name);
+        ThrowHelper.ThrowArgumentExceptionForIsNotEmpty(name);
     }
 
     /// <summary>

--- a/CommunityToolkit.Diagnostics/Guard.String.cs
+++ b/CommunityToolkit.Diagnostics/Guard.String.cs
@@ -66,24 +66,6 @@ partial class Guard
     }
 
     /// <summary>
-    /// Asserts that the input <see cref="string"/> instance must be <see langword="null"/> or whitespace.
-    /// </summary>
-    /// <param name="text">The input <see cref="string"/> instance to test.</param>
-    /// <param name="name">The name of the input parameter being tested.</param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is neither <see langword="null"/> nor whitespace.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Use " + nameof(IsNullOrWhiteSpace))]
-    public static void IsNullOrWhitespace(string? text, [CallerArgumentExpression("text")] string name = "")
-    {
-        if (string.IsNullOrWhiteSpace(text))
-        {
-            return;
-        }
-
-        ThrowHelper.ThrowArgumentExceptionForIsNullOrWhiteSpace(text, name);
-    }
-
-    /// <summary>
     /// Asserts that the input <see cref="string"/> instance must not be <see langword="null"/> or whitespace.
     /// </summary>
     /// <param name="text">The input <see cref="string"/> instance to test.</param>
@@ -92,24 +74,6 @@ partial class Guard
     /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is whitespace.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void IsNotNullOrWhiteSpace([NotNull] string? text, [CallerArgumentExpression("text")] string name = "")
-    {
-        if (!string.IsNullOrWhiteSpace(text))
-        {
-            return;
-        }
-
-        ThrowHelper.ThrowArgumentExceptionForIsNotNullOrWhiteSpace(text, name);
-    }
-
-    /// <summary>
-    /// Asserts that the input <see cref="string"/> instance must not be <see langword="null"/> or whitespace.
-    /// </summary>
-    /// <param name="text">The input <see cref="string"/> instance to test.</param>
-    /// <param name="name">The name of the input parameter being tested.</param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is <see langword="null"/> or whitespace.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Use " + nameof(IsNotNullOrWhiteSpace))]
-    public static void IsNotNullOrWhitespace([NotNull] string? text, [CallerArgumentExpression("text")] string name = "")
     {
         if (!string.IsNullOrWhiteSpace(text))
         {
@@ -171,24 +135,6 @@ partial class Guard
     }
 
     /// <summary>
-    /// Asserts that the input <see cref="string"/> instance must be whitespace.
-    /// </summary>
-    /// <param name="text">The input <see cref="string"/> instance to test.</param>
-    /// <param name="name">The name of the input parameter being tested.</param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is neither <see langword="null"/> nor whitespace.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Use " + nameof(IsWhiteSpace))]
-    public static void IsWhitespace(string text, [CallerArgumentExpression("text")] string name = "")
-    {
-        if (string.IsNullOrWhiteSpace(text))
-        {
-            return;
-        }
-
-        ThrowHelper.ThrowArgumentExceptionForIsWhiteSpace(text, name);
-    }
-
-    /// <summary>
     /// Asserts that the input <see cref="string"/> instance must not be <see langword="null"/> or whitespace.
     /// </summary>
     /// <param name="text">The input <see cref="string"/> instance to test.</param>
@@ -196,24 +142,6 @@ partial class Guard
     /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is <see langword="null"/> or whitespace.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void IsNotWhiteSpace(string text, [CallerArgumentExpression("text")] string name = "")
-    {
-        if (!string.IsNullOrWhiteSpace(text))
-        {
-            return;
-        }
-
-        ThrowHelper.ThrowArgumentExceptionForIsNotWhiteSpace(text, name);
-    }
-
-    /// <summary>
-    /// Asserts that the input <see cref="string"/> instance must not be <see langword="null"/> or whitespace.
-    /// </summary>
-    /// <param name="text">The input <see cref="string"/> instance to test.</param>
-    /// <param name="name">The name of the input parameter being tested.</param>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is <see langword="null"/> or whitespace.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Use " + nameof(IsNotWhiteSpace))]
-    public static void IsNotWhitespace(string text, [CallerArgumentExpression("text")] string name = "")
     {
         if (!string.IsNullOrWhiteSpace(text))
         {

--- a/CommunityToolkit.Diagnostics/Internals/Guard.String.ThrowHelper.cs
+++ b/CommunityToolkit.Diagnostics/Internals/Guard.String.ThrowHelper.cs
@@ -44,7 +44,7 @@ partial class Guard
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentException"/> when <see cref="IsNullOrWhitespace"/> fails.
+        /// Throws an <see cref="ArgumentException"/> when <see cref="IsNullOrWhiteSpace"/> fails.
         /// </summary>
         [DoesNotReturn]
         public static void ThrowArgumentExceptionForIsNullOrWhiteSpace(string? text, string name)
@@ -53,7 +53,7 @@ partial class Guard
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentException"/> when <see cref="IsNotNullOrWhitespace"/> fails.
+        /// Throws an <see cref="ArgumentException"/> when <see cref="IsNotNullOrWhiteSpace"/> fails.
         /// </summary>
         [DoesNotReturn]
         public static void ThrowArgumentExceptionForIsNotNullOrWhiteSpace(string? text, string name)
@@ -91,7 +91,7 @@ partial class Guard
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentException"/> when <see cref="IsWhitespace"/> fails.
+        /// Throws an <see cref="ArgumentException"/> when <see cref="IsWhiteSpace"/> fails.
         /// </summary>
         [DoesNotReturn]
         public static void ThrowArgumentExceptionForIsWhiteSpace(string text, string name)
@@ -100,7 +100,7 @@ partial class Guard
         }
 
         /// <summary>
-        /// Throws an <see cref="ArgumentException"/> when <see cref="IsNotWhitespace"/> fails.
+        /// Throws an <see cref="ArgumentException"/> when <see cref="IsNotWhiteSpace"/> fails.
         /// </summary>
         [DoesNotReturn]
         public static void ThrowArgumentExceptionForIsNotWhiteSpace(string text, string name)

--- a/CommunityToolkit.Diagnostics/Internals/Guard.String.ThrowHelper.cs
+++ b/CommunityToolkit.Diagnostics/Internals/Guard.String.ThrowHelper.cs
@@ -85,7 +85,7 @@ partial class Guard
         /// Throws an <see cref="ArgumentException"/> when <see cref="IsNotEmpty"/> fails.
         /// </summary>
         [DoesNotReturn]
-        public static void ThrowArgumentExceptionForIsNotEmpty(string text, string name)
+        public static void ThrowArgumentExceptionForIsNotEmpty(string name)
         {
             throw new ArgumentException($"Parameter {AssertString(name)} (string) must not be empty.", name);
         }


### PR DESCRIPTION
**Closes #172**

This PR removes some leftover obsolete APIs:

```csharp
namespace CommunityToolkit.Common
{
    public static class StringExtensions
    {
        public static string AsFormat(this string format, params object[] args);
    }
}

namespace CommunityToolkit.Diagnostics
{
    public static class Guard
    {
        public static void IsNullOrWhitespace(string? text, [CallerArgumentExpression("text")] string name = "");
        public static void IsNotNullOrWhitespace([NotNull] string? text, [CallerArgumentExpression("text")] string name = "");
        public static void IsWhitespace(string text, [CallerArgumentExpression("text")] string name = "");
        public static void IsNotWhitespace(string text, [CallerArgumentExpression("text")] string name = "")
    }
}
```