### PR TITLE
Fix StreamExtensions.Read<T> when using buffered streams

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
@@ -236,7 +236,7 @@ public static class StreamExtensions
         {
             do
             {
-                int bytesRead = stream.Read(buffer.AsSpan(bytesOffset, sizeof(T) - bytesOffset));
+                int bytesRead = stream.Read(buffer, bytesOffset, sizeof(T) - bytesOffset);
 
                 if (bytesRead == 0)
                 {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_StreamExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_StreamExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using CommunityToolkit.HighPerformance;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.HighPerformance.UnitTests.Extensions;
@@ -36,5 +35,84 @@ public class Test_StreamExtensions
         Assert.AreEqual(unchecked(uint.MaxValue * 324823489204ul), stream.Read<ulong>());
 
         _ = Assert.ThrowsException<InvalidOperationException>(() => stream.Read<long>());
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/513
+    [TestMethod]
+    public void Test_StreamExtensions_ReadWrite_WithBufferedStream()
+    {
+        Stream stream = new BufferedStream();
+
+        stream.Write(true);
+        stream.Write(42);
+        stream.Write(3.14f);
+        stream.Write(unchecked(uint.MaxValue * 324823489204ul));
+
+        stream.Position = 0;
+
+        Assert.AreEqual(true, stream.Read<bool>());
+        Assert.AreEqual(42, stream.Read<int>());
+        Assert.AreEqual(3.14f, stream.Read<float>());
+        Assert.AreEqual(unchecked(uint.MaxValue * 324823489204ul), stream.Read<ulong>());
+
+        _ = Assert.ThrowsException<InvalidOperationException>(() => stream.Read<long>());
+    }
+
+    private sealed class BufferedStream : MemoryStream
+    {
+        private ReadOnlyMemory<byte> bufferedBytes;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (this.bufferedBytes.IsEmpty)
+            {
+                this.bufferedBytes = ReadMoreBytes();
+            }
+
+            int bytesToCopy = Math.Min(this.bufferedBytes.Length, count);
+
+            this.bufferedBytes.Span.Slice(0, bytesToCopy).CopyTo(buffer.AsSpan(offset, count));
+            this.bufferedBytes = this.bufferedBytes.Slice(bytesToCopy);
+
+            return bytesToCopy;
+        }
+
+#if NET6_0_OR_GREATER
+        public override int Read(Span<byte> buffer)
+        {
+            if (this.bufferedBytes.IsEmpty)
+            {
+                this.bufferedBytes = ReadMoreBytes();
+            }
+
+            int bytesToCopy = Math.Min(this.bufferedBytes.Length, buffer.Length);
+
+            this.bufferedBytes.Span.Slice(0, bytesToCopy).CopyTo(buffer);
+            this.bufferedBytes = this.bufferedBytes.Slice(bytesToCopy);
+
+            return bytesToCopy;
+        }
+#endif
+
+        private byte[] ReadMoreBytes()
+        {
+            byte[] array = new byte[3];
+            int bytesOffset = 0;
+
+            do
+            {
+                int bytesRead = base.Read(array, bytesOffset, 3 - bytesOffset);
+
+                bytesOffset += bytesRead;
+
+                if (bytesRead == 0)
+                {
+                    return array.AsSpan(0, bytesOffset).ToArray();
+                }
+            }
+            while (bytesOffset < 3);
+
+            return array;
+        }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #513**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions
<!-- Please add any other information that might be helpful to reviewers. -->