### PR TITLE
Use Stream.ReadExactly on .NET 7

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
@@ -205,8 +205,14 @@ public static class StreamExtensions
     public static unsafe T Read<T>(this Stream stream)
         where T : unmanaged
     {
-#if NETSTANDARD2_1_OR_GREATER
-        T result = default;
+#if NET7_0_OR_GREATER
+        T result;
+
+        stream.ReadExactly(new Span<byte>(&result, sizeof(T)));
+
+        return result;
+#elif NETSTANDARD2_1_OR_GREATER
+        T result;
         int bytesOffset = 0;
 
         // As per Stream.Read's documentation:

--- a/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
@@ -198,7 +198,7 @@ public static class StreamExtensions
     /// <typeparam name="T">The type of value to read.</typeparam>
     /// <param name="stream">The source <see cref="Stream"/> instance to read from.</param>
     /// <returns>The <typeparamref name="T"/> value read from <paramref name="stream"/>.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if <paramref name="stream"/> reaches the end.</exception>
+    /// <exception cref="EndOfStreamException">Thrown if <paramref name="stream"/> reaches the end.</exception>
 #if NETSTANDARD2_1_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
@@ -226,7 +226,7 @@ public static class StreamExtensions
             // A return value of 0 indicates that the end of the stream has been reached
             if (bytesRead == 0)
             {
-                ThrowInvalidOperationExceptionForEndOfStream();
+                ThrowEndOfStreamException();
             }
 
             bytesOffset += bytesRead;
@@ -246,7 +246,7 @@ public static class StreamExtensions
 
                 if (bytesRead == 0)
                 {
-                    ThrowInvalidOperationExceptionForEndOfStream();
+                    ThrowEndOfStreamException();
                 }
 
                 bytesOffset += bytesRead;
@@ -299,11 +299,13 @@ public static class StreamExtensions
 #endif
     }
 
+#if !NET7_0_OR_GREATER
     /// <summary>
-    /// Throws an <see cref="InvalidOperationException"/> when <see cref="Read{T}"/> fails.
+    /// Throws an <see cref="EndOfStreamException"/> when <see cref="Read{T}"/> fails.
     /// </summary>
-    private static void ThrowInvalidOperationExceptionForEndOfStream()
+    private static void ThrowEndOfStreamException()
     {
-        throw new InvalidOperationException("The stream didn't contain enough data to read the requested item.");
+        throw new EndOfStreamException("The stream didn't contain enough data to read the requested item.");
     }
+#endif
 }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_StreamExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_StreamExtensions.cs
@@ -34,7 +34,7 @@ public class Test_StreamExtensions
         Assert.AreEqual(3.14f, stream.Read<float>());
         Assert.AreEqual(unchecked(uint.MaxValue * 324823489204ul), stream.Read<ulong>());
 
-        _ = Assert.ThrowsException<InvalidOperationException>(() => stream.Read<long>());
+        _ = Assert.ThrowsException<EndOfStreamException>(() => stream.Read<long>());
     }
 
     // See https://github.com/CommunityToolkit/dotnet/issues/513
@@ -55,7 +55,7 @@ public class Test_StreamExtensions
         Assert.AreEqual(3.14f, stream.Read<float>());
         Assert.AreEqual(unchecked(uint.MaxValue * 324823489204ul), stream.Read<ulong>());
 
-        _ = Assert.ThrowsException<InvalidOperationException>(() => stream.Read<long>());
+        _ = Assert.ThrowsException<EndOfStreamException>(() => stream.Read<long>());
     }
 
     private sealed class BufferedStream : MemoryStream


### PR DESCRIPTION
> "For the .NET 7 target `Stream.ReadExactly` could be used. It boils down the be [almost a one-liner](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA+ABATARgLABQGADAAQY4B0AkgPIDchhGAzOTkuVqQMKkDehUsPJsKnAK4A7AM4BDAGYxSAFVIAlGHIAmAHhUA+ABQAXABYBLGaQDKJ2HIC2pGfa2OAlKQDuZmLFVSEFJpRzkpOQBzGG0hEUECESTA2BkJABsTUgBeUm0YBTkMk0ZE5OFXB0dKTR0AUQQ5MBN0gE8jKRhvWwAHcN1gVpMYYyNB4YAqDwAyVOKAGhcLAC8YCAUjFQ9t0vLhDAB2UjnM3ZEAX0JzoA)."

_Originally posted by @gfoidl in https://github.com/CommunityToolkit/dotnet/pull/520#discussion_r1043183465_

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions

<!-- Please add any other information that might be helpful to reviewers. -->