### PR TITLE
Add EnsureCapacity to ArrayPoolExtensions

### DIFF
--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayPoolExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayPoolExtensions.cs
@@ -87,4 +87,73 @@ public class Test_ArrayPoolExtensions
         Assert.AreNotSame(array, backup);
         Assert.IsTrue(backup.AsSpan(0, 16).ToArray().All(i => i == 0));
     }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentOutOfRangeException))]
+    public void Test_ArrayPoolExtensions_EnsureCapacity_InvalidCapacity()
+    {
+        int[]? array = null;
+
+        ArrayPool<int>.Shared.EnsureCapacity(ref array, -1);
+    }
+
+    [TestMethod]
+    public void Test_ArrayPoolExtensions_EnsureCapacity_IdenticalCapacity()
+    {
+        int[]? array = ArrayPool<int>.Shared.Rent(10);
+        int[]? backup = array;
+
+        ArrayPool<int>.Shared.EnsureCapacity(ref array, 10);
+        Assert.AreSame(backup, array);
+        Assert.IsTrue(array.Length >= 10);
+    }
+
+    [TestMethod]
+    public void Test_ArrayPoolExtensions_EnsureCapacity_NewArray()
+    {
+        int[]? array = null;
+
+        ArrayPool<int>.Shared.EnsureCapacity(ref array, 7);
+
+        Assert.IsNotNull(array);
+        Assert.IsTrue(array.Length >= 7);
+        int[]? backup = array;
+
+        ArrayPool<int>.Shared.EnsureCapacity(ref array, 64);
+
+        Assert.AreNotSame(backup, array);
+        Assert.IsTrue(array.Length >= 64);
+    }
+
+    [TestMethod]
+    public void Test_ArrayPoolExtensions_EnsureCapacity_SufficientCapacity()
+    {
+        int[]? array = ArrayPool<int>.Shared.Rent(16);
+        int[]? backup = array;
+
+        ArrayPool<int>.Shared.EnsureCapacity(ref array, 8);
+        Assert.AreSame(backup, array);
+
+        ArrayPool<int>.Shared.EnsureCapacity(ref array, 16);
+        Assert.AreSame(backup, array);
+
+        ArrayPool<int>.Shared.EnsureCapacity(ref array, 0);
+        Assert.AreSame(backup, array);
+    }
+
+    [TestMethod]
+    public void Test_ArrayPoolExtensions_EnsureCapacity_ClearArray()
+    {
+        int[]? array = ArrayPool<int>.Shared.Rent(16);
+        int[]? backup = array;
+
+        array.AsSpan().Fill(7);
+        Assert.IsTrue(backup.All(i => i == 7));
+
+        ArrayPool<int>.Shared.EnsureCapacity(ref array, 256, true);
+
+        Assert.AreNotSame(backup, array);
+        Assert.IsTrue(backup.All(i => i == default));
+        Assert.IsTrue(array.Length >= 256);
+    }
 }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayPoolExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayPoolExtensions.cs
@@ -15,7 +15,7 @@ public class Test_ArrayPoolExtensions
 {
     [TestMethod]
     [ExpectedException(typeof(ArgumentOutOfRangeException))]
-    public void Test_ArrayExtensions_InvalidSize()
+    public void Test_ArrayPoolExtensions_Resize_InvalidSize()
     {
         int[]? array = null;
 
@@ -23,7 +23,7 @@ public class Test_ArrayPoolExtensions
     }
 
     [TestMethod]
-    public void Test_ArrayExtensions_NewArray()
+    public void Test_ArrayPoolExtensions_Resize_NewArray()
     {
         int[]? array = null;
 
@@ -34,7 +34,7 @@ public class Test_ArrayPoolExtensions
     }
 
     [TestMethod]
-    public void Test_ArrayExtensions_SameSize()
+    public void Test_ArrayPoolExtensions_Resize_SameSize()
     {
         int[] array = ArrayPool<int>.Shared.Rent(10);
         int[] backup = array;
@@ -45,7 +45,7 @@ public class Test_ArrayPoolExtensions
     }
 
     [TestMethod]
-    public void Test_ArrayExtensions_Expand()
+    public void Test_ArrayPoolExtensions_Resize_Expand()
     {
         int[] array = ArrayPool<int>.Shared.Rent(16);
         int[] backup = array;
@@ -60,7 +60,7 @@ public class Test_ArrayPoolExtensions
     }
 
     [TestMethod]
-    public void Test_ArrayExtensions_Shrink()
+    public void Test_ArrayPoolExtensions_Resize_Shrink()
     {
         int[] array = ArrayPool<int>.Shared.Rent(32);
         int[] backup = array;
@@ -75,7 +75,7 @@ public class Test_ArrayPoolExtensions
     }
 
     [TestMethod]
-    public void Test_ArrayExtensions_Clear()
+    public void Test_ArrayPoolExtensions_Resize_Clear()
     {
         int[] array = ArrayPool<int>.Shared.Rent(16);
         int[] backup = array;


### PR DESCRIPTION
**Closes #191**

Implements an extension `EnsureCapacity` for `ArrayPool<T>` that ensures that an array is not null and has a minimum length. Documentation closely mirrors the existing `Resize`-method for consistency. The only difference to the original proposal is the range check for `capacity`, as requested.

~~Added `[DoesNotReturn]` "polyfill" for under NETSTANDARD2.1. This isn't critical and can be removed if deemed not to be worth it.~~

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

Renamed weird/outdated test method names for existing `ArrayPoolExtensions.Resize`-tests so new tests fit in better.