### PR TITLE
Ensure `Task` is `await`'d in `AsyncRelayCommand` and `AsyncRelayCommand<T>`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,6 @@ msbuild.binlog
 # TAEF Log output
 WexLogFileOutput
 *.wtl
+
+#macOS Temporary Files
+*.DS_Store

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -277,9 +277,9 @@ public sealed class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCo
     }
 
     /// <inheritdoc/>
-    public void Execute(object? parameter)
+    public async void Execute(object? parameter)
     {
-        _ = ExecuteAsync(parameter);
+        await ExecuteAsync(parameter).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -214,7 +214,7 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
                 {
                     @this.PropertyChanged?.Invoke(@this, AsyncRelayCommand.ExecutionTaskChangedEventArgs);
                     @this.PropertyChanged?.Invoke(@this, AsyncRelayCommand.IsRunningChangedEventArgs);
-                    
+
                     if (@this.cancellationTokenSource is not null)
                     {
                         @this.PropertyChanged?.Invoke(@this, AsyncRelayCommand.CanBeCanceledChangedEventArgs);
@@ -273,15 +273,15 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Execute(T? parameter)
+    public async void Execute(T? parameter)
     {
-        _ = ExecuteAsync(parameter);
+        await ExecuteAsync(parameter).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public void Execute(object? parameter)
+    public async void Execute(object? parameter)
     {
-        _ = ExecuteAsync((T?)parameter);
+        await ExecuteAsync((T?)parameter).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/CommunityToolkit.Mvvm.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/CommunityToolkit.Mvvm.UnitTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -510,7 +510,7 @@ public class Test_AsyncRelayCommand
         const int delay = 500;
         const string exceptionMessage = "This Exception Is Thrown Inside of the Task";
 
-        Exception? executeException = null;
+        Exception? executeException = null, executeAsyncException = null;
 
         AsyncRelayCommand command = new(async () =>
         {
@@ -532,7 +532,7 @@ public class Test_AsyncRelayCommand
             executeException = e;
         }
 
-        Exception? executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(null));
+        executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(null));
 
         Assert.AreEqual(exceptionMessage, executeException?.Message);
         Assert.AreEqual(exceptionMessage, executeAsyncException?.Message);

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -506,13 +506,20 @@ public class Test_AsyncRelayCommand
     [TestMethod]
     public void Test_AsyncRelayCommand_EnsureExceptionThrown()
     {
+        const int delay = 500;
+
         AsyncRelayCommand command = new(async () =>
         {
-            await Task.Delay(500);
+            await Task.Delay(delay);
             throw new Exception("This Exception Is Thrown Inside of the Task");
         });
 
-        Assert.ThrowsException<Exception>(() => command.Execute(null));
+        Assert.ThrowsExceptionAsync<Exception>(async () =>
+        {
+            command.Execute(null);
+            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
+        });
+
         Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(null));
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -504,22 +504,26 @@ public class Test_AsyncRelayCommand
     }
 
     [TestMethod]
-    public void Test_AsyncRelayCommand_EnsureExceptionThrown()
+    public async Task Test_AsyncRelayCommand_EnsureExceptionThrown()
     {
         const int delay = 500;
+        const string exceptionMessage = "This Exception Is Thrown Inside of the Task";
 
         AsyncRelayCommand command = new(async () =>
         {
             await Task.Delay(delay);
-            throw new Exception("This Exception Is Thrown Inside of the Task");
+            throw new Exception(exceptionMessage);
         });
 
-        Assert.ThrowsExceptionAsync<Exception>(async () =>
+        Exception? executeException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
         {
             command.Execute(null);
             await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
         });
 
-        Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(null));
+        Exception? executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(null));
+
+        Assert.AreEqual(exceptionMessage, executeException.Message);
+        Assert.AreEqual(exceptionMessage, executeAsyncException.Message);
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -515,8 +515,15 @@ public class Test_AsyncRelayCommand
             throw new Exception(exceptionMessage);
         });
 
+        Exception? executeException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
+        {
+            command.Execute(null);
+            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
+        });
+
         Exception? executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(null));
 
+        Assert.AreEqual(exceptionMessage, executeException.Message);
         Assert.AreEqual(exceptionMessage, executeAsyncException.Message);
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -515,15 +515,8 @@ public class Test_AsyncRelayCommand
             throw new Exception(exceptionMessage);
         });
 
-        Exception? executeException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
-        {
-            command.Execute(null);
-            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
-        });
-
         Exception? executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(null));
 
-        Assert.AreEqual(exceptionMessage, executeException.Message);
         Assert.AreEqual(exceptionMessage, executeAsyncException.Message);
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand.cs
@@ -502,4 +502,17 @@ public class Test_AsyncRelayCommand
         Assert.IsFalse(command.CanBeCanceled);
         Assert.IsTrue(command.IsCancellationRequested);
     }
+
+    [TestMethod]
+    public void Test_AsyncRelayCommand_EnsureExceptionThrown()
+    {
+        AsyncRelayCommand command = new(async () =>
+        {
+            await Task.Delay(500);
+            throw new Exception("This Exception Is Thrown Inside of the Task");
+        });
+
+        Assert.ThrowsException<Exception>(() => command.Execute(null));
+        Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(null));
+    }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -437,4 +437,24 @@ public class Test_AsyncRelayCommandOfT
         Assert.IsFalse(command.CanBeCanceled);
         Assert.IsTrue(command.IsCancellationRequested);
     }
+
+    [TestMethod]
+    public void Test_AsyncRelayCommand_EnsureExceptionThrown()
+    {
+        const int delay = 500;
+
+        AsyncRelayCommand<int> command = new(async delay =>
+        {
+            await Task.Delay(delay);
+            throw new Exception("This Exception Is Thrown Inside of the Task");
+        });
+
+        Assert.ThrowsExceptionAsync<Exception>(async () =>
+        {
+            command.Execute(delay);
+            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
+        });
+
+        Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(delay));
+    }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -439,7 +439,7 @@ public class Test_AsyncRelayCommandOfT
     }
 
     [TestMethod]
-    public async Task Test_AsyncRelayCommandOfT_EnsureExceptionThrown()
+    public async Task Test_AsyncRelayCommand_EnsureExceptionThrown()
     {
         const int delay = 500;
         const string exceptionMessage = "This Exception Is Thrown Inside of the Task";
@@ -450,8 +450,22 @@ public class Test_AsyncRelayCommandOfT
             throw new Exception(exceptionMessage);
         });
 
+        Exception? executeException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
+        {
+            command.Execute((object)delay);
+            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
+        });
+
+        Exception? executeTException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
+        {
+            command.Execute(delay);
+            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
+        });
+
         Exception? executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(delay));
 
+        Assert.AreEqual(exceptionMessage, executeException.Message);
+        Assert.AreEqual(exceptionMessage, executeTException.Message);
         Assert.AreEqual(exceptionMessage, executeAsyncException.Message);
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -439,7 +439,7 @@ public class Test_AsyncRelayCommandOfT
     }
 
     [TestMethod]
-    public async Task Test_AsyncRelayCommand_EnsureExceptionThrown()
+    public async Task Test_AsyncRelayCommandOfT_EnsureExceptionThrown()
     {
         const int delay = 500;
         const string exceptionMessage = "This Exception Is Thrown Inside of the Task";
@@ -450,22 +450,8 @@ public class Test_AsyncRelayCommandOfT
             throw new Exception(exceptionMessage);
         });
 
-        Exception? executeException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
-        {
-            command.Execute((object)delay);
-            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
-        });
-
-        Exception? executeTException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
-        {
-            command.Execute(delay);
-            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
-        });
-
         Exception? executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(delay));
 
-        Assert.AreEqual(exceptionMessage, executeException.Message);
-        Assert.AreEqual(exceptionMessage, executeTException.Message);
         Assert.AreEqual(exceptionMessage, executeAsyncException.Message);
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -445,7 +445,7 @@ public class Test_AsyncRelayCommandOfT
         const int delay = 500;
         const string exceptionMessage = "This Exception Is Thrown Inside of the Task";
 
-        Exception? executeException = null, executeTException = null;
+        Exception? executeException = null, executeTException = null, executeAsyncException = null;
 
         AsyncRelayCommand<int> command = new(async delay =>
         {
@@ -481,7 +481,7 @@ public class Test_AsyncRelayCommandOfT
             executeTException = e;
         }
 
-        Exception? executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(delay));
+        executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(delay));
 
         Assert.AreEqual(exceptionMessage, executeException?.Message);
         Assert.AreEqual(exceptionMessage, executeTException?.Message);

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -439,22 +439,33 @@ public class Test_AsyncRelayCommandOfT
     }
 
     [TestMethod]
-    public void Test_AsyncRelayCommand_EnsureExceptionThrown()
+    public async Task Test_AsyncRelayCommand_EnsureExceptionThrown()
     {
         const int delay = 500;
+        const string exceptionMessage = "This Exception Is Thrown Inside of the Task";
 
         AsyncRelayCommand<int> command = new(async delay =>
         {
             await Task.Delay(delay);
-            throw new Exception("This Exception Is Thrown Inside of the Task");
+            throw new Exception(exceptionMessage);
         });
 
-        Assert.ThrowsExceptionAsync<Exception>(async () =>
+        Exception? executeException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
+        {
+            command.Execute((object)delay);
+            await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
+        });
+
+        Exception? executeTException = await Assert.ThrowsExceptionAsync<Exception>(async () =>
         {
             command.Execute(delay);
             await Task.Delay(delay * 2); // Ensure we don't escape `Assert.ThrowsExceptionAsync` before command throws Exception
         });
 
-        Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(delay));
+        Exception? executeAsyncException = await Assert.ThrowsExceptionAsync<Exception>(() => command.ExecuteAsync(delay));
+
+        Assert.AreEqual(exceptionMessage, executeException.Message);
+        Assert.AreEqual(exceptionMessage, executeTException.Message);
+        Assert.AreEqual(exceptionMessage, executeAsyncException.Message);
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

### Description

This PR ensures that `ICommand.Execute(object parameter)` and `IAsyncRelayCommand<T>.Execute(T parameter)` both `await` the execution of `Func<Task>? execute`.

It removes the bad practice of discarding a `Task`:
```cs
// Never discard a `Task`
_ = Task.Delay(100);

// Always await every `Task`
await Task.Delay(100);
```

I've added unit tests demonstrating why adding the `await` keyword is critical; the tests will fail if the updates in this PR to `AsyncRelayCommand` and `AsyncRelayCommand<T>` are removed.

### Explanation

Discarding a `Task` is a bad practice and should _never_ be done. 

Long story short, the compiler turns every `Task` into an `IAsyncStateMachine` in which a try/catch block is used to catch any `Exception` thrown inside of the `Task`.

If an `Exception` _is_ thrown inside of a `Task`, it is always re-thrown when the `await` keyword is used. If the `await` keyword is not used, the `Exception` is never re-thrown and is instead disposed when the `Task` is disposed, leading to bugs + race conditions.

I explain this in much more detail here in my AsyncAwaitBestPractices repo: https://github.com/brminnick/asyncawaitbestpractices#explaination

tl;dr A non-awaited Task doesn't rethrow Exceptions

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->