### PR TITLE
Make NullabilityAttributesGenerator incremental

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/Attributes/NullabilityAttributesGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Attributes/NullabilityAttributesGenerator.cs
@@ -29,31 +29,31 @@ public sealed class NullabilityAttributesGenerator : IIncrementalGenerator
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // Check that the target attributes are not available in the consuming project. To ensure that
-        // this works fine both in .NET (Core) and .NET Standard implementations, we also need to check
-        // that the target types are declared as public (we assume that in this case those types are from the BCL).
+        // Check that the target attributes are not available in the consuming project. To ensure that this
+        // works fine both in .NET (Core) and .NET Standard implementations, we also need to check that the
+        // target types are declared as public (we assume that in this case those types are from the BCL).
         // This avoids issues on .NET Standard with Roslyn also seeing internal types from referenced assemblies.
 
-        // Check whether [NotNull] is available
-        IncrementalValueProvider<bool> isNotNullAttributeAvailable =
+        // Check whether [NotNull] is not available
+        IncrementalValueProvider<bool> isNotNullAttributeNotAvailable =
             context.CompilationProvider
-            .Select(static (item, _) => item.HasAccessibleTypeWithMetadataName(NotNullAttributeMetadataName));
+            .Select(static (item, _) => !item.HasAccessibleTypeWithMetadataName(NotNullAttributeMetadataName));
 
         // Generate the [NotNull] type
-        context.RegisterConditionalSourceOutput(isNotNullAttributeAvailable, static context =>
+        context.RegisterConditionalSourceOutput(isNotNullAttributeNotAvailable, static context =>
         {
             string source = LoadAttributeSourceWithMetadataName(NotNullAttributeMetadataName);
 
             context.AddSource(NotNullAttributeMetadataName, source);
         });
 
-        // Check whether [NotNullIfNotNull] is available
-        IncrementalValueProvider<bool> isNotNullIfNotNullAttributeAvailable =
+        // Check whether [NotNullIfNotNull] is not available
+        IncrementalValueProvider<bool> isNotNullIfNotNullAttributeNotAvailable =
             context.CompilationProvider
-            .Select(static (item, _) => item.HasAccessibleTypeWithMetadataName(NotNullIfNotNullAttributeMetadataName));
+            .Select(static (item, _) => !item.HasAccessibleTypeWithMetadataName(NotNullIfNotNullAttributeMetadataName));
 
         // Generate the [NotNullIfNotNull] type
-        context.RegisterConditionalSourceOutput(isNotNullIfNotNullAttributeAvailable, static context =>
+        context.RegisterConditionalSourceOutput(isNotNullIfNotNullAttributeNotAvailable, static context =>
         {
             string source = LoadAttributeSourceWithMetadataName(NotNullIfNotNullAttributeMetadataName);
 

--- a/CommunityToolkit.Mvvm.SourceGenerators/Attributes/NullabilityAttributesGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Attributes/NullabilityAttributesGenerator.cs
@@ -5,53 +5,73 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 
 namespace CommunityToolkit.Mvvm.SourceGenerators;
 
 /// <summary>
 /// A source generator for necessary nullability attributes.
 /// </summary>
-[Generator]
-public sealed class NullabilityAttributesGenerator : ISourceGenerator
+[Generator(LanguageNames.CSharp)]
+public sealed class NullabilityAttributesGenerator : IIncrementalGenerator
 {
-    /// <inheritdoc/>
-    public void Initialize(GeneratorInitializationContext context)
-    {
-    }
-
-    /// <inheritdoc/>
-    public void Execute(GeneratorExecutionContext context)
-    {
-        AddSourceCodeIfTypeIsNotPresent(context, "System.Diagnostics.CodeAnalysis.NotNullAttribute");
-        AddSourceCodeIfTypeIsNotPresent(context, "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute");
-    }
+    /// <summary>
+    /// The <c>System.Diagnostics.CodeAnalysis.NotNullAttribute</c> metadata name.
+    /// </summary>
+    private const string NotNullAttributeMetadataName = "System.Diagnostics.CodeAnalysis.NotNullAttribute";
 
     /// <summary>
-    /// Adds the source for a given attribute type if it's not present already in the compilation.
+    /// The <c>System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute</c> metadata name.
     /// </summary>
-    private void AddSourceCodeIfTypeIsNotPresent(GeneratorExecutionContext context, string typeFullName)
+    private const string NotNullIfNotNullAttributeMetadataName = "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute";
+
+    /// <inheritdoc/>
+    public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Check that the target attributes are not available in the consuming project. To ensure that
         // this works fine both in .NET (Core) and .NET Standard implementations, we also need to check
         // that the target types are declared as public (we assume that in this case those types are from the BCL).
         // This avoids issues on .NET Standard with Roslyn also seeing internal types from referenced assemblies.
-        if (context.Compilation.HasAccessibleTypeWithMetadataName(typeFullName))
-        {
-            return;
-        }
 
+        // Check whether [NotNull] is available
+        IncrementalValueProvider<bool> isNotNullAttributeAvailable =
+            context.CompilationProvider
+            .Select(static (item, _) => item.HasAccessibleTypeWithMetadataName(NotNullAttributeMetadataName));
+
+        // Generate the [NotNull] type
+        context.RegisterConditionalSourceOutput(isNotNullAttributeAvailable, static context =>
+        {
+            string source = LoadAttributeSourceWithMetadataName(NotNullAttributeMetadataName);
+
+            context.AddSource(NotNullAttributeMetadataName, source);
+        });
+
+        // Check whether [NotNullIfNotNull] is available
+        IncrementalValueProvider<bool> isNotNullIfNotNullAttributeAvailable =
+            context.CompilationProvider
+            .Select(static (item, _) => item.HasAccessibleTypeWithMetadataName(NotNullIfNotNullAttributeMetadataName));
+
+        // Generate the [NotNullIfNotNull] type
+        context.RegisterConditionalSourceOutput(isNotNullIfNotNullAttributeAvailable, static context =>
+        {
+            string source = LoadAttributeSourceWithMetadataName(NotNullIfNotNullAttributeMetadataName);
+
+            context.AddSource(NotNullIfNotNullAttributeMetadataName, source);
+        });
+    }
+
+    /// <summary>
+    /// Gets the generated source for a specified attribute.
+    /// </summary>
+    private static string LoadAttributeSourceWithMetadataName(string typeFullName)
+    {
         string typeName = typeFullName.Split('.').Last();
         string filename = $"CommunityToolkit.Mvvm.SourceGenerators.EmbeddedResources.{typeName}.cs";
 
         Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(filename);
         StreamReader reader = new(stream);
 
-        string source = reader.ReadToEnd();
-
-        context.AddSource($"{typeFullName}.cs", SourceText.From(source, Encoding.UTF8));
+        return reader.ReadToEnd();
     }
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
@@ -95,9 +95,7 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
             // Insert all members into the same partial type declaration
             CompilationUnitSyntax compilationUnit = item.Hierarchy.GetCompilationUnit(memberDeclarations);
 
-            context.AddSource(
-                hintName: $"{item.Hierarchy.FilenameHint}.cs",
-                sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+            context.AddSource(item.Hierarchy.FilenameHint, compilationUnit.ToFullString());
         });
 
         // Gather all property changing names
@@ -115,9 +113,7 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
 
             if (compilationUnit is not null)
             {
-                context.AddSource(
-                    hintName: "__KnownINotifyPropertyChangingArgs.cs",
-                    sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+                context.AddSource("__KnownINotifyPropertyChangingArgs", compilationUnit.ToFullString());
             }
         });
 
@@ -136,9 +132,7 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
 
             if (compilationUnit is not null)
             {
-                context.AddSource(
-                    hintName: "__KnownINotifyPropertyChangedArgs.cs",
-                    sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+                context.AddSource("__KnownINotifyPropertyChangedArgs", compilationUnit.ToFullString());
             }
         });
     }

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservableValidatorValidateAllPropertiesGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservableValidatorValidateAllPropertiesGenerator.cs
@@ -56,9 +56,7 @@ public sealed partial class ObservableValidatorValidateAllPropertiesGenerator : 
         {
             CompilationUnitSyntax compilationUnit = Execute.GetSyntax(item);
 
-            context.AddSource(
-                hintName: "__ObservableValidatorExtensions.cs",
-                sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+            context.AddSource("__ObservableValidatorExtensions", compilationUnit.ToFullString());
         });
 
         // Generate the class with all validation methods
@@ -66,9 +64,7 @@ public sealed partial class ObservableValidatorValidateAllPropertiesGenerator : 
         {
             CompilationUnitSyntax compilationUnit = Execute.GetSyntax(item);
 
-            context.AddSource(
-                hintName: $"{item.FilenameHint}.cs",
-                sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+            context.AddSource(item.FilenameHint, compilationUnit.ToFullString());
         });
     }
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/TransitiveMembersGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/TransitiveMembersGenerator.cs
@@ -124,9 +124,7 @@ public abstract partial class TransitiveMembersGenerator<TInfo> : IIncrementalGe
             ImmutableArray<MemberDeclarationSyntax> filteredMemberDeclarations = FilterDeclaredMembers(item.Info, sourceMemberDeclarations);
             CompilationUnitSyntax compilationUnit = item.Hierarchy.GetCompilationUnit(filteredMemberDeclarations, this.classDeclaration.BaseList);
 
-            context.AddSource(
-                hintName: $"{item.Hierarchy.FilenameHint}.cs",
-                sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+            context.AddSource(item.Hierarchy.FilenameHint, compilationUnit.ToFullString());
         });
     }
 

--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.cs
@@ -71,9 +71,7 @@ public sealed partial class ICommandGenerator : IIncrementalGenerator
             ImmutableArray<MemberDeclarationSyntax> memberDeclarations = Execute.GetSyntax(item.Info);
             CompilationUnitSyntax compilationUnit = item.Hierarchy.GetCompilationUnit(memberDeclarations);
 
-            context.AddSource(
-                hintName: $"{item.Hierarchy.FilenameHint}.{item.Info.MethodName}.cs",
-                sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+            context.AddSource($"{item.Hierarchy.FilenameHint}.{item.Info.MethodName}", compilationUnit.ToFullString());
         });
     }
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Messaging/IMessengerRegisterAllGenerator.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Messaging/IMessengerRegisterAllGenerator.cs
@@ -71,9 +71,7 @@ public sealed partial class IMessengerRegisterAllGenerator : IIncrementalGenerat
         {
             CompilationUnitSyntax compilationUnit = Execute.GetSyntax(item);
 
-            context.AddSource(
-                hintName: "__IMessengerExtensions.cs",
-                sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+            context.AddSource("__IMessengerExtensions", compilationUnit.ToFullString());
         });
 
         // Generate the class with all registration methods
@@ -81,9 +79,7 @@ public sealed partial class IMessengerRegisterAllGenerator : IIncrementalGenerat
         {
             CompilationUnitSyntax compilationUnit = Execute.GetSyntax(item);
 
-            context.AddSource(
-                hintName: $"{item.FilenameHint}.cs",
-                sourceText: SourceText.From(compilationUnit.ToFullString(), Encoding.UTF8));
+            context.AddSource(item.FilenameHint, compilationUnit.ToFullString());
         });
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #178**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions