### PR TITLE
Drop .NET Core 3.1 TFM

### DIFF
--- a/CommunityToolkit.HighPerformance/Buffers/MemoryOwner{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/MemoryOwner{T}.cs
@@ -6,7 +6,7 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
 #endif
 using CommunityToolkit.HighPerformance.Buffers.Views;
@@ -171,13 +171,13 @@ public sealed class MemoryOwner<T> : IMemoryOwner<T>
                 ThrowObjectDisposedException();
             }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
             ref T r0 = ref array!.DangerousGetReferenceAt(this.start);
 
-            // On .NET Core runtimes, we can manually create a span from the starting reference to
+            // On .NET 6+ runtimes, we can manually create a span from the starting reference to
             // skip the argument validations, which include an explicit null check, covariance check
             // for the array and the actual validation for the starting offset and target length. We
-            // only do this on .NET Core as we can leverage the runtime-specific array layout to get
+            // only do this on .NET 6+ as we can leverage the runtime-specific array layout to get
             // a fast access to the initial element, which makes this trick worth it. Otherwise, on
             // runtimes where we would need to at least access a static field to retrieve the base
             // byte offset within an SZ array object, we can get better performance by just using the

--- a/CommunityToolkit.HighPerformance/Buffers/SpanOwner{T}.cs
+++ b/CommunityToolkit.HighPerformance/Buffers/SpanOwner{T}.cs
@@ -6,7 +6,7 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
 #endif
 using CommunityToolkit.HighPerformance.Buffers.Views;
@@ -141,7 +141,7 @@ public readonly ref struct SpanOwner<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
             ref T r0 = ref this.array!.DangerousGetReference();
 
             return MemoryMarshal.CreateSpan(ref r0, this.length);

--- a/CommunityToolkit.HighPerformance/CommunityToolkit.HighPerformance.csproj
+++ b/CommunityToolkit.HighPerformance/CommunityToolkit.HighPerformance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -47,22 +47,10 @@
 
     <When Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
 
-      <!-- NETSTANDARD2_1_OR_GREATER: includes both .NET Standard 2.1, .NET Core 3.1 and .NET 6.
-           Additionally, also enable trimming support on .NET 6. -->
+      <!-- NETSTANDARD2_1_OR_GREATER: includes both .NET Standard 2.1 and .NET 6 and above -->
       <PropertyGroup>
         <DefineConstants>NETSTANDARD2_1_OR_GREATER</DefineConstants>
       </PropertyGroup>
-    </When>
-
-    <When Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-      <PropertyGroup>
-        <DefineConstants>NETSTANDARD2_1_OR_GREATER</DefineConstants>
-      </PropertyGroup>
-
-      <!-- .NET Core 3.1 has the Unsafe type, but the version it ships with lacks Unsafe.IsNullRef<T> -->
-      <ItemGroup>
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-      </ItemGroup>
     </When>
   </Choose>
 

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.1D.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.1D.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
 #endif
 using CommunityToolkit.HighPerformance.Enumerables;
@@ -33,11 +33,6 @@ public static partial class ArrayExtensions
     {
 #if NET6_0_OR_GREATER
         return ref MemoryMarshal.GetArrayDataReference(array);
-#elif NETCOREAPP3_1
-        RawArrayData? arrayData = Unsafe.As<RawArrayData>(array)!;
-        ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
-
-        return ref r0;
 #else
         IntPtr offset = RuntimeHelpers.GetArrayDataByteOffset<T>();
 
@@ -61,12 +56,6 @@ public static partial class ArrayExtensions
         ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)i);
 
         return ref ri;
-#elif NETCOREAPP3_1
-        RawArrayData? arrayData = Unsafe.As<RawArrayData>(array)!;
-        ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
-        ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)i);
-
-        return ref ri;
 #else
         IntPtr offset = RuntimeHelpers.GetArrayDataByteOffset<T>();
         ref T r0 = ref ObjectMarshal.DangerousGetObjectDataReferenceAt<T>(array, offset);
@@ -75,26 +64,6 @@ public static partial class ArrayExtensions
         return ref ri;
 #endif
     }
-
-#if NETCOREAPP3_1
-    // Description taken from CoreCLR: see https://source.dot.net/#System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs,285.
-    // CLR arrays are laid out in memory as follows (multidimensional array bounds are optional):
-    // [ sync block || pMethodTable || num components || MD array bounds || array data .. ]
-    //                 ^                                 ^                  ^ returned reference
-    //                 |                                 \-- ref Unsafe.As<RawArrayData>(array).Data
-    //                 \-- array
-    // The base size of an array includes all the fields before the array data,
-    // including the sync block and method table. The reference to RawData.Data
-    // points at the number of components, skipping over these two pointer-sized fields.
-    [StructLayout(LayoutKind.Sequential)]
-    private sealed class RawArrayData
-    {
-#pragma warning disable CS0649 // Unassigned fields
-        public IntPtr Length;
-        public byte Data;
-#pragma warning restore CS0649
-    }
-#endif
 
     /// <summary>
     /// Counts the number of occurrences of a given value into a target <typeparamref name="T"/> array instance.

--- a/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
@@ -29,11 +29,6 @@ partial class ArrayExtensions
     {
 #if NET6_0_OR_GREATER
         return ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array));
-#elif NETCOREAPP3_1
-        RawArray3DData? arrayData = Unsafe.As<RawArray3DData>(array)!;
-        ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
-
-        return ref r0;
 #else
         IntPtr offset = RuntimeHelpers.GetArray3DDataByteOffset<T>();
 
@@ -69,15 +64,6 @@ partial class ArrayExtensions
         ref T ri = ref Unsafe.Add(ref r0, index);
 
         return ref ri;
-#elif NETCOREAPP3_1
-        RawArray3DData? arrayData = Unsafe.As<RawArray3DData>(array)!;
-        nint offset =
-            ((nint)(uint)i * (nint)(uint)arrayData.Height * (nint)(uint)arrayData.Width) +
-            ((nint)(uint)j * (nint)(uint)arrayData.Width) + (nint)(uint)k;
-        ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
-        ref T ri = ref Unsafe.Add(ref r0, offset);
-
-        return ref ri;
 #else
         int height = array.GetLength(1);
         int width = array.GetLength(2);
@@ -91,25 +77,6 @@ partial class ArrayExtensions
         return ref ri;
 #endif
     }
-
-#if NETCOREAPP3_1
-    // See description for this in the 2D partial file.
-    // Using the CHW naming scheme here (like with RGB images).
-    [StructLayout(LayoutKind.Sequential)]
-    private sealed class RawArray3DData
-    {
-#pragma warning disable CS0649 // Unassigned fields
-        public IntPtr Length;
-        public int Channel;
-        public int Height;
-        public int Width;
-        public int ChannelLowerBound;
-        public int HeightLowerBound;
-        public int WidthLowerBound;
-        public byte Data;
-#pragma warning restore CS0649
-    }
-#endif
 
 #if NETSTANDARD2_1_OR_GREATER
     /// <summary>

--- a/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
+++ b/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
@@ -26,7 +26,7 @@ public static class StringExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref char DangerousGetReference(this string text)
     {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         return ref Unsafe.AsRef(text.GetPinnableReference());
 #else
         return ref MemoryMarshal.GetReference(text.AsSpan());
@@ -43,7 +43,7 @@ public static class StringExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref char DangerousGetReferenceAt(this string text, int i)
     {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         ref char r0 = ref Unsafe.AsRef(text.GetPinnableReference());
 #else
         ref char r0 = ref MemoryMarshal.GetReference(text.AsSpan());

--- a/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Runtime.Intrinsics.X86;
 #endif
 
@@ -224,7 +224,7 @@ public static class BitHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint ExtractRange(uint value, byte start, byte length)
     {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         if (Bmi1.IsSupported)
         {
             return Bmi1.BitFieldExtract(value, start, length);
@@ -270,7 +270,7 @@ public static class BitHelper
         uint loadMask = highBits << start;
         uint storeMask = (flags & highBits) << start;
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         if (Bmi1.IsSupported)
         {
             return Bmi1.AndNot(loadMask, value) | storeMask;
@@ -386,7 +386,7 @@ public static class BitHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong ExtractRange(ulong value, byte start, byte length)
     {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         if (Bmi1.X64.IsSupported)
         {
             return Bmi1.X64.BitFieldExtract(value, start, length);
@@ -432,7 +432,7 @@ public static class BitHelper
         ulong loadMask = highBits << start;
         ulong storeMask = (flags & highBits) << start;
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         if (Bmi1.X64.IsSupported)
         {
             return Bmi1.X64.AndNot(loadMask, value) | storeMask;

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/BitOperations.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/BitOperations.cs
@@ -5,10 +5,6 @@
 #if !NET6_0_OR_GREATER
 
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1
-using System.Runtime.Intrinsics.X86;
-using static System.Numerics.BitOperations;
-#endif
 
 namespace CommunityToolkit.HighPerformance.Helpers.Internals;
 
@@ -29,22 +25,6 @@ internal static class BitOperations
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe uint RoundUpToPowerOf2(uint value)
     {
-#if NETCOREAPP3_1
-        if (Lzcnt.IsSupported)
-        {
-            if (sizeof(nint) == 8)
-            {
-                return (uint)(0x1_0000_0000ul >> LeadingZeroCount(value - 1));
-            }
-            else
-            {
-                int shift = 32 - LeadingZeroCount(value - 1);
-
-                return (1u ^ (uint)(shift >> 5)) << shift;
-            }
-        }
-#endif
-
         // Based on https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
         --value;
         value |= value >> 1;

--- a/CommunityToolkit.HighPerformance/Helpers/Internals/RuntimeHelpers.cs
+++ b/CommunityToolkit.HighPerformance/Helpers/Internals/RuntimeHelpers.cs
@@ -75,7 +75,7 @@ internal static class RuntimeHelpers
         return (nint)array.LongLength;
     }
 
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET6_0_OR_GREATER
     /// <summary>
     /// Gets the byte offset to the first <typeparamref name="T"/> element in a SZ array.
     /// </summary>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,13 +53,13 @@ jobs:
 
   # Test solution #
 
+  # Run .NET 7 unit tests
+  - script: dotnet test --no-build -c $(Build.Configuration) -f net7.0 -l "trx;LogFileName=VSTestResults_net7.0.trx"
+    displayName: Run .NET 7 unit tests
+
   # Run .NET 6 unit tests
   - script: dotnet test --no-build -c $(Build.Configuration) -f net6.0 -l "trx;LogFileName=VSTestResults_net6.0.trx"
     displayName: Run .NET 6 unit tests
-
-  # Run .NET Core 3.1 unit tests
-  - script: dotnet test --no-build -c $(Build.Configuration) -f netcoreapp3.1 -l "trx;LogFileName=VSTestResults_netcoreapp3.1.trx"
-    displayName: Run .NET Core 3.1 unit tests
 
   # Run .NET Framework 4.7.2 unit tests
   - script: dotnet test --no-build -c $(Build.Configuration) -f net472 -l "trx;LogFileName=VSTestResults_net472.trx"

--- a/tests/CommunityToolkit.Common.UnitTests/CommunityToolkit.Common.UnitTests.csproj
+++ b/tests/CommunityToolkit.Common.UnitTests/CommunityToolkit.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Diagnostics.UnitTests/CommunityToolkit.Diagnostics.UnitTests.csproj
+++ b/tests/CommunityToolkit.Diagnostics.UnitTests/CommunityToolkit.Diagnostics.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Buffers/Test_StringPool.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Buffers/Test_StringPool.cs
@@ -217,7 +217,7 @@ public class Test_StringPool
         Assert.AreEqual(nameof(helloworld), helloworld);
         Assert.AreEqual(nameof(dotnetCommunityToolkit), dotnetCommunityToolkit);
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
 
         // .NET Framework reuses strings in a way that makes these tests fail.
         // The actual underlying APIs are still working as expected though.

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/CommunityToolkit.HighPerformance.UnitTests.csproj
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/CommunityToolkit.HighPerformance.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <NoWarn>$(NoWarn);CA2252</NoWarn>
   </PropertyGroup>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Enumerables/Test_ReadOnlyRefEnumerable{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Enumerables/Test_ReadOnlyRefEnumerable{T}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
 
 using System;
 using System.Runtime.CompilerServices;
@@ -81,7 +81,7 @@ public class Test_ReadOnlyRefEnumerable
         _ = Assert.ThrowsException<IndexOutOfRangeException>(() => ReadOnlyRefEnumerable<int>.DangerousCreate(in array[0], array.Length, 1)[array.Length]);
     }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [TestMethod]
     [DataRow(1, new[] { 1 })]
     [DataRow(1, new[] { 1, 2, 3, 4 })]

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Enumerables/Test_RefEnumerable{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Enumerables/Test_RefEnumerable{T}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
 
 using System;
 using System.Runtime.CompilerServices;
@@ -81,7 +81,7 @@ public class Test_RefEnumerable
         _ = Assert.ThrowsException<IndexOutOfRangeException>(() => RefEnumerable<int>.DangerousCreate(ref array[0], array.Length, 1)[array.Length]);
     }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [TestMethod]
     [DataRow(1, new[] { 1 })]
     [DataRow(1, new[] { 1, 2, 3, 4 })]

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayExtensions.2D.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayExtensions.2D.cs
@@ -419,7 +419,7 @@ public partial class Test_ArrayExtensions
         _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() => array.GetColumn(0).ToArray());
     }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_ArrayExtensions_2D_AsSpan_Empty()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_IBufferWriterExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_IBufferWriterExtensions.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
 using System.Buffers;
 #endif
 using System.IO;

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Internals/Test_RuntimeHelpers.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Internals/Test_RuntimeHelpers.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET6_0_OR_GREATER
 
 using System;
 using CommunityToolkit.HighPerformance.Helpers.Internals;

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_HashCode{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_HashCode{T}.cs
@@ -55,7 +55,7 @@ public class Test_HashCodeOfT
         TestForType<char>();
     }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_HashCodeOfT_ManagedType_TestRepeat()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For.cs
@@ -38,7 +38,7 @@ public partial class Test_ParallelHelper
         }
     }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
     public void Test_ParallelHelper_ForInvalidRange_FromEnd()

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For2D.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Helpers/Test_ParallelHelper.For2D.cs
@@ -50,7 +50,7 @@ public partial class Test_ParallelHelper
         }
     }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [TestMethod]
     [ExpectedException(typeof(ArgumentException))]
     public void Test_ParallelHelper_For2DInvalidRange_FromEnd()

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_Memory2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_Memory2D{T}.cs
@@ -194,7 +194,7 @@ public class Test_Memory2DT
         _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() => new Memory2D<int>(array, 0, 0, 0, 3, 3));
     }
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_Memory2DT_MemoryConstructor()
     {
@@ -352,7 +352,7 @@ public class Test_Memory2DT
         Assert.AreEqual(memory.Span[2], 3);
     }
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_Memory2DT_TryGetMemory_3()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlyMemory2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlyMemory2D{T}.cs
@@ -174,7 +174,7 @@ public class Test_ReadOnlyMemory2DT
         _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() => new ReadOnlyMemory2D<int>(array, 0, 0, 0, 3, 3));
     }
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_ReadOnlyMemory2DT_ReadOnlyMemoryConstructor()
     {
@@ -316,7 +316,7 @@ public class Test_ReadOnlyMemory2DT
         Assert.AreEqual(memory.Span[2], 3);
     }
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_ReadOnlyMemory2DT_TryGetReadOnlyMemory_3()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlySpan2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlySpan2D{T}.cs
@@ -35,7 +35,7 @@ public class Test_ReadOnlySpan2DT
         Assert.AreEqual(empty2.Height, 0);
     }
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
     [TestMethod]
     public unsafe void Test_ReadOnlySpan2DT_RefConstructor()
     {
@@ -386,7 +386,7 @@ public class Test_ReadOnlySpan2DT
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref array[0, 0]));
     }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [TestMethod]
     public unsafe void Test_ReadOnlySpan2DT_Index_Indexer_1()
     {
@@ -535,7 +535,7 @@ public class Test_ReadOnlySpan2DT
         Assert.AreEqual(slice3[0, 0], 5);
     }
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_ReadOnlySpan2DT_GetRowReadOnlySpan()
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_Span2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_Span2D{T}.cs
@@ -46,7 +46,7 @@ public class Test_Span2DT
         Assert.AreEqual(empty4.Height, 0);
     }
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
     [TestMethod]
     public unsafe void Test_Span2DT_RefConstructor()
     {
@@ -546,7 +546,7 @@ public class Test_Span2DT
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref array[0, 0]));
     }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [TestMethod]
     public unsafe void Test_Span2DT_Index_Indexer_1()
     {
@@ -700,7 +700,7 @@ public class Test_Span2DT
         Assert.AreEqual(slice3[0, 0], 5);
     }
 
-#if NETCOREAPP
+#if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_Span2DT_GetRowSpan()
     {

--- a/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.Internals.UnitTests/CommunityToolkit.Mvvm.Internals.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Internals.UnitTests/CommunityToolkit.Mvvm.Internals.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.Internals.UnitTests/Test_Messenger.cs
+++ b/tests/CommunityToolkit.Mvvm.Internals.UnitTests/Test_Messenger.cs
@@ -14,7 +14,7 @@ namespace CommunityToolkit.Mvvm.Internals.UnitTests;
 [TestClass]
 public partial class Test_Messenger
 {
-#if NETCOREAPP // Auto-trimming is disabled on .NET Framework
+#if NET6_0_OR_GREATER // Auto-trimming is disabled on .NET Framework
     [TestMethod]
     public void Test_WeakReferenceMessenger_AutoCleanup()
     {

--- a/tests/CommunityToolkit.Mvvm.Roslyn401.UnitTests/CommunityToolkit.Mvvm.Roslyn401.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Roslyn401.UnitTests/CommunityToolkit.Mvvm.Roslyn401.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/tests/CommunityToolkit.Mvvm.Roslyn431.UnitTests/CommunityToolkit.Mvvm.Roslyn431.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Roslyn431.UnitTests/CommunityToolkit.Mvvm.Roslyn431.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
@@ -50,10 +50,8 @@ internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpA
     {
         CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> test = new(languageVersion) { TestCode = source };
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
-#elif NETCOREAPP3_1
-        test.TestState.ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp31;
 #else
         test.TestState.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default;
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(RequiredAttribute).Assembly.Location));


### PR DESCRIPTION
This PR includes two changes:

- Remove the .NET Core 3.1 TFM from the HighPerformance package
- Switch all unit tests from .NET Core 3.1 to .NET 7

Ie. tests are now on .NET Framework 4.7.2, .NET 6 and .NET 7.

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions