### PR TITLE
Match methods/checks added to the Guard.

### DIFF
--- a/CommunityToolkit.Diagnostics/Guard.String.cs
+++ b/CommunityToolkit.Diagnostics/Guard.String.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 #pragma warning disable CS8777
 
@@ -331,5 +332,47 @@ partial class Guard
         }
 
         ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, text, name);
+    }
+
+
+
+
+    /// <summary>
+    /// Asserts that the <paramref name="regexPattern" /> is matched.
+    /// </summary> 
+    /// <param name="value">The input <see cref="string"/> value to test.</param>
+    /// <param name="regexPattern">The Regular expression which must be matched by the <typeparamref name="T" />.</param>
+    /// <param name="name">The name of the input parameter being tested.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> does not match <paramref name="regexPattern"/>.</exception>
+    /// <remarks>The method is generic to prevent using it with value types.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Match(string value, string regexPattern, [CallerArgumentExpression("value")] string name = "")
+    {
+        if (Regex.IsMatch(value, regexPattern))
+        {
+            return;
+        }
+
+        ThrowHelper.ThrowArgumentExceptionForMatch<string>(name);
+    }
+
+
+    /// <summary>
+    /// Asserts that the <paramref name="regexPattern" /> is not matched.
+    /// </summary>  
+    /// <param name="value">The input <see cref="string"/> value to test.</param>
+    /// <param name="regexPattern">The Regular expression which must be not matched by the <typeparamref name="T" />.</param>
+    /// <param name="name">The name of the input parameter being tested.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> match <paramref name="regexPattern"/>.</exception>
+    /// <remarks>The method is generic to prevent using it with value types.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void NotMatch(string value, string regexPattern, [CallerArgumentExpression("value")] string name = "")
+    {
+        if (!Regex.IsMatch(value, regexPattern))
+        {
+            return;
+        }
+
+        ThrowHelper.ThrowArgumentExceptionForNotMatch<string>(name);
     }
 }

--- a/CommunityToolkit.Diagnostics/Guard.cs
+++ b/CommunityToolkit.Diagnostics/Guard.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
 namespace CommunityToolkit.Diagnostics;
@@ -274,4 +275,49 @@ public static partial class Guard
 
         ThrowHelper.ThrowArgumentExceptionForIsReferenceNotEqualTo<T>(name);
     }
+
+
+    /// <summary>
+    /// Asserts that the <paramref name="predicate" /> is satisfied.
+    /// </summary>
+    /// <typeparam name="T">The type of input values to compare.</typeparam>
+    /// <param name="value">The input <typeparamref name="T"/> value to test.</param>
+    /// <param name="predicate">The predicate which must be satisfied by the <typeparamref name="T" />.</param>
+    /// <param name="name">The name of the input parameter being tested.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> does not satisfy <paramref name="predicate"/>.</exception>
+    /// <remarks>The method is generic to prevent using it with value types.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Match<T>(T value, Expression<Func<T, bool>> predicate, [CallerArgumentExpression("value")] string name = "")
+        where T : class
+    {
+        if (predicate.Compile()(value))
+        {
+            return;
+        }
+
+        ThrowHelper.ThrowArgumentExceptionForMatch<T>(name);
+    }
+
+
+    /// <summary>
+    /// Asserts that the <paramref name="predicate" /> is not satisfied.
+    /// </summary>
+    /// <typeparam name="T">The type of input values to compare.</typeparam>
+    /// <param name="value">The input <typeparamref name="T"/> value to test.</param>
+    /// <param name="predicate">The predicate which must be not satisfied by the <typeparamref name="T" />.</param>
+    /// <param name="name">The name of the input parameter being tested.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> satisfys <paramref name="predicate"/>.</exception>
+    /// <remarks>The method is generic to prevent using it with value types.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void NotMatch<T>(T value, Expression<Func<T, bool>> predicate, [CallerArgumentExpression("value")] string name = "")
+        where T : class
+    {
+        if (!predicate.Compile()(value))
+        {
+            return;
+        }
+
+        ThrowHelper.ThrowArgumentExceptionForNotMatch<T>(name);
+    }
+
 }

--- a/CommunityToolkit.Diagnostics/Internals/Guard.ThrowHelper.cs
+++ b/CommunityToolkit.Diagnostics/Internals/Guard.ThrowHelper.cs
@@ -162,6 +162,28 @@ partial class Guard
         }
 
         /// <summary>
+        /// Throws an <see cref="ArgumentException"/> when <see cref="Match{T}"/> fails.
+        /// </summary>
+        /// <typeparam name="T">The type of input value being compared.</typeparam>
+        [DoesNotReturn]
+        public static void ThrowArgumentExceptionForMatch<T>(string name)
+            where T : class
+        {
+            throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must match the predicate/patterns.", name);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> when <see cref="NotMatch{T}"/> fails.
+        /// </summary>
+        /// <typeparam name="T">The type of input value being compared.</typeparam>
+        [DoesNotReturn]
+        public static void ThrowArgumentExceptionForNotMatch<T>(string name)
+            where T : class
+        {
+            throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not match the predicate/patterns.", name);
+        }
+
+        /// <summary>
         /// Throws an <see cref="ArgumentException"/> when <see cref="IsTrue(bool,string)"/> fails.
         /// </summary>
         [DoesNotReturn]

--- a/tests/CommunityToolkit.Diagnostics.UnitTests/Test_Guard.cs
+++ b/tests/CommunityToolkit.Diagnostics.UnitTests/Test_Guard.cs
@@ -344,6 +344,67 @@ public partial class Test_Guard
     }
 
     [TestMethod]
+    public void Test_Guard_Match_Ok()
+    {
+        SomeClass subject = new() { Number = 5 };
+
+        Guard.Match(subject, s => s.Number == 5, nameof(Test_Guard_Match_Ok));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Test_Guard_Match_Fail()
+    {
+        SomeClass subject = new() { Number = 15 };
+
+        Guard.Match(subject, s => s.Number == 5, nameof(Test_Guard_Match_Fail));
+    }
+
+    [TestMethod]
+    public void Test_Guard_NotMatch_Ok()
+    {
+        SomeClass subject = new() { Number = 15 };
+
+        Guard.NotMatch(subject, s => s.Number == 5, nameof(Test_Guard_NotMatch_Ok));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Test_Guard_NotMatch_Fail()
+    {
+        SomeClass subject = new() { Number = 5 };
+
+        Guard.NotMatch(subject, s => s.Number == 5, nameof(Test_Guard_NotMatch_Fail));
+    }
+
+
+    [TestMethod]
+    public void Test_Guard_Match_Pattern_Ok()
+    {
+        Guard.Match("I love .NET", "^I.*T$", nameof(Test_Guard_Match_Pattern_Ok));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Test_Guard_Match_Pattern_Fail()
+    {
+        Guard.Match("I love .NET!", "^I.*T$", nameof(Test_Guard_Match_Pattern_Fail));
+    }
+
+    [TestMethod]
+    public void Test_Guard_NotMatch_Pattern_Ok()
+    {
+        Guard.NotMatch("I love .NET!", "^I.*T$", nameof(Test_Guard_NotMatch_Pattern_Ok));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Test_Guard_NotMatch_Pattern_Fail()
+    {
+        Guard.NotMatch("I love .NET", "^I.*T$", nameof(Test_Guard_NotMatch_Pattern_Fail));
+    }
+
+    [TestMethod]
     public void Test_Guard_IsTrue_Ok()
     {
         Guard.IsTrue(true, nameof(Test_Guard_IsTrue_Ok));
@@ -801,5 +862,12 @@ public partial class Test_Guard
         }
 
         Assert.Fail();
+    }
+
+    internal class SomeClass
+    {
+        public string Text { get; set; }
+
+        public int Number { get; set; }
     }
 }


### PR DESCRIPTION
# New check Methods
## Object -> Match\<T>: 
Asserts that the predicate is satisfied.

```csharp
 public static void Match<T>(T value, Expression<Func<T, bool>> predicate, [CallerArgumentExpression("value")] string name = "")
```

## Object -> NotMatch\<T>: 
Asserts that the predicate is not satisfied.

```csharp
 public static void NotMatch<T>(T value, Expression<Func<T, bool>> predicate, [CallerArgumentExpression("value")] string name = "")
```

## String -> Match: 
Asserts that the regular expression is matched.

```csharp
public static void Match(string value, string regexPattern, [CallerArgumentExpression("value")] string name = "")
```

## String -> NotMatch: 
Asserts that the regular expression is not matched.

```csharp
public static void NotMatch(string value, string regexPattern, [CallerArgumentExpression("value")] string name = "")
```


