### PR TITLE
Improve exceptions for invalid command arguments

### DIFF
--- a/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -262,13 +262,18 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool CanExecute(object? parameter)
     {
-        if (default(T) is not null &&
-            parameter is null)
+        // Special case, see RelayCommand<T>.CanExecute(object?) for more info
+        if (parameter is null && default(T) is not null)
         {
             return false;
         }
 
-        return CanExecute((T?)parameter);
+        if (!RelayCommand<T>.TryGetCommandArgument(parameter, out T? result))
+        {
+            RelayCommand<T>.ThrowArgumentExceptionForInvalidCommandArgument(parameter);
+        }
+
+        return CanExecute(result);
     }
 
     /// <inheritdoc/>
@@ -286,7 +291,12 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
     /// <inheritdoc/>
     public void Execute(object? parameter)
     {
-        Execute((T?)parameter);
+        if (!RelayCommand<T>.TryGetCommandArgument(parameter, out T? result))
+        {
+            RelayCommand<T>.ThrowArgumentExceptionForInvalidCommandArgument(parameter);
+        }
+
+        Execute(result);
     }
 
     /// <inheritdoc/>
@@ -322,7 +332,12 @@ public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationA
     /// <inheritdoc/>
     public Task ExecuteAsync(object? parameter)
     {
-        return ExecuteAsync((T?)parameter);
+        if (!RelayCommand<T>.TryGetCommandArgument(parameter, out T? result))
+        {
+            RelayCommand<T>.ThrowArgumentExceptionForInvalidCommandArgument(parameter);
+        }
+
+        return ExecuteAsync(result);
     }
 
     /// <inheritdoc/>

--- a/CommunityToolkit.Mvvm/Input/Interfaces/IAsyncRelayCommand.cs
+++ b/CommunityToolkit.Mvvm/Input/Interfaces/IAsyncRelayCommand.cs
@@ -63,6 +63,7 @@ public interface IAsyncRelayCommand : IRelayCommand, INotifyPropertyChanged
     /// </summary>
     /// <param name="parameter">The input parameter.</param>
     /// <returns>The <see cref="Task"/> representing the async operation being executed.</returns>
+    /// <exception cref="System.ArgumentException">Thrown if <paramref name="parameter"/> is incompatible with the underlying command implementation.</exception>
     Task ExecuteAsync(object? parameter);
 
     /// <summary>

--- a/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -6,6 +6,7 @@
 // more info in ThirdPartyNotices.txt in the root of the project.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace CommunityToolkit.Mvvm.Input;
@@ -81,13 +82,19 @@ public sealed class RelayCommand<T> : IRelayCommand<T>
     /// <inheritdoc/>
     public bool CanExecute(object? parameter)
     {
-        if (default(T) is not null &&
-            parameter is null)
+        // Special case a null value for a value type argument type.
+        // This ensures that no exceptions are thrown during initialization.
+        if (parameter is null && default(T) is not null)
         {
             return false;
         }
 
-        return CanExecute((T?)parameter);
+        if (!TryGetCommandArgument(parameter, out T? result))
+        {
+            ThrowArgumentExceptionForInvalidCommandArgument(parameter);
+        }
+
+        return CanExecute(result);
     }
 
     /// <inheritdoc/>
@@ -100,6 +107,66 @@ public sealed class RelayCommand<T> : IRelayCommand<T>
     /// <inheritdoc/>
     public void Execute(object? parameter)
     {
-        Execute((T?)parameter);
+        if (!TryGetCommandArgument(parameter, out T? result))
+        {
+            ThrowArgumentExceptionForInvalidCommandArgument(parameter);
+        }
+
+        Execute(result);
+    }
+
+    /// <summary>
+    /// Tries to get a command argument of compatible type <typeparamref name="T"/> from an input <see cref="object"/>.
+    /// </summary>
+    /// <param name="parameter">The input parameter.</param>
+    /// <param name="result">The resulting <typeparamref name="T"/> value, if any.</param>
+    /// <returns>Whether or not a compatible command argument could be retrieved.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetCommandArgument(object? parameter, out T? result)
+    {
+        // If the argument is null and the default value of T is also null, then the
+        // argument is valid. T might be a reference type or a nullable value type.
+        if (parameter is null && default(T) is null)
+        {
+            result = default;
+
+            return true;
+        }
+
+        // Check if the argument is a T value, so either an instance of a type or a derived
+        // type of T is a reference type, an interface implementation if T is an interface,
+        // or a boxed value type in case T was a value type.
+        if (parameter is T argument)
+        {
+            result = argument;
+
+            return true;
+        }
+
+        result = default;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException"/> if an invalid command argument is used.
+    /// </summary>
+    /// <param name="parameter">The input parameter.</param>
+    /// <exception cref="ArgumentException">Thrown with an error message to give info on the invalid parameter.</exception>
+    [DoesNotReturn]
+    internal static void ThrowArgumentExceptionForInvalidCommandArgument(object? parameter)
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Exception GetException(object? parameter)
+        {
+            if (parameter is null)
+            {
+                return new ArgumentException($"Parameter \"{nameof(parameter)}\" (object) must not be null, as the command type requires an argument of type {typeof(T)}.", nameof(parameter));
+            }
+
+            return new ArgumentException($"Parameter \"{nameof(parameter)}\" (object) cannot be of type {parameter.GetType()}, as the command type requires an argument of type {typeof(T)}.", nameof(parameter));
+        }
+
+        throw GetException(parameter);
     }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Helpers/ExceptionHelper.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Helpers/ExceptionHelper.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommunityToolkit.Mvvm.UnitTests.Helpers;
+
+/// <summary>
+/// A helper class to validate scenarios related to <see cref="Exception"/>-s.
+/// </summary>
+internal static class ExceptionHelper
+{
+    /// <summary>
+    /// Asserts that a given action throws an <see cref="ArgumentException"/> with a specific parameter name.
+    /// </summary>
+    /// <param name="action">The input <see cref="Action"/> to invoke.</param>
+    /// <param name="parameterName">The expected parameter name.</param>
+    public static void ThrowsArgumentExceptionWithParameterName(Action action, string parameterName)
+    {
+        bool success = false;
+
+        try
+        {
+            action();
+        }
+        catch (Exception e)
+        {
+            Assert.IsTrue(e.GetType() == typeof(ArgumentException));
+            Assert.AreEqual(parameterName, ((ArgumentException)e).ParamName);
+
+            success = true;
+        }
+
+        Assert.IsTrue(success);
+    }
+}

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_AsyncRelayCommand{T}.cs
@@ -62,7 +62,11 @@ public class Test_AsyncRelayCommandOfT
 
         Assert.AreEqual(ticks, 2);
 
-        _ = Assert.ThrowsException<InvalidCastException>(() => command.Execute(new object()));
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(42), "parameter");
+        
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(42), "parameter");
     }
 
     [TestMethod]
@@ -87,6 +91,12 @@ public class Test_AsyncRelayCommandOfT
         command.Execute("2");
 
         Assert.AreEqual(ticks, 2);
+
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(42), "parameter");
+        
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(42), "parameter");
     }
 
     [TestMethod]
@@ -112,10 +122,16 @@ public class Test_AsyncRelayCommandOfT
         command.Execute("42");
 
         Assert.AreEqual(ticks, 42);
+
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(42), "parameter");
+        
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(42), "parameter");
     }
 
     [TestMethod]
-    public void Test_AsyncRelayCommandOfT_NullWithValueType()
+    public void Test_AsyncRelayCommandOfT_InvalidArgumentWithValueType()
     {
         int n = 0;
 
@@ -125,18 +141,38 @@ public class Test_AsyncRelayCommandOfT
             return Task.CompletedTask;
         });
 
+        // Special case
         Assert.IsFalse(command.CanExecute(null));
-        _ = Assert.ThrowsException<NullReferenceException>(() => command.Execute(null));
 
-        command = new AsyncRelayCommand<int>(
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute("Hello"), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(3.14f), "parameter");
+
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(null), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute("Hello"), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(3.14f), "parameter");
+    }
+
+    [TestMethod]
+    public void Test_AsyncRelayCommandOfT_InvalidArgumentWithValueType_WithCanExecute()
+    {
+        int n = 0;
+
+        AsyncRelayCommand<int>? command = new(
             i =>
             {
                 n = i;
                 return Task.CompletedTask;
             }, i => i > 0);
 
+        // Special case
         Assert.IsFalse(command.CanExecute(null));
-        _ = Assert.ThrowsException<NullReferenceException>(() => command.Execute(null));
+
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute("Hello"), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(3.14f), "parameter");
+
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(null), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute("Hello"), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(3.14f), "parameter");
     }
 
     [TestMethod]
@@ -239,7 +275,11 @@ public class Test_AsyncRelayCommandOfT
 
         Assert.IsFalse(command.IsRunning);
 
-        _ = Assert.ThrowsException<InvalidCastException>(() => command.Execute(new object()));
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(3.14f), "parameter");
+
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(3.14f), "parameter");
     }
 
     [TestMethod]

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommand{T}.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommand{T}.cs
@@ -4,6 +4,7 @@
 
 using System;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.UnitTests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.Mvvm.UnitTests;
@@ -21,7 +22,11 @@ public class Test_RelayCommandOfT
         Assert.IsTrue(command.CanExecute("Text"));
         Assert.IsTrue(command.CanExecute(null));
 
-        _ = Assert.ThrowsException<InvalidCastException>(() => command.CanExecute(new object()));
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(42), "parameter");
+        
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(42), "parameter");
 
         (object?, EventArgs?) args = default;
 
@@ -51,7 +56,11 @@ public class Test_RelayCommandOfT
         Assert.IsTrue(command.CanExecute("Text"));
         Assert.IsFalse(command.CanExecute(null));
 
-        _ = Assert.ThrowsException<InvalidCastException>(() => command.CanExecute(new object()));
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(42), "parameter");
+        
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(new object()), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(42), "parameter");
 
         command.Execute((object)"Hello");
 
@@ -64,18 +73,38 @@ public class Test_RelayCommandOfT
     }
 
     [TestMethod]
-    public void Test_RelayCommand_NullWithValueType()
+    public void Test_RelayCommand_InvalidArgumentWithValueType()
     {
         int n = 0;
 
         RelayCommand<int>? command = new(i => n = i);
 
+        // Special case
         Assert.IsFalse(command.CanExecute(null));
-        _ = Assert.ThrowsException<NullReferenceException>(() => command.Execute(null));
 
-        command = new RelayCommand<int>(i => n = i, i => i > 0);
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute("Hello"), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(3.14f), "parameter");
 
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(null), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute("Hello"), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(3.14f), "parameter");
+    }
+
+    [TestMethod]
+    public void Test_RelayCommand_InvalidArgumentWithValueType_WithCanExecute()
+    {
+        int n = 0;
+
+        RelayCommand<int>? command = new(i => n = i, i => i > 0);
+
+        // Special case
         Assert.IsFalse(command.CanExecute(null));
-        _ = Assert.ThrowsException<NullReferenceException>(() => command.Execute(null));
+
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute("Hello"), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.CanExecute(3.14f), "parameter");
+
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(null), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute("Hello"), "parameter");
+        ExceptionHelper.ThrowsArgumentExceptionWithParameterName(() => command.Execute(3.14f), "parameter");
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #296**

This exception changes the generic commands to always thrown `ArgumentException` if the input is invalid.
This also includes a helpful exception message.
They no longer throw `NullReferenceException` or `InvalidCastException`.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions