### PR TITLE
Fix [RelayCommand] for methods that can't be lowered

### DIFF
--- a/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
+++ b/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
@@ -439,7 +439,17 @@ partial class RelayCommandGenerator
 
             propertyName += "Command";
 
-            string fieldName = $"{char.ToLower(propertyName[0], CultureInfo.InvariantCulture)}{propertyName.Substring(1)}";
+            char firstCharacter = propertyName[0];
+            char loweredFirstCharacter = char.ToLower(firstCharacter, CultureInfo.InvariantCulture);
+
+            // The field name is generated depending on whether the first character can be lowered:
+            //   - If it can, then the field name is just the property name starting in lowercase.
+            //   - If it can't (eg. starts with '中'), then the '_' prefix is added to the property name.
+            string fieldName = (firstCharacter == loweredFirstCharacter) switch
+            {
+                true => $"_{propertyName}",
+                false => $"{loweredFirstCharacter}{propertyName.Substring(1)}"
+            };
 
             return (fieldName, propertyName);
         }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -946,6 +946,25 @@ public partial class Test_ObservablePropertyAttribute
         Assert.AreEqual(testAttribute2.Animal, (Animal)67);
     }
 
+    // See https://github.com/CommunityToolkit/dotnet/issues/446
+    [TestMethod]
+    public void Test_ObservableProperty_CommandNamesThatCantBeLowered()
+    {
+        ModelWithCommandNamesThatCantBeLowered model = new();
+
+        // Just ensures this builds
+        _ = model.中文Command;
+        _ = model.c中文Command;
+
+        FieldInfo? fieldInfo = typeof(ModelWithCommandNamesThatCantBeLowered).GetField($"_{nameof(ModelWithCommandNamesThatCantBeLowered.中文)}Command", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.AreSame(model.中文Command, fieldInfo.GetValue(model));
+
+        fieldInfo = typeof(ModelWithCommandNamesThatCantBeLowered).GetField($"_{nameof(ModelWithCommandNamesThatCantBeLowered.c中文)}Command", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.AreSame(model.c中文Command, fieldInfo.GetValue(model));
+    }
+
     public abstract partial class BaseViewModel : ObservableObject
     {
         public string? Content { get; set; }
@@ -1516,5 +1535,18 @@ public partial class Test_ObservablePropertyAttribute
         public object? NestedArray { get; set; }
 
         public Animal Animal { get; set; }
+    }
+
+    private sealed partial class ModelWithCommandNamesThatCantBeLowered
+    {
+        [RelayCommand]
+        public void 中文()
+        {
+        }
+
+        [RelayCommand]
+        public void c中文()
+        {
+        }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #446**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions