### PR TITLE
Correct typo in converters

### DIFF
--- a/CommunityToolkit.Common/Converters.cs
+++ b/CommunityToolkit.Common/Converters.cs
@@ -42,7 +42,7 @@ public static class Converters
         }
         else
         {
-            return ((size >> 50) / 1024F).ToString("F0") + " EB";
+            return ((size >> 50) / 1024F).ToString("F1") + " EB";
         }
     }
 }

--- a/CommunityToolkit.Common/Extensions/EventHandlerExtensions.cs
+++ b/CommunityToolkit.Common/Extensions/EventHandlerExtensions.cs
@@ -54,11 +54,11 @@ public static class EventHandlerExtensions
                 invocationDelegate(sender, eventArgs);
 
 #pragma warning disable CS0618 // Type or member is obsolete
-                    EventDeferral? deferral = eventArgs.GetCurrentDeferralAndReset();
+                EventDeferral? deferral = eventArgs.GetCurrentDeferralAndReset();
 
                 return deferral?.WaitForCompletion(cancellationToken) ?? Task.CompletedTask;
 #pragma warning restore CS0618 // Type or member is obsolete
-                })
+            })
             .ToArray();
 
         return Task.WhenAll(tasks);

--- a/CommunityToolkit.Common/IncrementalLoadingCollection/IIncrementalSource.cs
+++ b/CommunityToolkit.Common/IncrementalLoadingCollection/IIncrementalSource.cs
@@ -29,5 +29,5 @@ public interface IIncrementalSource<TSource>
     /// <returns>
     /// Returns a collection of <typeparamref name="TSource"/>.
     /// </returns>
-    Task<IEnumerable<TSource>> GetPagedItemsAsync(int pageIndex, int pageSize, CancellationToken cancellationToken = default(CancellationToken));
+    Task<IEnumerable<TSource>> GetPagedItemsAsync(int pageIndex, int pageSize, CancellationToken cancellationToken = default);
 }

--- a/tests/CommunityToolkit.Common.UnitTests/Test_Converters.cs
+++ b/tests/CommunityToolkit.Common.UnitTests/Test_Converters.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommunityToolkit.Common.UnitTests;
+
+[TestClass]
+public class Test_Converters
+{
+    [TestMethod]
+    [DataRow(1024L - 1, "1023 bytes")]
+    [DataRow(1024L, "1.0 KB")]
+    [DataRow(1024L * 1024, "1.0 MB")]
+    [DataRow(1024L * 1024 * 1024, "1.0 GB")]
+    [DataRow(1024L * 1024 * 1024 * 1024, "1.0 TB")]
+    [DataRow(1024L * 1024 * 1024 * 1024 * 1024, "1.0 PB")]
+    [DataRow(1024L * 1024 * 1024 * 1024 * 1024 * 1024, "1.0 EB")]
+    public void Test_ToFileSizeString(long size, string expected)
+    {
+        Assert.AreEqual(expected, Converters.ToFileSizeString(size));
+    }
+}


### PR DESCRIPTION
Changes:
1. Code cleanup
2. Correct typo to close: https://github.com/CommunityToolkit/dotnet/issues/393