### PR TITLE
Remove unnecessary finalizers

### DIFF
--- a/CommunityToolkit.HighPerformance/Buffers/ArrayPoolBufferWriter{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/ArrayPoolBufferWriter{T}.cs
@@ -99,11 +99,6 @@ public sealed class ArrayPoolBufferWriter<T> : IBuffer<T>, IMemoryOwner<T>
         this.index = 0;
     }
 
-    /// <summary>
-    /// Finalizes an instance of the <see cref="ArrayPoolBufferWriter{T}"/> class.
-    /// </summary>
-    ~ArrayPoolBufferWriter() => Dispose();
-
     /// <inheritdoc/>
     Memory<T> IMemoryOwner<T>.Memory
     {
@@ -310,8 +305,6 @@ public sealed class ArrayPoolBufferWriter<T> : IBuffer<T>, IMemoryOwner<T>
         {
             return;
         }
-
-        GC.SuppressFinalize(this);
 
         this.array = null;
 

--- a/CommunityToolkit.HighPerformance/Buffers/MemoryOwner{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/MemoryOwner{T}.cs
@@ -78,11 +78,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
     }
 
     /// <summary>
-    /// Finalizes an instance of the <see cref="MemoryOwner{T}"/> class.
-    /// </summary>
-    ~MemoryOwner() => Dispose();
-
-    /// <summary>
     /// Gets an empty <see cref="MemoryOwner{T}"/> instance.
     /// </summary>
     public static MemoryOwner<T> Empty
@@ -294,8 +289,6 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
         {
             return;
         }
-
-        GC.SuppressFinalize(this);
 
         this.array = null;
 


### PR DESCRIPTION
This PR removes two unnecessary finalizers, one in `ArrayPoolBufferWriter<T>` and one in `MemoryOwner<T>`. Doing so makes allocating these two types much faster. The finalizers are not needed because the types are wrapping managed resources, and not returning an array to the pool is not critical, plus if a developer forgot to call `Dispose` that's just a user error and not something that would be done in a "high performance" scenario in the first place.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions