### PR TITLE
Multi-target Roslyn dependency in MVVM Toolkit generators

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.csproj
+++ b/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.csproj
@@ -19,7 +19,7 @@
     <MvvmToolkitSourceGeneratorRoslynVersion Condition="'$(MvvmToolkitSourceGeneratorRoslynVersion)' == ''">4.0.1</MvvmToolkitSourceGeneratorRoslynVersion>
     
     <!-- The output path will end up being eg. "bin\Debug\roslyn4.0\netstandard2.0" (the trailing "netstandard2.0" is added automatically) -->
-    <OutputPath>bin\$(Configuration)\roslyn$(MvvmToolkitSourceGeneratorRoslynVersion.Substring(0, 3))</OutputPath>
+    <OutputPath>bin\$(Configuration)\roslyn$(MvvmToolkitSourceGeneratorRoslynVersion.Substring(0, 3))\</OutputPath>
     
     <!-- Also define a "ROSLYN_<MAJOR>_<MINOR>" build constant, so the generator code can multi-target whenever needed and add any required polyfills -->
     <DefineConstants>$(DefineConstants);ROSLYN_$(MvvmToolkitSourceGeneratorRoslynVersion.Substring(0, 3).Replace('.', '_'))</DefineConstants>

--- a/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.csproj
+++ b/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.csproj
@@ -18,8 +18,11 @@
     <!-- When the property is not set (which will not happen when creating a NuGet package anyway), just default to 4.0.1 -->
     <MvvmToolkitSourceGeneratorRoslynVersion Condition="'$(MvvmToolkitSourceGeneratorRoslynVersion)' == ''">4.0.1</MvvmToolkitSourceGeneratorRoslynVersion>
     
-    <!-- The output path will end up being eg. "bin\Debug\roslyn4.0\netstandard2.0" (the trailing "netstandard2.0" is added automatically) -->
-    <OutputPath>bin\$(Configuration)\roslyn$(MvvmToolkitSourceGeneratorRoslynVersion.Substring(0, 3))\</OutputPath>
+    <!--
+      The output path will end up being eg. "bin\Debug\roslyn4.0\netstandard2.0" (the trailing "netstandard2.0" is added automatically).
+      This is only set when $(MvvmToolkitIsGeneratingNuGetPackage) is set (when packing CommunityToolkit.Mvvm). This avoids unit test issues.
+    -->
+    <OutputPath Condition="'$(MvvmToolkitIsGeneratingNuGetPackage)' == 'true'">bin\$(Configuration)\roslyn$(MvvmToolkitSourceGeneratorRoslynVersion.Substring(0, 3))\</OutputPath>
     
     <!-- Also define a "ROSLYN_<MAJOR>_<MINOR>" build constant, so the generator code can multi-target whenever needed and add any required polyfills -->
     <DefineConstants>$(DefineConstants);ROSLYN_$(MvvmToolkitSourceGeneratorRoslynVersion.Substring(0, 3).Replace('.', '_'))</DefineConstants>

--- a/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.csproj
+++ b/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.csproj
@@ -5,6 +5,26 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!--
+    The MVVM Toolkit source generators rely on Roslyn multi-targeting to support multiple versions of the Microsoft.CodeAnalysis.CSharp package.
+    This package reference actually needs a matching version of Roslyn to be available for consumers of the source generator, so if we always
+    used the latest version, the MVVM Toolkit would just fail to load for users of eg. an older version of Visual Studio. Thankfully, Roslyn
+    supports analyzers that bundle multiple versions in the same NuGet package, each in a subfolder with a name matching the Roslyn version.
+    To leverage this, this project receives the MvvmToolkitSourceGeneratorRoslynVersion property as input, so that the MVVM Toolkit can build
+    it multiple times with multiple versions during packing, to then extract each .dll and copy it to the right NuGet package folder.
+  -->
+  <PropertyGroup>
+    
+    <!-- When the property is not set (which will not happen when creating a NuGet package anyway), just default to 4.0.1 -->
+    <MvvmToolkitSourceGeneratorRoslynVersion Condition="'$(MvvmToolkitSourceGeneratorRoslynVersion)' == ''">4.0.1</MvvmToolkitSourceGeneratorRoslynVersion>
+    
+    <!-- The output path will end up being eg. "bin\Debug\roslyn4.0\netstandard2.0" (the trailing "netstandard2.0" is added automatically) -->
+    <OutputPath>bin\$(Configuration)\roslyn$(MvvmToolkitSourceGeneratorRoslynVersion.Substring(0, 3))</OutputPath>
+    
+    <!-- Also define a "ROSLYN_<MAJOR>_<MINOR>" build constant, so the generator code can multi-target whenever needed and add any required polyfills -->
+    <DefineConstants>$(DefineConstants);ROSLYN_$(MvvmToolkitSourceGeneratorRoslynVersion.Substring(0, 3).Replace('.', '_'))</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="EmbeddedResources\INotifyPropertyChanged.cs" />
     <Compile Remove="EmbeddedResources\NotNullAttribute.cs" />
@@ -32,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MvvmToolkitSourceGeneratorRoslynVersion)" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -40,9 +40,14 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
-  <!-- Source generator project reference for packing -->
+  <!-- Reference the various multi-targeted versions of the source generator project (one per Roslyn version) -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <ProjectReference Include="..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" ReferenceOutputAssembly="false">
+      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=4.0.1</Properties>
+    </ProjectReference>
+    <ProjectReference Include="..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" ReferenceOutputAssembly="false">
+      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=4.3.0</Properties>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup Label="Package">
@@ -53,11 +58,12 @@
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="build\netstandard2.0" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="build\netstandard2.1" Pack="true" />
 
-    <!-- Pack the source generator to the right package folder -->
-    <None Include="..\CommunityToolkit.Mvvm.SourceGenerators\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Mvvm.SourceGenerators.dll"
-          PackagePath="analyzers\dotnet\roslyn4.0\cs"
-          Pack="true"
-          Visible="false" />
+    <!--
+      Pack the source generator to the right package folders (each matching the target Roslyn version).
+      Roslyn will automatically load the highest version compatible with Roslyn's version in the SDK.
+    -->
+    <None Include="..\CommunityToolkit.Mvvm.SourceGenerators\bin\$(Configuration)\roslyn4.0\netstandard2.0\CommunityToolkit.Mvvm.SourceGenerators.dll" PackagePath="analyzers\dotnet\roslyn4.0\cs" Pack="true" Visible="false" />
+    <None Include="..\CommunityToolkit.Mvvm.SourceGenerators\bin\$(Configuration)\roslyn4.3\netstandard2.0\CommunityToolkit.Mvvm.SourceGenerators.dll" PackagePath="analyzers\dotnet\roslyn4.3\cs" Pack="true" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -43,10 +43,10 @@
   <!-- Reference the various multi-targeted versions of the source generator project (one per Roslyn version) -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <ProjectReference Include="..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" ReferenceOutputAssembly="false">
-      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=4.0.1</Properties>
+      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=4.0.1;MvvmToolkitIsGeneratingNuGetPackage=true</Properties>
     </ProjectReference>
     <ProjectReference Include="..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" ReferenceOutputAssembly="false">
-      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=4.3.0</Properties>
+      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=4.3.0;MvvmToolkitIsGeneratingNuGetPackage=true</Properties>
     </ProjectReference>
   </ItemGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,14 @@ jobs:
   - script: dotnet test -c Release -f net6.0 -l "trx;LogFileName=VSTestResults_net6.0.trx"
     displayName: Run .NET 6 unit tests
 
+  # Run the .NET 6 MVVM Toolkit tests targeting Roslyn 4.0.1
+  - script: dotnet test tests\CommunityToolkit.Mvvm.UnitTests\CommunityToolkit.Mvvm.UnitTests.csproj -c Release -f net6.0 -l "trx;LogFileName=VSTestResults_net6.0_mvvmtoolkit_roslyn401.trx"
+    displayName: Run CommunityToolkit.Mvvm.UnitTests unit tests with Roslyn 4.0.1
+
+  # Run the .NET 6 MVVM Toolkit source generator tests targeting Roslyn 4.0.1
+  - script: dotnet test tests\CommunityToolkit.Mvvm.SourceGenerators.UnitTests\CommunityToolkit.Mvvm.SourceGenerators.UnitTests.csproj -c Release -f net6.0 -l "trx;LogFileName=VSTestResults_net6.0_mvvmtoolkit_generators_roslyn401.trx"
+    displayName: Run CommunityToolkit.Mvvm.UnitTests unit tests with Roslyn 4.0.1
+
   # Run .NET Core 3.1 tests
   - script: dotnet test -c Release -f netcoreapp3.1 -l "trx;LogFileName=VSTestResults_netcoreapp3.1.trx"
     displayName: Run .NET Core 3.1 unit tests

--- a/tests/CommunityToolkit.Mvvm.ExternalAssembly/CommunityToolkit.Mvvm.ExternalAssembly.csproj
+++ b/tests/CommunityToolkit.Mvvm.ExternalAssembly/CommunityToolkit.Mvvm.ExternalAssembly.csproj
@@ -12,9 +12,15 @@
     <NoWarn>$(NoWarn);CS8002;SA0001</NoWarn>
   </PropertyGroup>
 
+  <!-- See comments in CommunityToolkit.MvvmUnitTests -->
+  <PropertyGroup>
+    <MvvmToolkitSourceGeneratorRoslynVersion Condition="'$(MvvmToolkitSourceGeneratorRoslynVersion)' == ''">4.3.0</MvvmToolkitSourceGeneratorRoslynVersion>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\CommunityToolkit.Mvvm\CommunityToolkit.Mvvm.csproj" />
-    <ProjectReference Include="..\..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build">
+      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=$(MvvmToolkitSourceGeneratorRoslynVersion)</Properties>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
@@ -11,9 +11,15 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
 
+  <!-- See comments in CommunityToolkit.MvvmUnitTests -->
+  <PropertyGroup>
+    <MvvmToolkitSourceGeneratorRoslynVersion Condition="'$(MvvmToolkitSourceGeneratorRoslynVersion)' == ''">4.3.0</MvvmToolkitSourceGeneratorRoslynVersion>
+  </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" />
     <ProjectReference Include="..\..\CommunityToolkit.Mvvm\CommunityToolkit.Mvvm.csproj" />
+    <ProjectReference Include="..\..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj">
+      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=$(MvvmToolkitSourceGeneratorRoslynVersion)</Properties>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/CommunityToolkit.Mvvm.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/CommunityToolkit.Mvvm.UnitTests.csproj
@@ -12,9 +12,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\CommunityToolkit.Mvvm\CommunityToolkit.Mvvm.csproj" />
-    <ProjectReference Include="..\..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
     <ProjectReference Include="..\CommunityToolkit.Mvvm.ExternalAssembly\CommunityToolkit.Mvvm.ExternalAssembly.csproj" />
+  </ItemGroup>
+
+  <!-- Since the MVVM Toolkit generator uses multi-targeting for Roslyn versions, we also want to test all of them here -->
+  <PropertyGroup>
+    <MvvmToolkitSourceGeneratorRoslynVersion Condition="'$(MvvmToolkitSourceGeneratorRoslynVersion)' == ''">4.3.0</MvvmToolkitSourceGeneratorRoslynVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CommunityToolkit.Mvvm\CommunityToolkit.Mvvm.csproj" />
+    <ProjectReference Include="..\..\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build">
+      <Properties>MvvmToolkitSourceGeneratorRoslynVersion=$(MvvmToolkitSourceGeneratorRoslynVersion)</Properties>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #423**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Code follows all style conventions