### PR TITLE
Skip field reference diagnostics from constructors

### DIFF
--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -1602,6 +1602,29 @@ public class Test_SourceGeneratorsDiagnostics
         await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<FieldReferenceForObservablePropertyFieldAnalyzer>(source, LanguageVersion.CSharp8);
     }
 
+    [TestMethod]
+    public async Task FieldReferenceToFieldWithObservablePropertyAttribute_DoesNotEmitWarningFromWithinConstructor()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            partial class MyViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                int number;
+
+                public MyViewModel()
+                {
+                    number = 42;
+                    var temp = number;
+                    ref var x = ref number;
+                }
+            }
+            """;
+
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<FieldReferenceForObservablePropertyFieldAnalyzer>(source, LanguageVersion.CSharp8);
+    }
+
     /// <summary>
     /// Verifies the diagnostic errors for a given analyzer, and that all available source generators can run successfully with the input source (including subsequent compilation).
     /// </summary>


### PR DESCRIPTION
This PR is a small follow up for #532. Specifically it solves issues such as this:

```csharp
partial class ViewModel
{
    private string name;

    public ViewModel()
    {
        name = ""; // Warning
    }
}
```

The issue being that:

- If you assign the field, the MVVM Toolkit issues diagnostics
- If you assign the property, you get a nullability warning on the field

The fix is to just not emit diagnostics when assigning fields if the assignment is from a constructor of that type.

cc. @Youssef1313 would you mind also taking a look to confirm if this makes sense? Thank you! 😄

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions