### PR TITLE
Change IndexOf APIs to return -1 if not found

### DIFF
--- a/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
@@ -208,7 +208,7 @@ public static class ReadOnlySpanExtensions
     /// <typeparam name="T">The type if items in the input <see cref="ReadOnlySpan{T}"/>.</typeparam>
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> to calculate the index for.</param>
     /// <param name="value">The reference to the target item to get the index for.</param>
-    /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>.</returns>
+    /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>, or <c>-1</c>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> does not belong to <paramref name="span"/>.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int IndexOf<T>(this ReadOnlySpan<T> span, in T value)
@@ -221,7 +221,7 @@ public static class ReadOnlySpanExtensions
 
         if ((nuint)elementOffset >= (uint)span.Length)
         {
-            SpanExtensions.ThrowArgumentOutOfRangeExceptionForInvalidReference();
+            return -1;
         }
 
         return (int)elementOffset;

--- a/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
@@ -209,7 +209,6 @@ public static class ReadOnlySpanExtensions
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> to calculate the index for.</param>
     /// <param name="value">The reference to the target item to get the index for.</param>
     /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>, or <c>-1</c>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> does not belong to <paramref name="span"/>.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int IndexOf<T>(this ReadOnlySpan<T> span, in T value)
     {

--- a/CommunityToolkit.HighPerformance/Extensions/SpanExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/SpanExtensions.cs
@@ -146,8 +146,7 @@ public static class SpanExtensions
     /// <typeparam name="T">The type if items in the input <see cref="Span{T}"/>.</typeparam>
     /// <param name="span">The input <see cref="Span{T}"/> to calculate the index for.</param>
     /// <param name="value">The reference to the target item to get the index for.</param>
-    /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> does not belong to <paramref name="span"/>.</exception>
+    /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>, or <c>-1</c>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int IndexOf<T>(this Span<T> span, ref T value)
     {
@@ -158,7 +157,7 @@ public static class SpanExtensions
 
         if ((nuint)elementOffset >= (uint)span.Length)
         {
-            ThrowArgumentOutOfRangeExceptionForInvalidReference();
+            return -1;
         }
 
         return (int)elementOffset;
@@ -275,13 +274,5 @@ public static class SpanExtensions
     public static bool TryCopyTo<T>(this Span<T> span, RefEnumerable<T> destination)
     {
         return destination.TryCopyFrom(span);
-    }
-
-    /// <summary>
-    /// Throws an <see cref="ArgumentOutOfRangeException"/> when the given reference is out of range.
-    /// </summary>
-    internal static void ThrowArgumentOutOfRangeExceptionForInvalidReference()
-    {
-        throw new ArgumentOutOfRangeException("value", "The input reference does not belong to an element of the input span");
     }
 }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.cs
@@ -98,19 +98,17 @@ public partial class Test_ReadOnlySpanExtensions
     {
         static void Test<T>()
         {
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    T? a = default;
+            T? a = default;
 
-                    _ = default(ReadOnlySpan<T?>).IndexOf(in a);
-                });
+            int indexOfA = default(ReadOnlySpan<T?>).IndexOf(in a);
 
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    ReadOnlySpan<T?> data = new T?[] { default };
+            Assert.AreEqual(-1, indexOfA);
 
-                    _ = data.Slice(1).IndexOf(in data[0]);
-                });
+            ReadOnlySpan<T?> data = new T?[] { default };
+
+            int indexOfData = data.Slice(1).IndexOf(in data[0]);
+
+            Assert.AreEqual(-1, indexOfData);
         }
 
         Test<byte>();
@@ -148,29 +146,27 @@ public partial class Test_ReadOnlySpanExtensions
         static void Test<T>()
         {
             // Before start
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    ReadOnlySpan<T?> data = new T?[] { default, default, default, default };
+            ReadOnlySpan<T?> data = new T?[] { default, default, default, default };
 
-                    _ = data.Slice(1).IndexOf(in data[0]);
-                });
+            int index = data.Slice(1).IndexOf(in data[0]);
+
+            Assert.AreEqual(-1, index);
 
             // After end
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    ReadOnlySpan<T?> data = new T?[] { default, default, default, default };
+            data = new T?[] { default, default, default, default };
 
-                    _ = data.Slice(0, 2).IndexOf(in data[2]);
-                });
+            index = data.Slice(0, 2).IndexOf(in data[2]);
+
+            Assert.AreEqual(-1, index);
 
             // Local variable
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    T?[]? dummy = new T?[] { default };
-                    ReadOnlySpan<T?> data = new T?[] { default, default, default, default };
+            T?[]? dummy = new T?[] { default };
 
-                    _ = data.IndexOf(in dummy[0]);
-                });
+             data = new T?[] { default, default, default, default };
+
+            index = data.IndexOf(in dummy[0]);
+
+            Assert.AreEqual(-1, index);
         }
 
         Test<byte>();

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_SpanExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_SpanExtensions.cs
@@ -51,19 +51,17 @@ public class Test_SpanExtensions
     {
         static void Test<T>()
         {
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    T? a = default;
+            T? a = default;
 
-                    _ = default(Span<T?>).IndexOf(ref a);
-                });
+            int indexOfA = default(Span<T?>).IndexOf(ref a);
 
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    Span<T?> data = new T?[] { default };
+            Assert.AreEqual(-1, indexOfA);
 
-                    _ = data.Slice(1).IndexOf(ref data[0]);
-                });
+            Span<T?> data = new T?[] { default };
+
+            int indexOfData = data.Slice(1).IndexOf(ref data[0]);
+
+            Assert.AreEqual(-1, indexOfData);
         }
 
         Test<byte>();
@@ -101,29 +99,27 @@ public class Test_SpanExtensions
         static void Test<T>()
         {
             // Before start
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    Span<T?> data = new T?[] { default, default, default, default };
+            Span<T?> data = new T?[] { default, default, default, default };
 
-                    _ = data.Slice(1).IndexOf(ref data[0]);
-                });
+            int index = data.Slice(1).IndexOf(ref data[0]);
+
+            Assert.AreEqual(-1, index);
 
             // After end
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    Span<T?> data = new T?[] { default, default, default, default };
+            data = new T?[] { default, default, default, default };
 
-                    _ = data.Slice(0, 2).IndexOf(ref data[2]);
-                });
+            index = data.Slice(0, 2).IndexOf(ref data[2]);
+
+            Assert.AreEqual(-1, index);
 
             // Local variable
-            _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                {
-                    T?[]? dummy = new T?[] { default };
-                    Span<T?> data = new T?[] { default, default, default, default };
+            T?[]? dummy = new T?[] { default };
 
-                    _ = data.IndexOf(ref dummy[0]);
-                });
+            data = new T?[] { default, default, default, default };
+
+            index = data.IndexOf(ref dummy[0]);
+
+            Assert.AreEqual(-1, index);
         }
 
         Test<byte>();


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #189**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)entire description over that)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions