### PR TITLE
Add unique prefixes to all .targets properties and items

### DIFF
--- a/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
+++ b/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
@@ -1,17 +1,17 @@
 <Project>
 
   <!-- Get the analyzer from the CommunityToolkit.Mvvm NuGet package -->
-  <Target Name="_MVVMToolkitGatherAnalyzers">
+  <Target Name="MVVMToolkitGatherAnalyzers">
     <ItemGroup>
-      <_MVVMToolkitAnalyzer Include="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' == 'CommunityToolkit.Mvvm'" />
+      <MVVMToolkitAnalyzer Include="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' == 'CommunityToolkit.Mvvm'" />
     </ItemGroup>
   </Target>
 
   <!-- Remove the analyzer if using Roslyn 3.x (incremental generators require Roslyn 4.x) -->
-  <Target Name="_MVVMToolkitRemoveAnalyzersForRoslyn3"
+  <Target Name="MVVMToolkitRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
-          DependsOnTargets="_MVVMToolkitGatherAnalyzers">
+          DependsOnTargets="MVVMToolkitGatherAnalyzers">
 
     <!-- Use the CSharpCoreTargetsPath property to find the version of the compiler we are using. This is the same mechanism
          MSBuild uses to find the compiler. We could check the assembly version for any compiler assembly (since they all have
@@ -32,7 +32,7 @@
 
     <!-- If the Roslyn version is < 4.0, disable the source generators -->
     <ItemGroup Condition ="'$(MVVMToolkitCurrentCompilerVersionIsNotNewEnough)' == 'true'">
-      <Analyzer Remove="@(_MVVMToolkitAnalyzer)"/>
+      <Analyzer Remove="@(MVVMToolkitAnalyzer)"/>
     </ItemGroup>
 
     <!-- If the source generators are disabled, also emit a warning. This would've been produced by MSBuild itself as well, but
@@ -42,14 +42,14 @@
   </Target>
 
   <!-- Remove the analyzer if Roslyn is missing -->
-  <Target Name="_MVVMToolkitRemoveAnalyzersForRosynNotFound"
+  <Target Name="MVVMToolkitRemoveAnalyzersForRosynNotFound"
           Condition="'$(CSharpCoreTargetsPath)' == ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
-          DependsOnTargets="_MVVMToolkitGatherAnalyzers">
+          DependsOnTargets="MVVMToolkitGatherAnalyzers">
 
     <!-- If no Roslyn assembly could be found, just remove the analyzer without emitting a warning -->
     <ItemGroup>
-      <Analyzer Remove="@(_MVVMToolkitAnalyzer)"/>
+      <Analyzer Remove="@(MVVMToolkitAnalyzer)"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This PR adds unique prefixes to all properties and items in the .targets file bundled with the MVVM Toolkit.
This ensures there can be no conflicts with other targets defining the same elements from other NuGet packages.

Essentially, this PR fixes this: https://github.com/Sergio0694/ComputeSharp/actions/runs/2523630796.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions