### PR TITLE
Fix incorrect MVVMTK0015 with inherited members

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -187,13 +187,13 @@ partial class ObservablePropertyGenerator
             // Validates a property name using existing properties
             bool IsPropertyNameValid(string propertyName)
             {
-                return fieldSymbol.ContainingType.GetMembers(propertyName).OfType<IPropertySymbol>().Any();
+                return fieldSymbol.ContainingType.GetAllMembers(propertyName).OfType<IPropertySymbol>().Any();
             }
 
             // Validate a property name including generated properties too
             bool IsPropertyNameValidWithGeneratedMembers(string propertyName)
             {
-                foreach (ISymbol member in fieldSymbol.ContainingType.GetMembers())
+                foreach (ISymbol member in fieldSymbol.ContainingType.GetAllMembers())
                 {
                     if (member is IFieldSymbol otherFieldSymbol &&
                         !SymbolEqualityComparer.Default.Equals(fieldSymbol, otherFieldSymbol) &&
@@ -256,7 +256,7 @@ partial class ObservablePropertyGenerator
             {
                 // Each target must be a string matching the name of a property from the containing type of the annotated field, and the
                 // property must be of type IRelayCommand, or any type that implements that interface (to avoid generating invalid code).
-                if (fieldSymbol.ContainingType.GetMembers(commandName).OfType<IPropertySymbol>().FirstOrDefault() is IPropertySymbol propertySymbol)
+                if (fieldSymbol.ContainingType.GetAllMembers(commandName).OfType<IPropertySymbol>().FirstOrDefault() is IPropertySymbol propertySymbol)
                 {
                     // If there is a property member with the specified name, check that it's valid. If it isn't, the
                     // target is definitely not valid, and the additional checks below can just be skipped. The property
@@ -285,7 +285,7 @@ partial class ObservablePropertyGenerator
             // Validate a command name including generated command too
             bool IsCommandNameValidWithGeneratedMembers(string commandName)
             {
-                foreach (ISymbol member in fieldSymbol.ContainingType.GetMembers())
+                foreach (ISymbol member in fieldSymbol.ContainingType.GetAllMembers())
                 {
                     if (member is IMethodSymbol methodSymbol &&
                         methodSymbol.HasAttributeWithFullyQualifiedName("global::CommunityToolkit.Mvvm.Input.ICommandAttribute") &&

--- a/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -200,8 +200,6 @@ partial class ObservablePropertyGenerator
                         otherFieldSymbol.HasAttributeWithFullyQualifiedName("global::CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") &&
                         propertyName == GetGeneratedPropertyName(otherFieldSymbol))
                     {
-                        propertyChangedNames.Add(propertyName);
-
                         return true;
                     }
                 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Extensions/INamedTypeSymbolExtensions.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Extensions/INamedTypeSymbolExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -38,5 +39,38 @@ internal static class INamedTypeSymbolExtensions
         // to avoid errors when generating code. This is a known issue with source generators not accepting
         // those characters at the moment, see: https://github.com/dotnet/roslyn/issues/58476.
         return BuildFrom(symbol, new StringBuilder(256)).ToString().Replace('`', '-').Replace('+', '.');
+    }
+
+    /// <summary>
+    /// Gets all member symbols from a given <see cref="INamedTypeSymbol"/> instance, including inherited ones.
+    /// </summary>
+    /// <param name="symbol">The input <see cref="INamedTypeSymbol"/> instance.</param>
+    /// <returns>A sequence of all member symbols for <paramref name="symbol"/>.</returns>
+    public static IEnumerable<ISymbol> GetAllMembers(this INamedTypeSymbol symbol)
+    {
+        for (INamedTypeSymbol? currentSymbol = symbol; currentSymbol is { SpecialType: not SpecialType.System_Object }; currentSymbol = currentSymbol.BaseType)
+        {
+            foreach (ISymbol memberSymbol in currentSymbol.GetMembers())
+            {
+                yield return memberSymbol;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets all member symbols from a given <see cref="INamedTypeSymbol"/> instance, including inherited ones.
+    /// </summary>
+    /// <param name="symbol">The input <see cref="INamedTypeSymbol"/> instance.</param>
+    /// <param name="name">The name of the members to look for.</param>
+    /// <returns>A sequence of all member symbols for <paramref name="symbol"/>.</returns>
+    public static IEnumerable<ISymbol> GetAllMembers(this INamedTypeSymbol symbol, string name)
+    {
+        for (INamedTypeSymbol? currentSymbol = symbol; currentSymbol is not null; currentSymbol = currentSymbol.BaseType)
+        {
+            foreach (ISymbol memberSymbol in currentSymbol.GetMembers(name))
+            {
+                yield return memberSymbol;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #201**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions