### PR TITLE
Replace Unsafe.SizeOf<T>() with sizeof(T)

### DIFF
--- a/build/Community.Toolkit.Common.props
+++ b/build/Community.Toolkit.Common.props
@@ -22,6 +22,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
+
+    <!--
+      Suppress ref safety warnings in unsafe contexts (see https://github.com/dotnet/csharplang/issues/6476).
+      This is used eg. to replace Unsafe.SizeOf<T>() calls with just sizeof(T). The warning is not necessary
+      since in order to use these APIs the caller already has to be in an unsafe context.
+    -->
+    <NoWarn>$(NoWarn);CS8500</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/CommunityToolkit.Diagnostics/Extensions/ValueTypeExtensions.cs
+++ b/src/CommunityToolkit.Diagnostics/Extensions/ValueTypeExtensions.cs
@@ -44,7 +44,7 @@ public static class ValueTypeExtensions
     public static unsafe string ToHexString<T>(this T value)
         where T : unmanaged
     {
-        int sizeOfT = Unsafe.SizeOf<T>();
+        int sizeOfT = sizeof(T);
         int bufferSize = (2 * sizeOfT) + 2;
         char* p = stackalloc char[bufferSize];
 

--- a/src/CommunityToolkit.Diagnostics/Guard.String.cs
+++ b/src/CommunityToolkit.Diagnostics/Guard.String.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Runtime.CompilerServices;
 
 #pragma warning disable CS8777

--- a/src/CommunityToolkit.HighPerformance/Buffers/Internals/ArrayMemoryManager{TFrom,TTo}.cs
+++ b/src/CommunityToolkit.HighPerformance/Buffers/Internals/ArrayMemoryManager{TFrom,TTo}.cs
@@ -70,13 +70,13 @@ internal sealed class ArrayMemoryManager<TFrom, TTo> : MemoryManager<TTo>, IMemo
     /// <inheritdoc/>
     public override unsafe MemoryHandle Pin(int elementIndex = 0)
     {
-        if ((uint)elementIndex >= (uint)(this.length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()))
+        if ((uint)elementIndex >= (uint)(this.length * sizeof(TFrom) / sizeof(TTo)))
         {
             ThrowArgumentOutOfRangeExceptionForInvalidIndex();
         }
 
-        int bytePrefix = this.offset * Unsafe.SizeOf<TFrom>();
-        int byteSuffix = elementIndex * Unsafe.SizeOf<TTo>();
+        int bytePrefix = this.offset * sizeof(TFrom);
+        int byteSuffix = elementIndex * sizeof(TTo);
         int byteOffset = bytePrefix + byteSuffix;
 
         GCHandle handle = GCHandle.Alloc(this.array, GCHandleType.Pinned);

--- a/src/CommunityToolkit.HighPerformance/Buffers/Internals/ProxyMemoryManager{TFrom,TTo}.cs
+++ b/src/CommunityToolkit.HighPerformance/Buffers/Internals/ProxyMemoryManager{TFrom,TTo}.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance.Buffers.Internals.Interfaces;
 using RuntimeHelpers = CommunityToolkit.HighPerformance.Helpers.Internals.RuntimeHelpers;
@@ -57,17 +56,17 @@ internal sealed class ProxyMemoryManager<TFrom, TTo> : MemoryManager<TTo>, IMemo
     }
 
     /// <inheritdoc/>
-    public override MemoryHandle Pin(int elementIndex = 0)
+    public override unsafe MemoryHandle Pin(int elementIndex = 0)
     {
-        if ((uint)elementIndex >= (uint)(this.length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()))
+        if ((uint)elementIndex >= (uint)(this.length * sizeof(TFrom) / sizeof(TTo)))
         {
             ThrowArgumentExceptionForInvalidIndex();
         }
 
-        int bytePrefix = this.offset * Unsafe.SizeOf<TFrom>();
-        int byteSuffix = elementIndex * Unsafe.SizeOf<TTo>();
+        int bytePrefix = this.offset * sizeof(TFrom);
+        int byteSuffix = elementIndex * sizeof(TTo);
         int byteOffset = bytePrefix + byteSuffix;
-        int shiftedOffset = Math.DivRem(byteOffset, Unsafe.SizeOf<TFrom>(), out int remainder);
+        int shiftedOffset = Math.DivRem(byteOffset, sizeof(TFrom), out int remainder);
 
         if (remainder != 0)
         {

--- a/src/CommunityToolkit.HighPerformance/Buffers/Internals/StringMemoryManager{TTo}.cs
+++ b/src/CommunityToolkit.HighPerformance/Buffers/Internals/StringMemoryManager{TTo}.cs
@@ -66,13 +66,13 @@ internal sealed class StringMemoryManager<TTo> : MemoryManager<TTo>, IMemoryMana
     /// <inheritdoc/>
     public override unsafe MemoryHandle Pin(int elementIndex = 0)
     {
-        if ((uint)elementIndex >= (uint)(this.length * Unsafe.SizeOf<char>() / Unsafe.SizeOf<TTo>()))
+        if ((uint)elementIndex >= (uint)(this.length * sizeof(char) / sizeof(TTo)))
         {
             ThrowArgumentOutOfRangeExceptionForInvalidIndex();
         }
 
-        int bytePrefix = this.offset * Unsafe.SizeOf<char>();
-        int byteSuffix = elementIndex * Unsafe.SizeOf<TTo>();
+        int bytePrefix = this.offset * sizeof(char);
+        int byteSuffix = elementIndex * sizeof(TTo);
         int byteOffset = bytePrefix + byteSuffix;
 
         GCHandle handle = GCHandle.Alloc(this.text, GCHandleType.Pinned);

--- a/src/CommunityToolkit.HighPerformance/Extensions/IBufferWriterExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/IBufferWriterExtensions.cs
@@ -45,10 +45,10 @@ public static class IBufferWriterExtensions
     /// <param name="writer">The target <see cref="IBufferWriter{T}"/> instance to write to.</param>
     /// <param name="value">The input value to write to <paramref name="writer"/>.</param>
     /// <exception cref="ArgumentException">Thrown if <paramref name="writer"/> reaches the end.</exception>
-    public static void Write<T>(this IBufferWriter<byte> writer, T value)
+    public static unsafe void Write<T>(this IBufferWriter<byte> writer, T value)
         where T : unmanaged
     {
-        int length = Unsafe.SizeOf<T>();
+        int length = sizeof(T);
         Span<byte> span = writer.GetSpan(1);
 
         if (span.Length < length)

--- a/src/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
@@ -210,13 +210,13 @@ public static class ReadOnlySpanExtensions
     /// <param name="value">The reference to the target item to get the index for.</param>
     /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>, or <c>-1</c>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOf<T>(this ReadOnlySpan<T> span, in T value)
+    public static unsafe int IndexOf<T>(this ReadOnlySpan<T> span, in T value)
     {
         ref T r0 = ref MemoryMarshal.GetReference(span);
         ref T r1 = ref Unsafe.AsRef(value);
         IntPtr byteOffset = Unsafe.ByteOffset(ref r0, ref r1);
 
-        nint elementOffset = byteOffset / (nint)(uint)Unsafe.SizeOf<T>();
+        nint elementOffset = byteOffset / (nint)(uint)sizeof(T);
 
         if ((nuint)elementOffset >= (uint)span.Length)
         {

--- a/src/CommunityToolkit.HighPerformance/Extensions/SpanExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/SpanExtensions.cs
@@ -148,12 +148,12 @@ public static class SpanExtensions
     /// <param name="value">The reference to the target item to get the index for.</param>
     /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>, or <c>-1</c>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOf<T>(this Span<T> span, ref T value)
+    public static unsafe int IndexOf<T>(this Span<T> span, ref T value)
     {
         ref T r0 = ref MemoryMarshal.GetReference(span);
         IntPtr byteOffset = Unsafe.ByteOffset(ref r0, ref value);
 
-        nint elementOffset = byteOffset / (nint)(uint)Unsafe.SizeOf<T>();
+        nint elementOffset = byteOffset / (nint)(uint)sizeof(T);
 
         if ((nuint)elementOffset >= (uint)span.Length)
         {

--- a/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
@@ -202,12 +202,12 @@ public static class StreamExtensions
 #if NETSTANDARD2_1_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-    public static T Read<T>(this Stream stream)
+    public static unsafe T Read<T>(this Stream stream)
         where T : unmanaged
     {
 #if NETSTANDARD2_1_OR_GREATER
         T result = default;
-        int length = Unsafe.SizeOf<T>();
+        int length = sizeof(T);
 
         unsafe
         {
@@ -219,7 +219,7 @@ public static class StreamExtensions
 
         return result;
 #else
-        int length = Unsafe.SizeOf<T>();
+        int length = sizeof(T);
         byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
 
         try
@@ -247,19 +247,19 @@ public static class StreamExtensions
 #if NETSTANDARD2_1_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-    public static void Write<T>(this Stream stream, in T value)
+    public static unsafe void Write<T>(this Stream stream, in T value)
         where T : unmanaged
     {
 #if NETSTANDARD2_1_OR_GREATER
         ref T r0 = ref Unsafe.AsRef(value);
         ref byte r1 = ref Unsafe.As<T, byte>(ref r0);
-        int length = Unsafe.SizeOf<T>();
+        int length = sizeof(T);
 
         ReadOnlySpan<byte> span = MemoryMarshal.CreateReadOnlySpan(ref r1, length);
 
         stream.Write(span);
 #else
-        int length = Unsafe.SizeOf<T>();
+        int length = sizeof(T);
         byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
 
         try

--- a/src/CommunityToolkit.HighPerformance/Helpers/HashCode{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Helpers/HashCode{T}.cs
@@ -50,7 +50,7 @@ public struct HashCode<T>
     /// <returns>The hash code for the input <see cref="ReadOnlySpan{T}"/> instance</returns>
     /// <remarks>The returned hash code is not processed through <see cref="HashCode"/> APIs.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static int CombineValues(ReadOnlySpan<T> span)
+    internal static unsafe int CombineValues(ReadOnlySpan<T> span)
     {
         ref T r0 = ref MemoryMarshal.GetReference(span);
 
@@ -70,7 +70,7 @@ public struct HashCode<T>
         // process. In that case it will just compute the byte size as a 32 bit
         // multiplication with overflow, which is guaranteed never to happen anyway.
         ref byte rb = ref Unsafe.As<T, byte>(ref r0);
-        nint length = (nint)((uint)span.Length * (uint)Unsafe.SizeOf<T>());
+        nint length = (nint)((uint)span.Length * (uint)sizeof(T));
 
         return SpanHelper.GetDjb2LikeByteHash(ref rb, length);
     }

--- a/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -657,7 +657,7 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="Memory2D{T}"/> instance representing a slice of the current one.</returns>
-    public Memory2D<T> Slice(int row, int column, int height, int width)
+    public unsafe Memory2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)
         {
@@ -682,7 +682,7 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
         int shift = ((this.width + this.pitch) * row) + column;
         int pitch = this.pitch + (this.width - width);
 
-        IntPtr offset = this.offset + (shift * Unsafe.SizeOf<T>());
+        IntPtr offset = this.offset + (shift * sizeof(T));
 
         return new(this.instance!, offset, height, width, pitch);
     }

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -670,7 +670,7 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="ReadOnlyMemory2D{T}"/> instance representing a slice of the current one.</returns>
-    public ReadOnlyMemory2D<T> Slice(int row, int column, int height, int width)
+    public unsafe ReadOnlyMemory2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)
         {
@@ -695,7 +695,7 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
         int shift = ((this.width + this.pitch) * row) + column;
         int pitch = this.pitch + (this.width - width);
 
-        IntPtr offset = this.offset + (shift * Unsafe.SizeOf<T>());
+        IntPtr offset = this.offset + (shift * sizeof(T));
 
         return new(this.instance!, offset, height, width, pitch);
     }

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -801,7 +801,7 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="ReadOnlySpan2D{T}"/> instance representing a slice of the current one.</returns>
-    public ReadOnlySpan2D<T> Slice(int row, int column, int height, int width)
+    public unsafe ReadOnlySpan2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)
         {
@@ -831,7 +831,7 @@ public readonly ref partial struct ReadOnlySpan2D<T>
 
         return new(in r0, height, width, pitch);
 #else
-        IntPtr offset = this.offset + (shift * (nint)(uint)Unsafe.SizeOf<T>());
+        IntPtr offset = this.offset + (shift * (nint)(uint)sizeof(T));
 
         return new(this.instance, offset, height, width, pitch);
 #endif

--- a/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -957,7 +957,7 @@ public readonly ref partial struct Span2D<T>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="Span2D{T}"/> instance representing a slice of the current one.</returns>
-    public Span2D<T> Slice(int row, int column, int height, int width)
+    public unsafe Span2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)
         {
@@ -987,7 +987,7 @@ public readonly ref partial struct Span2D<T>
 
         return new(ref r0, height, width, pitch);
 #else
-        IntPtr offset = this.Offset + (shift * (nint)(uint)Unsafe.SizeOf<T>());
+        IntPtr offset = this.Offset + (shift * (nint)(uint)sizeof(T));
 
         return new(this.Instance, offset, height, width, pitch);
 #endif

--- a/src/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.Observables.cs
+++ b/src/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.Observables.cs
@@ -3,12 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using CommunityToolkit.Mvvm.Messaging.Internals;
 
 namespace CommunityToolkit.Mvvm.Messaging;
 

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Buffers/Internals/UnmanagedSpanOwner.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Buffers/Internals/UnmanagedSpanOwner.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace CommunityToolkit.HighPerformance.UnitTests.Buffers.Internals;
@@ -32,7 +31,7 @@ internal sealed unsafe class UnmanagedSpanOwner<T> : MemoryManager<T>
     /// <param name="size">The size of the buffer to rent.</param>
     public UnmanagedSpanOwner(int size)
     {
-        this.ptr = Marshal.AllocHGlobal(size * Unsafe.SizeOf<T>());
+        this.ptr = Marshal.AllocHGlobal(size * sizeof(T));
         this.length = size;
     }
 

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_IBufferWriterExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_IBufferWriterExtensions.cs
@@ -7,7 +7,6 @@ using System;
 using System.Buffers;
 #endif
 using System.IO;
-using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Buffers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -17,7 +16,7 @@ namespace CommunityToolkit.HighPerformance.UnitTests.Extensions;
 public class Test_IBufferWriterExtensions
 {
     [TestMethod]
-    public void Test_IBufferWriterExtensions_WriteReadOverBytes()
+    public unsafe void Test_IBufferWriterExtensions_WriteReadOverBytes()
     {
         ArrayPoolBufferWriter<byte> writer = new();
 
@@ -33,7 +32,7 @@ public class Test_IBufferWriterExtensions
         writer.Write(d);
         writer.Write(guid);
 
-        int count = sizeof(byte) + sizeof(char) + sizeof(float) + sizeof(double) + Unsafe.SizeOf<Guid>();
+        int count = sizeof(byte) + sizeof(char) + sizeof(float) + sizeof(double) + sizeof(Guid);
 
         Assert.AreEqual(count, writer.WrittenCount);
 

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommandAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommandAttribute.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
This PR suppresses `CS8500` in the solution and uses `sizeof(T)` for all size-of expressions instead of `Unsafe.SizeOf<T>()`.

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions