### PR TITLE
Fix generation of nested types that are not classes

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/Models/HierarchyInfo.Syntax.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Models/HierarchyInfo.Syntax.cs
@@ -30,28 +30,26 @@ partial record HierarchyInfo
         // Create the partial type declaration with the given member declarations.
         // This code produces a class declaration as follows:
         //
-        // partial class <TYPE_NAME>
+        // partial <TYPE_KIND> TYPE_NAME>
         // {
         //     <MEMBERS>
         // }
-        ClassDeclarationSyntax classDeclarationSyntax =
-            ClassDeclaration(Names[0])
+        TypeDeclarationSyntax typeDeclarationSyntax =
+            Hierarchy[0].GetSyntax()
             .AddModifiers(Token(SyntaxKind.PartialKeyword))
             .AddMembers(memberDeclarations.ToArray());
 
         // Add the base list, if present
         if (baseList is not null)
         {
-            classDeclarationSyntax = classDeclarationSyntax.WithBaseList(baseList);
+            typeDeclarationSyntax = typeDeclarationSyntax.WithBaseList(baseList);
         }
 
-        TypeDeclarationSyntax typeDeclarationSyntax = classDeclarationSyntax;
-
         // Add all parent types in ascending order, if any
-        foreach (string parentType in Names.AsSpan().Slice(1))
+        foreach (TypeInfo parentType in Hierarchy.AsSpan().Slice(1))
         {
             typeDeclarationSyntax =
-                ClassDeclaration(parentType)
+                parentType.GetSyntax()
                 .AddModifiers(Token(SyntaxKind.PartialKeyword))
                 .AddMembers(typeDeclarationSyntax);
         }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Models/HierarchyInfo.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Models/HierarchyInfo.cs
@@ -40,7 +40,8 @@ internal sealed partial record HierarchyInfo(string FilenameHint, string Metadat
         {
             hierarchy.Add(new TypeInfo(
                 parent.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                parent.TypeKind));
+                parent.TypeKind,
+                parent.IsRecord));
         }
 
         return new(

--- a/CommunityToolkit.Mvvm.SourceGenerators/Models/HierarchyInfo.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Models/HierarchyInfo.cs
@@ -22,8 +22,8 @@ namespace CommunityToolkit.Mvvm.SourceGenerators.Models;
 /// <param name="FilenameHint">The filename hint for the current type.</param>
 /// <param name="MetadataName">The metadata name for the current type.</param>
 /// <param name="Namespace">Gets the namespace for the current type.</param>
-/// <param name="Names">Gets the sequence of type definitions containing the current type.</param>
-internal sealed partial record HierarchyInfo(string FilenameHint, string MetadataName, string Namespace, ImmutableArray<string> Names)
+/// <param name="Hierarchy">Gets the sequence of type definitions containing the current type.</param>
+internal sealed partial record HierarchyInfo(string FilenameHint, string MetadataName, string Namespace, ImmutableArray<TypeInfo> Hierarchy)
 {
     /// <summary>
     /// Creates a new <see cref="HierarchyInfo"/> instance from a given <see cref="INamedTypeSymbol"/>.
@@ -32,20 +32,22 @@ internal sealed partial record HierarchyInfo(string FilenameHint, string Metadat
     /// <returns>A <see cref="HierarchyInfo"/> instance describing <paramref name="typeSymbol"/>.</returns>
     public static HierarchyInfo From(INamedTypeSymbol typeSymbol)
     {
-        ImmutableArray<string>.Builder names = ImmutableArray.CreateBuilder<string>();
+        ImmutableArray<TypeInfo>.Builder hierarchy = ImmutableArray.CreateBuilder<TypeInfo>();
 
         for (INamedTypeSymbol? parent = typeSymbol;
              parent is not null;
              parent = parent.ContainingType)
         {
-            names.Add(parent.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+            hierarchy.Add(new TypeInfo(
+                parent.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                parent.TypeKind));
         }
 
         return new(
             typeSymbol.GetFullMetadataNameForFileName(),
             typeSymbol.MetadataName,
             typeSymbol.ContainingNamespace.ToDisplayString(new(typeQualificationStyle: NameAndContainingTypesAndNamespaces)),
-            names.ToImmutable());
+            hierarchy.ToImmutable());
     }
 
     /// <summary>
@@ -59,7 +61,7 @@ internal sealed partial record HierarchyInfo(string FilenameHint, string Metadat
             hashCode.Add(obj.FilenameHint);
             hashCode.Add(obj.MetadataName);
             hashCode.Add(obj.Namespace);
-            hashCode.AddRange(obj.Names);
+            hashCode.AddRange(obj.Hierarchy);
         }
 
         /// <inheritdoc/>
@@ -69,7 +71,7 @@ internal sealed partial record HierarchyInfo(string FilenameHint, string Metadat
                 x.FilenameHint == y.FilenameHint &&
                 x.MetadataName == y.MetadataName &&
                 x.Namespace == y.Namespace &&
-                x.Names.SequenceEqual(y.Names);
+                x.Hierarchy.SequenceEqual(y.Hierarchy);
         }
     }
 }

--- a/CommunityToolkit.Mvvm.SourceGenerators/Models/TypeInfo.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Models/TypeInfo.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators.Models;
+
+/// <summary>
+/// A model describing a type info in a type hierarchy.
+/// </summary>
+/// <param name="QualifiedName">The qualified name for the type.</param>
+/// <param name="Kind">The type of the type in the hierarchy.</param>
+internal sealed record TypeInfo(string QualifiedName, TypeKind Kind)
+{
+    /// <summary>
+    /// Creates a <see cref="TypeDeclarationSyntax"/> instance for the current info.
+    /// </summary>
+    /// <returns>A <see cref="TypeDeclarationSyntax"/> instance for the current info.</returns>
+    public TypeDeclarationSyntax GetSyntax()
+    {
+        // Create the partial type declaration with the kind.
+        // This code produces a class declaration as follows:
+        //
+        // <TYPE_KIND> <TYPE_NAME>
+        // {
+        // }
+        return Kind switch
+        {
+            TypeKind.Struct => StructDeclaration(QualifiedName),
+            TypeKind.Interface => InterfaceDeclaration(QualifiedName),
+            _ => ClassDeclaration(QualifiedName)
+        };
+    }
+}

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_SourceGenerators.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_SourceGenerators.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel.DataAnnotations;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommunityToolkit.Mvvm.UnitTests;
+
+/// <summary>
+/// This class contains general unit tests for source generators, without a specific dependency on one.
+/// For instance, this can be used for tests that validate common generation helpers used by all generators.
+/// </summary>
+[TestClass]
+public partial class Test_SourceGenerators
+{
+    [TestMethod]
+    public void Test_SourceGenerators_NestedTypesThatAreNotJustClasses()
+    {
+        // This test just needs to compile, mostly
+        NestedStructType.NestedInterfaceType.MyViewModel model = new();
+
+        Assert.IsNull(model.Name);
+        Assert.IsTrue(model.TestCommand is IRelayCommand);
+    }
+
+    public partial struct NestedStructType
+    {
+        public partial interface NestedInterfaceType
+        {
+            [ObservableRecipient]
+            public partial class MyViewModel : ObservableValidator
+            {
+                [ObservableProperty]
+                [Required]
+                private string? name;
+
+                [ICommand]
+                private void Test()
+                {
+                }
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Test_SourceGenerators_NestedTypesThatAreNotJustClassesAndWithGenerics()
+    {
+        // This test just needs to compile, mostly
+        NestedStructTypeWithGenerics<int, float>.NestedInterfaceType<string>.MyViewModel model = new();
+
+        Assert.IsNull(model.Name);
+        Assert.IsTrue(model.TestCommand is IRelayCommand);
+    }
+
+    public partial struct NestedStructTypeWithGenerics<T1, T2>
+        where T2 : struct
+    {
+        public partial interface NestedInterfaceType<TFoo>
+        {
+            [INotifyPropertyChanged]
+            public partial class MyViewModel
+            {
+                [ObservableProperty]
+                private string? name;
+
+                [ICommand]
+                private void Test()
+                {
+                }
+            }
+        }
+    }
+}

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_SourceGenerators.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_SourceGenerators.cs
@@ -20,7 +20,7 @@ public partial class Test_SourceGenerators
     public void Test_SourceGenerators_NestedTypesThatAreNotJustClasses()
     {
         // This test just needs to compile, mostly
-        NestedStructType.NestedInterfaceType.MyViewModel model = new();
+        NestedStructType.NestedInterfaceType.NestedRecord.MyViewModel model = new();
 
         Assert.IsNull(model.Name);
         Assert.IsTrue(model.TestCommand is IRelayCommand);
@@ -30,16 +30,19 @@ public partial class Test_SourceGenerators
     {
         public partial interface NestedInterfaceType
         {
-            [ObservableRecipient]
-            public partial class MyViewModel : ObservableValidator
+            public partial record NestedRecord
             {
-                [ObservableProperty]
-                [Required]
-                private string? name;
-
-                [ICommand]
-                private void Test()
+                [ObservableRecipient]
+                public partial class MyViewModel : ObservableValidator
                 {
+                    [ObservableProperty]
+                    [Required]
+                    private string? name;
+
+                    [ICommand]
+                    private void Test()
+                    {
+                    }
                 }
             }
         }
@@ -49,7 +52,7 @@ public partial class Test_SourceGenerators
     public void Test_SourceGenerators_NestedTypesThatAreNotJustClassesAndWithGenerics()
     {
         // This test just needs to compile, mostly
-        NestedStructTypeWithGenerics<int, float>.NestedInterfaceType<string>.MyViewModel model = new();
+        NestedStructTypeWithGenerics<int, float>.NestedInterfaceType<string>.NestedRecord<string>.MyViewModel model = new();
 
         Assert.IsNull(model.Name);
         Assert.IsTrue(model.TestCommand is IRelayCommand);
@@ -60,15 +63,18 @@ public partial class Test_SourceGenerators
     {
         public partial interface NestedInterfaceType<TFoo>
         {
-            [INotifyPropertyChanged]
-            public partial class MyViewModel
+            public partial record NestedRecord<TBar>
             {
-                [ObservableProperty]
-                private string? name;
-
-                [ICommand]
-                private void Test()
+                [INotifyPropertyChanged]
+                public partial class MyViewModel
                 {
+                    [ObservableProperty]
+                    private string? name;
+
+                    [ICommand]
+                    private void Test()
+                    {
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #210**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions