### PR TITLE
Add analyzer for incorrect [INotifyPropertyChanged] and [ObservableObject] use

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -38,3 +38,5 @@ MVVMTK0028 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator 
 MVVMTK0029 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0029
 MVVMTK0030 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0030
 MVVMTK0031 | CommunityToolkit.Mvvm.SourceGenerators.RelayCommandGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0031
+MVVMTK0032 | CommunityToolkit.Mvvm.SourceGenerators.INotifyPropertyChangedGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0032
+MVVMTK0033 | CommunityToolkit.Mvvm.SourceGenerators.ObservableObjectGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0033

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -49,6 +49,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.Execute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\FieldWithOrphanedDependentObservablePropertyAttributesAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\ClassUsingAttributeInsteadOfInheritanceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\UnsupportedCSharpLanguageVersionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Suppressors\ObservablePropertyAttributeWithPropertyTargetDiagnosticSuppressor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\DiagnosticDescriptors.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/ClassUsingAttributeInsteadOfInheritanceAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/ClassUsingAttributeInsteadOfInheritanceAnalyzer.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates a warning when a class is using a code generation attribute when it could inherit instead.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ClassUsingAttributeInsteadOfInheritanceAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The mapping of target attributes that will trigger the analyzer.
+    /// </summary>
+    private static readonly ImmutableDictionary<string, string> GeneratorAttributeNamesToFullyQualifiedNamesMap = ImmutableDictionary.CreateRange(new[]
+    {
+        new KeyValuePair<string, string>("ObservableObjectAttribute", "CommunityToolkit.Mvvm.ComponentModel.ObservableObjectAttribute"),
+        new KeyValuePair<string, string>("INotifyPropertyChangedAttribute", "CommunityToolkit.Mvvm.ComponentModel.INotifyPropertyChangedAttribute"),
+    });
+
+    /// <summary>
+    /// The mapping of diagnostics for each target attribute.
+    /// </summary>
+    private static readonly ImmutableDictionary<string, DiagnosticDescriptor> GeneratorAttributeNamesToDiagnosticsMap = ImmutableDictionary.CreateRange(new[]
+    {
+        new KeyValuePair<string, DiagnosticDescriptor>("ObservableObjectAttribute", InheritFromObservableObjectInsteadOfUsingObservableObjectAttributeWarning),
+        new KeyValuePair<string, DiagnosticDescriptor>("INotifyPropertyChangedAttribute", InheritFromObservableObjectInsteadOfUsingINotifyPropertyChangedAttributeWarning),
+    });
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        InheritFromObservableObjectInsteadOfUsingObservableObjectAttributeWarning,
+        InheritFromObservableObjectInsteadOfUsingINotifyPropertyChangedAttributeWarning);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        // Defer the callback registration to when the compilation starts, so we can execute more
+        // preliminary checks and skip registering any kind of symbol analysis at all if not needed.
+        context.RegisterSymbolAction(static context =>
+        {
+            // We're looking for class declarations
+            if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Class, IsRecord: false, IsStatic: false, IsImplicitlyDeclared: false } classSymbol)
+            {
+                return;
+            }
+
+            foreach (AttributeData attribute in context.Symbol.GetAttributes())
+            {
+                // Same logic as in FieldWithOrphanedDependentObservablePropertyAttributesAnalyzer to find target attributes
+                if (attribute.AttributeClass is { Name: string attributeName } attributeClass &&
+                    GeneratorAttributeNamesToFullyQualifiedNamesMap.TryGetValue(attributeName, out string? fullyQualifiedAttributeName) &&
+                    context.Compilation.GetTypeByMetadataName(fullyQualifiedAttributeName) is INamedTypeSymbol attributeSymbol &&
+                    SymbolEqualityComparer.Default.Equals(attributeClass, attributeSymbol))
+                {
+                    // The type is annotated with either [ObservableObject] or [INotifyPropertyChanged].
+                    // Next, we need to check whether it isn't already inheriting from another type.
+                    if (classSymbol.BaseType is { SpecialType: SpecialType.System_Object })
+                    {
+                        // This type is using the attribute when it could just inherit from ObservableObject, which is preferred
+                        context.ReportDiagnostic(Diagnostic.Create(GeneratorAttributeNamesToDiagnosticsMap[attributeClass.Name], context.Symbol.Locations.FirstOrDefault(), context.Symbol));
+                    }
+                }
+            }
+        }, SymbolKind.NamedType);
+    }
+}

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UnsupportedCSharpLanguageVersionAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UnsupportedCSharpLanguageVersionAnalyzer.cs
@@ -32,7 +32,7 @@ public sealed class UnsupportedCSharpLanguageVersionAnalyzer : DiagnosticAnalyze
         new KeyValuePair<string, string>("ObservableObjectAttribute", "CommunityToolkit.Mvvm.ComponentModel.ObservableObjectAttribute"),
         new KeyValuePair<string, string>("ObservablePropertyAttribute", "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute"),
         new KeyValuePair<string, string>("ObservableRecipientAttribute", "CommunityToolkit.Mvvm.ComponentModel.ObservableRecipientAttribute"),
-        new KeyValuePair<string, string>("RelayCommandAttribute", "CommunityToolkit.Mvvm.Input.RelayCommandAttribute"),
+        new KeyValuePair<string, string>("RelayCommandAttribute", "CommunityToolkit.Mvvm.Input.RelayCommandAttribute")
     });
 
     /// <inheritdoc/>
@@ -62,15 +62,7 @@ public sealed class UnsupportedCSharpLanguageVersionAnalyzer : DiagnosticAnalyze
                     return;
                 }
 
-                ImmutableArray<AttributeData> attributes = context.Symbol.GetAttributes();
-
-                // If the symbol has no attributes, there's nothing left to do
-                if (attributes.IsEmpty)
-                {
-                    return;
-                }
-
-                foreach (AttributeData attribute in attributes)
+                foreach (AttributeData attribute in context.Symbol.GetAttributes())
                 {
                     // Go over each attribute on the target symbol, and check if the attribute type name is a candidate.
                     // If it is, double check by actually resolving the symbol from the compilation and comparing against it.

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -134,7 +134,7 @@ internal static class DiagnosticDescriptors
         id: "MVVMTK0008",
         title: "Unsupported C# language version",
         messageFormat: "The source generator features from the MVVM Toolkit require consuming projects to set the C# language version to at least C# 8.0",
-        category: typeof(CSharpParseOptions).FullName,
+        category: typeof(UnsupportedCSharpLanguageVersionAnalyzer).FullName,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "The source generator features from the MVVM Toolkit require consuming projects to set the C# language version to at least C# 8.0. Make sure to add <LangVersion>8.0</LangVersion> (or above) to your .csproj file.",
@@ -507,4 +507,40 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Cannot apply the [RelayCommand] attribute specifying a task scheduler exception flow option to methods mapping to non-asynchronous command types.",
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0031");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when <c>[INotifyPropertyChanged]</c> is used on a type that could inherit from <c>ObservableObject</c> instead.
+    /// <para>
+    /// Format: <c>"The type {0} is using the [INotifyPropertyChanged] attribute while having no base type, and it should instead inherit from ObservableObject"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InheritFromObservableObjectInsteadOfUsingINotifyPropertyChangedAttributeWarning = new DiagnosticDescriptor(
+        id: "MVVMTK0032",
+        title: "Inherit from ObservableObject instead of using [INotifyPropertyChanged]",
+        messageFormat: "The type {0} is using the [INotifyPropertyChanged] attribute while having no base type, and it should instead inherit from ObservableObject",
+        category: typeof(INotifyPropertyChangedGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "Classes with no base types should prefer inheriting from ObservableObject instead of using attributes to generate INotifyPropertyChanged code, as that will " +
+            "reduce the binary size of the application (the attributes are only meant to support cases where the annotated types are already inheriting from a different type).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0032");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when <c>[ObservableObject]</c> is used on a type that could inherit from <c>ObservableObject</c> instead.
+    /// <para>
+    /// Format: <c>"The type {0} is using the [ObservableObject] attribute while having no base type, and it should instead inherit from ObservableObject"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InheritFromObservableObjectInsteadOfUsingObservableObjectAttributeWarning = new DiagnosticDescriptor(
+        id: "MVVMTK0033",
+        title: "Inherit from ObservableObject instead of using [ObservableObject]",
+        messageFormat: "The type {0} is using the [ObservableObject] attribute while having no base type, and it should instead inherit from ObservableObject",
+        category: typeof(ObservableObjectGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "Classes with no base types should prefer inheriting from ObservableObject instead of using attributes to generate INotifyPropertyChanged code, as that will " +
+            "reduce the binary size of the application (the attributes are only meant to support cases where the annotated types are already inheriting from a different type).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0032");
 }

--- a/tests/CommunityToolkit.Mvvm.ExternalAssembly/ModelWithObservableObjectAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.ExternalAssembly/ModelWithObservableObjectAttribute.cs
@@ -4,6 +4,8 @@
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
+#pragma warning disable MVVMTK0033
+
 namespace CommunityToolkit.Mvvm.ExternalAssembly;
 
 /// <summary>

--- a/tests/CommunityToolkit.Mvvm.ExternalAssembly/SampleModelWithINPCAndObservableProperties.cs
+++ b/tests/CommunityToolkit.Mvvm.ExternalAssembly/SampleModelWithINPCAndObservableProperties.cs
@@ -4,6 +4,8 @@
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
+#pragma warning disable MVVMTK0032
+
 namespace CommunityToolkit.Mvvm.ExternalAssembly;
 
 /// <summary>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -1495,6 +1495,42 @@ public class Test_SourceGeneratorsDiagnostics
         VerifyGeneratedDiagnostics<RelayCommandGenerator>(source, "MVVMTK0031");
     }
 
+    [TestMethod]
+    public async Task UsingINotifyPropertyChangedAttributeOnClassWithNoBaseType()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                [INotifyPropertyChanged]
+                public partial class {|MVVMTK0032:SampleViewModel|}
+                {
+                }
+            }
+            """;
+
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<ClassUsingAttributeInsteadOfInheritanceAnalyzer>(source, LanguageVersion.CSharp8);
+    }
+
+    [TestMethod]
+    public async Task UsingObservableObjectAttributeOnClassWithNoBaseType()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                [ObservableObject]
+                public partial class {|MVVMTK0033:SampleViewModel|}
+                {
+                }
+            }
+            """;
+
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<ClassUsingAttributeInsteadOfInheritanceAnalyzer>(source, LanguageVersion.CSharp8);
+    }
+
     /// <summary>
     /// Verifies the diagnostic errors for a given analyzer, and that all available source generators can run successfully with the input source (including subsequent compilation).
     /// </summary>
@@ -1536,20 +1572,6 @@ public class Test_SourceGeneratorsDiagnostics
         IIncrementalGenerator generator = new TGenerator();
 
         VerifyGeneratedDiagnostics(CSharpSyntaxTree.ParseText(source, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp8)), new[] { generator }, diagnosticsIds);
-    }
-
-    /// <summary>
-    /// Verifies the output of a source generator.
-    /// </summary>
-    /// <typeparam name="TGenerator">The generator type to use.</typeparam>
-    /// <param name="syntaxTree">The input source to process.</param>
-    /// <param name="diagnosticsIds">The diagnostic ids to expect for the input source code.</param>
-    private static void VerifyGeneratedDiagnostics<TGenerator>(SyntaxTree syntaxTree, params string[] diagnosticsIds)
-        where TGenerator : class, IIncrementalGenerator, new()
-    {
-        IIncrementalGenerator generator = new TGenerator();
-
-        VerifyGeneratedDiagnostics(syntaxTree, new[] { generator }, diagnosticsIds);
     }
 
     /// <summary>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_INotifyPropertyChangedAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_INotifyPropertyChangedAttribute.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#pragma warning disable MVVMTK0032
+
 namespace CommunityToolkit.Mvvm.UnitTests;
 
 [TestClass]

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservableObjectAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservableObjectAttribute.cs
@@ -6,6 +6,8 @@ using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#pragma warning disable MVVMTK0033
+
 namespace CommunityToolkit.Mvvm.UnitTests;
 
 [TestClass]

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -8,7 +8,9 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
+#if NET6_0_OR_GREATER
 using System.Runtime.CompilerServices;
+#endif
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
@@ -18,6 +20,8 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#pragma warning disable MVVMTK0032, MVVMTK0033
 
 namespace CommunityToolkit.Mvvm.UnitTests;
 

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservableRecipientAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservableRecipientAttribute.cs
@@ -12,6 +12,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#pragma warning disable MVVMTK0033
+
 namespace CommunityToolkit.Mvvm.UnitTests;
 
 [TestClass]

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_SourceGenerators.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_SourceGenerators.cs
@@ -7,6 +7,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#pragma warning disable MVVMTK0032
+
 namespace CommunityToolkit.Mvvm.UnitTests;
 
 /// <summary>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #530**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions