### PR TITLE
Use ref fields on .NET 7 for all span-like types

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Enumerables/ReadOnlySpanEnumerable{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Enumerables/ReadOnlySpanEnumerable{T}.cs
@@ -81,10 +81,22 @@ public ref struct ReadOnlySpanEnumerable<T>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly ref struct Item
     {
+#if NET7_0_OR_GREATER
+        /// <summary>
+        /// The <typeparamref name="T"/> reference for the <see cref="Item"/> instance.
+        /// </summary>
+        private readonly ref readonly T reference;
+
+        /// <summary>
+        /// The index of the current <see cref="Item"/> instance.
+        /// </summary>
+        private readonly int index;
+#else
         /// <summary>
         /// The source <see cref="ReadOnlySpan{T}"/> instance.
         /// </summary>
         private readonly ReadOnlySpan<T> span;
+#endif
 
 #if NETSTANDARD2_1_OR_GREATER
         /// <summary>
@@ -95,7 +107,12 @@ public ref struct ReadOnlySpanEnumerable<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Item(ref T value, int index)
         {
+#if NET7_0_OR_GREATER
+            this.reference = ref value;
+            this.index = index;
+#else
             this.span = MemoryMarshal.CreateReadOnlySpan(ref value, index);
+#endif
         }
 #else
         /// <summary>
@@ -124,7 +141,9 @@ public ref struct ReadOnlySpanEnumerable<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+                return ref this.reference;
+#elif NETSTANDARD2_1_OR_GREATER
                 return ref MemoryMarshal.GetReference(this.span);
 #else
                 ref T r0 = ref MemoryMarshal.GetReference(this.span);
@@ -143,7 +162,9 @@ public ref struct ReadOnlySpanEnumerable<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+                return this.index;
+#elif NETSTANDARD2_1_OR_GREATER
                 return this.span.Length;
 #else
                 return this.index;

--- a/src/CommunityToolkit.HighPerformance/Enumerables/SpanEnumerable{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Enumerables/SpanEnumerable{T}.cs
@@ -86,10 +86,22 @@ public ref struct SpanEnumerable<T>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly ref struct Item
     {
+#if NET7_0_OR_GREATER
+        /// <summary>
+        /// The <typeparamref name="T"/> reference for the <see cref="Item"/> instance.
+        /// </summary>
+        private readonly ref T reference;
+
+        /// <summary>
+        /// The index of the current <see cref="Item"/> instance.
+        /// </summary>
+        private readonly int index;
+#else
         /// <summary>
         /// The source <see cref="Span{T}"/> instance.
         /// </summary>
         private readonly Span<T> span;
+#endif
 
 #if NETSTANDARD2_1_OR_GREATER
         /// <summary>
@@ -100,7 +112,12 @@ public ref struct SpanEnumerable<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Item(ref T value, int index)
         {
+#if NET7_0_OR_GREATER
+            this.reference = ref value;
+            this.index = index;
+#else
             this.span = MemoryMarshal.CreateSpan(ref value, index);
+#endif
         }
 #else
         /// <summary>
@@ -121,15 +138,17 @@ public ref struct SpanEnumerable<T>
         }
 #endif
 
-        /// <summary>
-        /// Gets the reference to the current value.
-        /// </summary>
+            /// <summary>
+            /// Gets the reference to the current value.
+            /// </summary>
         public ref T Value
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+                return ref this.reference;
+#elif NETSTANDARD2_1_OR_GREATER
                 return ref MemoryMarshal.GetReference(this.span);
 #else
                 ref T r0 = ref MemoryMarshal.GetReference(this.span);
@@ -148,7 +167,9 @@ public ref struct SpanEnumerable<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+                return this.index;
+#elif NETSTANDARD2_1_OR_GREATER
                 return this.span.Length;
 #else
                 return this.index;

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
@@ -2,13 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if !NET7_0_OR_GREATER
 using System;
+#endif
 using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Enumerables;
 using CommunityToolkit.HighPerformance.Memory.Internals;
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER && !NET7_0_OR_GREATER
 using System.Runtime.InteropServices;
-#else
+#elif NETSTANDARD2_0
 using RuntimeHelpers = CommunityToolkit.HighPerformance.Helpers.Internals.RuntimeHelpers;
 #endif
 
@@ -84,7 +86,17 @@ partial struct ReadOnlySpan2D<T>
     /// </summary>
     public ref struct Enumerator
     {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        /// <summary>
+        /// The <typeparamref name="T"/> reference for the <see cref="ReadOnlySpan2D{T}"/> instance.
+        /// </summary>
+        private readonly ref readonly T reference;
+
+        /// <summary>
+        /// The height of the specified 2D region.
+        /// </summary>
+        private readonly int height;
+#elif NETSTANDARD2_1_OR_GREATER
         /// <summary>
         /// The <see cref="ReadOnlySpan{T}"/> instance pointing to the first item in the target memory area.
         /// </summary>
@@ -133,7 +145,10 @@ partial struct ReadOnlySpan2D<T>
         /// <param name="span">The target <see cref="ReadOnlySpan2D{T}"/> instance to enumerate.</param>
         internal Enumerator(ReadOnlySpan2D<T> span)
         {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+            this.reference = ref span.reference;
+            this.height = span.height;
+#elif NETSTANDARD2_1_OR_GREATER
             this.span = span.span;
 #else
             this.instance = span.instance;
@@ -167,7 +182,9 @@ partial struct ReadOnlySpan2D<T>
             // another row available: wrap to a new line and continue.
             this.x = 0;
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+            return ++this.y < this.height;
+#elif NETSTANDARD2_1_OR_GREATER
             return ++this.y < this.span.Length;
 #else
             return ++this.y < this.height;
@@ -182,7 +199,9 @@ partial struct ReadOnlySpan2D<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+                ref T r0 = ref Unsafe.AsRef(in this.reference);
+#elif NETSTANDARD2_1_OR_GREATER
                 ref T r0 = ref MemoryMarshal.GetReference(this.span);
 #else
                 ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -780,14 +780,14 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// <returns>A reference to the 0th element, or a <see langword="null"/> reference.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public unsafe ref T GetPinnableReference()
+    public unsafe ref readonly T GetPinnableReference()
     {
-        ref T r0 = ref Unsafe.AsRef<T>(null);
+        ref readonly T r0 = ref Unsafe.AsRef<T>(null);
 
         if (Length != 0)
         {
 #if NET7_0_OR_GREATER
-            r0 = ref Unsafe.AsRef(in this.reference);
+            r0 = ref this.reference;
 #elif NETSTANDARD2_1_OR_GREATER
             r0 = ref MemoryMarshal.GetReference(this.span);
 #else

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -28,7 +28,17 @@ namespace CommunityToolkit.HighPerformance;
 [DebuggerDisplay("{ToString(),raw}")]
 public readonly ref partial struct ReadOnlySpan2D<T>
 {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// The <typeparamref name="T"/> reference for the <see cref="ReadOnlySpan2D{T}"/> instance.
+    /// </summary>
+    private readonly ref readonly T reference;
+
+    /// <summary>
+    /// The height of the specified 2D region.
+    /// </summary>
+    private readonly int height;
+#elif NETSTANDARD2_1_OR_GREATER
     /// <summary>
     /// The <see cref="ReadOnlySpan{T}"/> instance pointing to the first item in the target memory area.
     /// </summary>
@@ -71,7 +81,12 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ReadOnlySpan2D(in T value, int height, int width, int pitch)
     {
+#if NET7_0_OR_GREATER
+        this.reference = ref value;
+        this.height = height;
+#else
         this.span = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(value), height);
+#endif
         this.width = width;
         this.stride = width + pitch;
     }
@@ -109,7 +124,10 @@ public readonly ref partial struct ReadOnlySpan2D<T>
 
         OverflowHelper.EnsureIsInNativeIntRange(height, width, pitch);
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        this.reference = ref Unsafe.AsRef<T>(pointer);
+        this.height = height;
+#elif NETSTANDARD2_1_OR_GREATER
         this.span = new ReadOnlySpan<T>(pointer, height);
 #else
         this.instance = null;
@@ -206,7 +224,10 @@ public readonly ref partial struct ReadOnlySpan2D<T>
             ThrowHelper.ThrowArgumentException();
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        this.reference = ref array.DangerousGetReferenceAt(offset);
+        this.height = height;
+#elif NETSTANDARD2_1_OR_GREATER
         this.span = MemoryMarshal.CreateReadOnlySpan(ref array.DangerousGetReferenceAt(offset), height);
 #else
         this.instance = array;
@@ -230,7 +251,10 @@ public readonly ref partial struct ReadOnlySpan2D<T>
             return;
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        this.reference = ref array.DangerousGetReference();
+        this.height = array.GetLength(0);
+#elif NETSTANDARD2_1_OR_GREATER
         this.span = MemoryMarshal.CreateReadOnlySpan(ref array.DangerousGetReference(), array.GetLength(0));
 #else
         this.instance = array;
@@ -289,7 +313,10 @@ public readonly ref partial struct ReadOnlySpan2D<T>
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForWidth();
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        this.reference = ref array.DangerousGetReferenceAt(row, column);
+        this.height = height;
+#elif NETSTANDARD2_1_OR_GREATER
         this.span = MemoryMarshal.CreateReadOnlySpan(ref array.DangerousGetReferenceAt(row, column), height);
 #else
         this.instance = array;
@@ -313,7 +340,10 @@ public readonly ref partial struct ReadOnlySpan2D<T>
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForDepth();
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        this.reference = ref array.DangerousGetReferenceAt(depth, 0, 0);
+        this.height = array.GetLength(1);
+#elif NETSTANDARD2_1_OR_GREATER
         this.span = MemoryMarshal.CreateReadOnlySpan(ref array.DangerousGetReferenceAt(depth, 0, 0), array.GetLength(1));
 #else
         this.instance = array;
@@ -363,7 +393,10 @@ public readonly ref partial struct ReadOnlySpan2D<T>
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForWidth();
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        this.reference = ref array.DangerousGetReferenceAt(depth, row, column);
+        this.height = height;
+#elif NETSTANDARD2_1_OR_GREATER
         this.span = MemoryMarshal.CreateReadOnlySpan(ref array.DangerousGetReferenceAt(depth, row, column), height);
 #else
         this.instance = array;
@@ -441,7 +474,12 @@ public readonly ref partial struct ReadOnlySpan2D<T>
             ThrowHelper.ThrowArgumentException();
         }
 
+#if NET7_0_OR_GREATER
+        this.reference = ref span.DangerousGetReferenceAt(offset);
+        this.height = height;
+#else
         this.span = MemoryMarshal.CreateSpan(ref span.DangerousGetReferenceAt(offset), height);
+#endif
         this.width = width;
         this.stride = width + pitch;
     }
@@ -509,7 +547,9 @@ public readonly ref partial struct ReadOnlySpan2D<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+            return this.height;
+#elif NETSTANDARD2_1_OR_GREATER
             return this.span.Length;
 #else
             return this.height;
@@ -746,7 +786,9 @@ public readonly ref partial struct ReadOnlySpan2D<T>
 
         if (Length != 0)
         {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+            r0 = ref Unsafe.AsRef(in this.reference);
+#elif NETSTANDARD2_1_OR_GREATER
             r0 = ref MemoryMarshal.GetReference(this.span);
 #else
             r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
@@ -763,7 +805,9 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T DangerousGetReference()
     {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        return ref Unsafe.AsRef(in this.reference);
+#elif NETSTANDARD2_1_OR_GREATER
         return ref MemoryMarshal.GetReference(this.span);
 #else
         return ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
@@ -779,7 +823,9 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T DangerousGetReferenceAt(int i, int j)
     {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        ref T r0 = ref Unsafe.AsRef(in this.reference);
+#elif NETSTANDARD2_1_OR_GREATER
         ref T r0 = ref MemoryMarshal.GetReference(this.span);
 #else
         ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
@@ -826,7 +872,11 @@ public readonly ref partial struct ReadOnlySpan2D<T>
         nint shift = ((nint)(uint)this.stride * (nint)(uint)row) + (nint)(uint)column;
         int pitch = this.stride - width;
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        ref T r0 = ref Unsafe.Add(ref Unsafe.AsRef(in this.reference), shift);
+
+        return new(in r0, height, width, pitch);
+#elif NETSTANDARD2_1_OR_GREATER
         ref T r0 = ref this.span.DangerousGetReferenceAt(shift);
 
         return new(in r0, height, width, pitch);
@@ -868,7 +918,11 @@ public readonly ref partial struct ReadOnlySpan2D<T>
         if (this.stride == this.width &&
             Length <= int.MaxValue)
         {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+            span = MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.reference), (int)Length);
+
+            return true;
+#elif NETSTANDARD2_1_OR_GREATER
             span = MemoryMarshal.CreateReadOnlySpan(ref MemoryMarshal.GetReference(this.span), (int)Length);
 
             return true;
@@ -979,7 +1033,10 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     public static bool operator ==(ReadOnlySpan2D<T> left, ReadOnlySpan2D<T> right)
     {
         return
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+            Unsafe.AreSame(ref Unsafe.AsRef(in left.reference), ref Unsafe.AsRef(in right.reference)) &&
+            left.height == right.height &&
+#elif NETSTANDARD2_1_OR_GREATER
             left.span == right.span &&
 #else
             ReferenceEquals(

--- a/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
@@ -2,13 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if !NET7_0_OR_GREATER
 using System;
+#endif
 using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Enumerables;
 using CommunityToolkit.HighPerformance.Memory.Internals;
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER && !NET7_0_OR_GREATER
 using System.Runtime.InteropServices;
-#else
+#elif NETSTANDARD2_0
 using RuntimeHelpers = CommunityToolkit.HighPerformance.Helpers.Internals.RuntimeHelpers;
 #endif
 
@@ -84,7 +86,17 @@ partial struct Span2D<T>
     /// </summary>
     public ref struct Enumerator
     {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+        /// <summary>
+        /// The <typeparamref name="T"/> reference for the <see cref="Span2D{T}"/> instance.
+        /// </summary>
+        private readonly ref T reference;
+
+        /// <summary>
+        /// The height of the specified 2D region.
+        /// </summary>
+        private readonly int height;
+#elif NETSTANDARD2_1_OR_GREATER
         /// <summary>
         /// The <see cref="Span{T}"/> instance pointing to the first item in the target memory area.
         /// </summary>
@@ -133,7 +145,10 @@ partial struct Span2D<T>
         /// <param name="span">The target <see cref="Span2D{T}"/> instance to enumerate.</param>
         internal Enumerator(Span2D<T> span)
         {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+            this.reference = ref span.reference;
+            this.height = span.height;
+#elif NETSTANDARD2_1_OR_GREATER
             this.span = span.span;
 #else
             this.instance = span.Instance;
@@ -167,7 +182,9 @@ partial struct Span2D<T>
             // another row available: wrap to a new line and continue.
             this.x = 0;
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+            return ++this.y < this.height;
+#elif NETSTANDARD2_1_OR_GREATER
             return ++this.y < this.span.Length;
 #else
             return ++this.y < this.height;
@@ -182,7 +199,9 @@ partial struct Span2D<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-#if NETSTANDARD2_1_OR_GREATER
+#if NET7_0_OR_GREATER
+                ref T r0 = ref this.reference;
+#elif NETSTANDARD2_1_OR_GREATER
                 ref T r0 = ref MemoryMarshal.GetReference(this.span);
 #else
                 ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlySpan2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlySpan2D{T}.cs
@@ -351,7 +351,7 @@ public class Test_ReadOnlySpan2DT
     {
         Assert.IsTrue(Unsafe.AreSame(
             ref Unsafe.AsRef<int>(null),
-            ref ReadOnlySpan2D<int>.Empty.GetPinnableReference()));
+            ref Unsafe.AsRef(in ReadOnlySpan2D<int>.Empty.GetPinnableReference())));
 
         int[,] array =
         {
@@ -361,7 +361,7 @@ public class Test_ReadOnlySpan2DT
 
         ReadOnlySpan2D<int> span2d = new(array);
 
-        ref int r0 = ref span2d.GetPinnableReference();
+        ref int r0 = ref Unsafe.AsRef(in span2d.GetPinnableReference());
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref array[0, 0]));
     }


### PR DESCRIPTION
This PR uses `ref` fields in all span-like types (ie. `Span2D<T>`, `SpanEnumerable<T>`, `RefEnumerable<T>`).

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions