### PR TITLE
Use Nullable.GetValueRefOrDefaultRef where possible

### DIFF
--- a/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
@@ -35,7 +35,11 @@ public static class NullableExtensions
     public static ref T DangerousGetValueOrDefaultReference<T>(this ref T? value)
         where T : struct
     {
+#if NET7_0_OR_GREATER
+        return ref Unsafe.AsRef(in Nullable.GetValueRefOrDefaultRef(in value));
+#else
         return ref Unsafe.As<T?, RawNullableData<T>>(ref value).Value;
+#endif
     }
 
     /// <summary>
@@ -51,12 +55,17 @@ public static class NullableExtensions
     {
         if (value.HasValue)
         {
+#if NET7_0_OR_GREATER
+            return ref Unsafe.AsRef(in Nullable.GetValueRefOrDefaultRef(in value));
+#else
             return ref Unsafe.As<T?, RawNullableData<T>>(ref value).Value;
+#endif
         }
 
         return ref Unsafe.NullRef<T>();
     }
 
+#if !NET7_0_OR_GREATER
     /// <summary>
     /// Mapping type that reflects the internal layout of the <see cref="Nullable{T}"/> type.
     /// See https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Nullable.cs.
@@ -70,6 +79,7 @@ public static class NullableExtensions
         public T Value;
 #pragma warning restore CS0649
     }
+#endif
 }
 
 #endif

--- a/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
@@ -50,9 +50,10 @@ public static class NullableExtensions
     /// <returns>A reference to the value of the input <see cref="Nullable{T}"/> instance, or a <see langword="null"/> <typeparamref name="T"/> reference.</returns>
     /// <remarks>The returned reference can be tested for <see langword="null"/> using <see cref="Unsafe.IsNullRef{T}(ref T)"/>.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe ref T DangerousGetValueOrNullReference<T>(ref this T? value)
+    public static ref T DangerousGetValueOrNullReference<T>(ref this T? value)
         where T : struct
     {
+#if NET7_0_OR_GREATER
         ref T resultRef = ref Unsafe.NullRef<T>();
 
         // This pattern ensures that the resulting code ends up having a single return, and a single
@@ -69,14 +70,18 @@ public static class NullableExtensions
         // This is better than what the code would've been with two separate returns in the method.
         if (value.HasValue)
         {
-#if NET7_0_OR_GREATER
             resultRef = ref Unsafe.AsRef(in Nullable.GetValueRefOrDefaultRef(in value));
-#else
-            resultRef = ref Unsafe.As<T?, RawNullableData<T>>(ref value).Value;
-#endif
         }
 
         return ref resultRef;
+#else
+        if (value.HasValue)
+        {
+            return ref Unsafe.As<T?, RawNullableData<T>>(ref value).Value;
+        }
+
+        return ref Unsafe.NullRef<T>();
+#endif
     }
 
 #if !NET7_0_OR_GREATER

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,6 @@ jobs:
     displayName: Install the .NET 7 SDK
     inputs:
       version: $(DotNet.Version)
-      includePreviewVersions: true
       performMultiLevelLookup: true
 
   # Set Build Version


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #498**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions