### PR TITLE
Replace Unsafe.NullRef<T>() with ref *(T*)null

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Buffers/StringPool.cs
+++ b/src/CommunityToolkit.HighPerformance/Buffers/StringPool.cs
@@ -493,7 +493,7 @@ public sealed class StringPool
         private unsafe ref string TryGet(ReadOnlySpan<char> span, int hashcode)
         {
             ref MapEntry mapEntriesRef = ref this.mapEntries.DangerousGetReference();
-            ref MapEntry entry = ref Unsafe.NullRef<MapEntry>();
+            ref MapEntry entry = ref *(MapEntry*)null;
             int length = this.buckets.Length;
             int bucketIndex = hashcode & (length - 1);
 
@@ -512,7 +512,7 @@ public sealed class StringPool
                 }
             }
 
-            return ref Unsafe.NullRef<string>();
+            return ref *(string*)null;
         }
 
         /// <summary>

--- a/src/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
@@ -50,11 +50,11 @@ public static class NullableExtensions
     /// <returns>A reference to the value of the input <see cref="Nullable{T}"/> instance, or a <see langword="null"/> <typeparamref name="T"/> reference.</returns>
     /// <remarks>The returned reference can be tested for <see langword="null"/> using <see cref="Unsafe.IsNullRef{T}(ref T)"/>.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref T DangerousGetValueOrNullReference<T>(ref this T? value)
+    public static unsafe ref T DangerousGetValueOrNullReference<T>(ref this T? value)
         where T : struct
     {
 #if NET7_0_OR_GREATER
-        ref T resultRef = ref Unsafe.NullRef<T>();
+        ref T resultRef = ref *(T*)null;
 
         // This pattern ensures that the resulting code ends up having a single return, and a single
         // forward branch (the one where the value is null) that is predicted non taken. That is,
@@ -80,7 +80,7 @@ public static class NullableExtensions
             return ref Unsafe.As<T?, RawNullableData<T>>(ref value).Value;
         }
 
-        return ref Unsafe.NullRef<T>();
+        return ref *(T*)null;
 #endif
     }
 

--- a/src/CommunityToolkit.Mvvm/Messaging/Internals/System/Collections.Generic/Dictionary2.cs
+++ b/src/CommunityToolkit.Mvvm/Messaging/Internals/System/Collections.Generic/Dictionary2.cs
@@ -340,9 +340,9 @@ internal class Dictionary2<TKey, TValue> : IDictionary2<TKey, TValue>
     /// </summary>
     /// <param name="key">Key to look for.</param>
     /// <returns>Reference to the existing value.</returns>
-    private ref TValue FindValue(TKey key)
+    private unsafe ref TValue FindValue(TKey key)
     {
-        ref Entry entry = ref Unsafe.NullRef<Entry>();
+        ref Entry entry = ref *(Entry*)null;
         uint hashCode = (uint)key.GetHashCode();
         int i = GetBucket(hashCode);
         Entry[] entries = this.entries;
@@ -373,7 +373,7 @@ internal class Dictionary2<TKey, TValue> : IDictionary2<TKey, TValue>
         return ref value;
 
         ReturnNotFound:
-        value = ref Unsafe.NullRef<TValue>();
+        value = ref *(TValue*)null;
 
         goto Return;
     }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Enumerables/Test_ReadOnlyRefEnumerable{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Enumerables/Test_ReadOnlyRefEnumerable{T}.cs
@@ -5,7 +5,6 @@
 #if NET6_0_OR_GREATER
 
 using System;
-using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Enumerables;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -41,9 +40,9 @@ public class Test_ReadOnlyRefEnumerable
     [DataRow(10, -14)]
     [DataRow(-32, -1)]
     [ExpectedException(typeof(ArgumentOutOfRangeException))]
-    public void Test_ReadOnlyRefEnumerable_DangerousCreate_BelowZero(int length, int step)
+    public unsafe void Test_ReadOnlyRefEnumerable_DangerousCreate_BelowZero(int length, int step)
     {
-        _ = ReadOnlyRefEnumerable<int>.DangerousCreate(in Unsafe.NullRef<int>(), length, step);
+        _ = ReadOnlyRefEnumerable<int>.DangerousCreate(in *(int*)null, length, step);
     }
 
     [TestMethod]

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Enumerables/Test_RefEnumerable{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Enumerables/Test_RefEnumerable{T}.cs
@@ -5,7 +5,6 @@
 #if NET6_0_OR_GREATER
 
 using System;
-using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Enumerables;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -41,9 +40,9 @@ public class Test_RefEnumerable
     [DataRow(10, -14)]
     [DataRow(-32, -1)]
     [ExpectedException(typeof(ArgumentOutOfRangeException))]
-    public void Test_RefEnumerable_DangerousCreate_BelowZero(int length, int step)
+    public unsafe void Test_RefEnumerable_DangerousCreate_BelowZero(int length, int step)
     {
-        _ = RefEnumerable<int>.DangerousCreate(ref Unsafe.NullRef<int>(), length, step);
+        _ = RefEnumerable<int>.DangerousCreate(ref *(int*)null, length, step);
     }
 
     [TestMethod]


### PR DESCRIPTION
This PR replace `Unsafe.NullRef<T>()` with `ref *(T*)null`.

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions