### PR TITLE
Remove SpinLock extension taking an object

### DIFF
--- a/CommunityToolkit.HighPerformance/Extensions/SpinLockExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/SpinLockExtensions.cs
@@ -57,7 +57,7 @@ public static class SpinLockExtensions
         /// </summary>
         /// <param name="spinLock">The target <see cref="SpinLock"/> to use.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public UnsafeLock(SpinLock* spinLock)
+        internal UnsafeLock(SpinLock* spinLock)
         {
             this.spinLock = spinLock;
             this.lockTaken = false;
@@ -103,33 +103,6 @@ public static class SpinLockExtensions
     {
         return new(ref spinLock);
     }
-#else
-    /// <summary>
-    /// Enters a specified <see cref="SpinLock"/> instance and returns a wrapper to use to release the lock.
-    /// This extension should be used though a <see langword="using"/> block or statement:
-    /// <code>
-    /// private SpinLock spinLock = new SpinLock();
-    ///
-    /// public void Foo()
-    /// {
-    ///     using (SpinLockExtensions.Enter(this, ref spinLock))
-    ///     {
-    ///         // Thread-safe code here...
-    ///     }
-    /// }
-    /// </code>
-    /// The compiler will take care of releasing the SpinLock when the code goes out of that <see langword="using"/> scope.
-    /// </summary>
-    /// <param name="owner">The owner <see cref="object"/> to create a portable reference for.</param>
-    /// <param name="spinLock">The target <see cref="SpinLock"/> to use (it must be within <paramref name="owner"/>).</param>
-    /// <returns>A wrapper type that will release <paramref name="spinLock"/> when its <see cref="System.IDisposable.Dispose"/> method is called.</returns>
-    /// <remarks>The returned <see cref="Lock"/> value shouldn't be used directly: use this extension in a <see langword="using"/> block or statement.</remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Lock Enter(object owner, ref SpinLock spinLock)
-    {
-        return new(owner, ref spinLock);
-    }
-#endif
 
     /// <summary>
     /// A <see langword="struct"/> that is used to enter and hold a <see cref="SpinLock"/> through a <see langword="using"/> block or statement.
@@ -150,34 +123,18 @@ public static class SpinLockExtensions
         /// </summary>
         private readonly bool lockTaken;
 
-#if NETSTANDARD2_1_OR_GREATER
         /// <summary>
         /// Initializes a new instance of the <see cref="Lock"/> struct.
         /// </summary>
         /// <param name="spinLock">The target <see cref="SpinLock"/> to use.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Lock(ref SpinLock spinLock)
+        internal Lock(ref SpinLock spinLock)
         {
             this.spinLock = new Ref<SpinLock>(ref spinLock);
             this.lockTaken = false;
 
             spinLock.Enter(ref this.lockTaken);
         }
-#else
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Lock"/> struct.
-        /// </summary>
-        /// <param name="owner">The owner <see cref="object"/> to create a portable reference for.</param>
-        /// <param name="spinLock">The target <see cref="SpinLock"/> to use (it must be within <paramref name="owner"/>).</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Lock(object owner, ref SpinLock spinLock)
-        {
-            this.spinLock = new Ref<SpinLock>(owner, ref spinLock);
-            this.lockTaken = false;
-
-            spinLock.Enter(ref this.lockTaken);
-        }
-#endif
 
         /// <summary>
         /// Implements the duck-typed <see cref="System.IDisposable.Dispose"/> method and releases the current <see cref="SpinLock"/> instance.
@@ -191,4 +148,5 @@ public static class SpinLockExtensions
             }
         }
     }
+#endif
 }

--- a/CommunityToolkit.HighPerformance/Extensions/SpinLockExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/SpinLockExtensions.cs
@@ -4,7 +4,9 @@
 
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+#if NETSTANDARD2_1_OR_GREATER
 using System.Runtime.Versioning;
+#endif
 using System.Threading;
 
 namespace CommunityToolkit.HighPerformance;
@@ -48,7 +50,7 @@ public static class SpinLockExtensions
         private readonly SpinLock* spinLock;
 
         /// <summary>
-        /// A value indicating whether or not the lock is taken by this <see cref="Lock"/> instance.
+        /// A value indicating whether or not the lock is taken by this <see cref="UnsafeLock"/> instance.
         /// </summary>
         private readonly bool lockTaken;
 

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_SpinLockExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_SpinLockExtensions.cs
@@ -33,6 +33,7 @@ public class Test_SpinLockExtensions
         Assert.AreEqual(sum, 1000 * 10);
     }
 
+#if !NETFRAMEWORK
     [TestMethod]
     public void Test_ArrayExtensions_Ref()
     {
@@ -44,11 +45,7 @@ public class Test_SpinLockExtensions
         {
             for (int j = 0; j < 10; j++)
             {
-#if NETFRAMEWORK
-                using (SpinLockExtensions.Enter(spinLockOwner, ref spinLockOwner.Lock))
-#else
                 using (spinLockOwner.Lock.Enter())
-#endif
                 {
                     sum++;
                 }
@@ -57,6 +54,7 @@ public class Test_SpinLockExtensions
 
         Assert.AreEqual(sum, 1000 * 10);
     }
+#endif
 
     /// <summary>
     /// A dummy model that owns a <see cref="SpinLock"/> object.


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #182**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)entire description over that)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions