### PR TITLE
Fix [ICommand] CanExecute with inherited generated property

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/ICommandGenerator.Execute.cs
@@ -723,11 +723,10 @@ partial class ICommandGenerator
             ImmutableArray<string> commandTypeArguments,
             [NotNullWhen(true)] out CanExecuteExpressionType? canExecuteExpressionType)
         {
-            foreach (ISymbol memberSymbol in containingType.GetMembers())
+            foreach (ISymbol memberSymbol in containingType.GetAllMembers())
             {
                 // Only look for instance fields of bool type
-                if (memberSymbol is not IFieldSymbol fieldSymbol ||
-                    fieldSymbol is { IsStatic: true } ||
+                if (memberSymbol is not IFieldSymbol { IsStatic: false } fieldSymbol ||
                     !fieldSymbol.Type.HasFullyQualifiedName("bool"))
                 {
                     continue;

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -645,6 +645,19 @@ public partial class Test_ObservablePropertyAttribute
         CollectionAssert.AreEqual(new[] { nameof(model.SomeProperty) }, propertyNames);
     }
 
+    // See https://github.com/CommunityToolkit/dotnet/issues/257
+    [TestMethod]
+    public void Test_ObservableProperty_InheritedModelWithCommandUsingInheritedObservablePropertyForCanExecute()
+    {
+        InheritedModelWithCommandUsingInheritedObservablePropertyForCanExecute model = new();
+
+        Assert.IsFalse(model.SaveCommand.CanExecute(null));
+
+        model.CanSave = true;
+
+        Assert.IsTrue(model.SaveCommand.CanExecute(null));
+    }
+
     public abstract partial class BaseViewModel : ObservableObject
     {
         public string? Content { get; set; }
@@ -1036,5 +1049,21 @@ public partial class Test_ObservablePropertyAttribute
         [AlsoBroadcastChange]
         [Display(Name = "Foo bar baz")]
         private object? _someProperty;
+    }
+
+    public abstract partial class BaseModelWithObservablePropertyAttribute : ObservableObject
+    {
+        [ObservableProperty]
+        private bool canSave;
+
+        public abstract void Save();
+    }
+
+    public partial class InheritedModelWithCommandUsingInheritedObservablePropertyForCanExecute : BaseModelWithObservablePropertyAttribute
+    {
+        [ICommand(CanExecute = nameof(CanSave))]
+        public override void Save()
+        {
+        }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #257**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions