### PR TITLE
Add target to fix analyzers on legacy .csproj projects

### DIFF
--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
@@ -41,6 +41,36 @@
     <Warning Condition ="'$(MVVMToolkitCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The MVVM Toolkit source generators have been disabled on the current configuration, as they need Roslyn 4.x in order to work. The MVVM Toolkit will work just fine, but features relying on the source generators will not be available."/>
   </Target>
 
+  <!--
+    Manually remove duplicate analyzers if Roslyn component versioning is not supported (ie. if a legacy .csproj project is used).
+    This target is only run if Roslyn 4.0 or greater is present, as otherwise all analyzers would have already been removed anyway.
+  -->
+  <Target Name="MVVMToolkitRemoveDuplicateAnalyzersWhenRoslynComponentVersioningIsNotSupported"
+          Condition="'$(MVVMToolkitCurrentCompilerVersionIsNotNewEnough)' != 'true' AND '$(SupportsRoslynComponentVersioning)' != 'true'"
+          AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
+          DependsOnTargets="MVVMToolkitRemoveAnalyzersForRoslyn3">
+
+      <!--
+        This switch manually implements Roslyn component versioning. That is, it checks the current version of Roslyn and
+        removes and removes all analyzers except the highest version that is supported. The fallback is just Roslyn 4.0.
+      -->
+    <PropertyGroup>
+      <MVVMToolkitSelectedRoslynAnalyzerDirectoryName Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MVVMToolkitCurrentCompilerVersion), 4.3))">roslyn4.3</MVVMToolkitSelectedRoslynAnalyzerDirectoryName>
+      <MVVMToolkitSelectedRoslynAnalyzerDirectoryName Condition="'$(MVVMToolkitSelectedRoslynAnalyzerDirectoryName)' == ''">roslyn4.0</MVVMToolkitSelectedRoslynAnalyzerDirectoryName>
+    </PropertyGroup>
+    <ItemGroup>
+      
+      <!--
+        This condition is a bit convoluted, but it's essentially just selecting all analyzers from the NuGet package that don't have the target Roslyn directory name in their full path.
+        For instance, if Roslyn 4.3 is the highest supported version, the target directory name will be "roslyn 4.3", and this condition will filter out all analyzers with a path such
+        as: "C:\...\.nuget\...\CommunityToolkit.Mvvm\analyzers\roslyn4.0\cs\CommunityToolkit.Mvvm". The [System.String]::Concat trick is used to achieve two things: we can't directly
+        invoke a property function (ie. Contains in this case) on a metadata item, so we need an intermediate string to invoke it on. We could also use [System.String]::new, but using
+        Concat is more efficient as it'll just skip the allocation entirely if one of the two inputs is an empty string, which is the case here.
+      -->
+      <Analyzer Remove="@(MVVMToolkitAnalyzer)" Condition="!$([System.String]::Concat('', '%(MVVMToolkitAnalyzer.FullPath)').Contains('$(MVVMToolkitSelectedRoslynAnalyzerDirectoryName)'))"/>
+    </ItemGroup>
+  </Target>
+
   <!-- Remove the analyzer if Roslyn is missing -->
   <Target Name="MVVMToolkitRemoveAnalyzersForRosynNotFound"
           Condition="'$(CSharpCoreTargetsPath)' == ''"


### PR DESCRIPTION
**Closes #540**
**Closes #495**

This PR adds a new target to remove duplicate analyzers when running on legacy style .csproj projects.

> **Note**: this does fix build errors, but IntelliSense is **completely** broken. Projects build but generated code isn't visible and is marked as errors. Analyzer warnings only show up in the output console but not in IntelliSense. Members referenced by generated code show up as unreferenced. The analyzers node in solution explorer is just completely empty and no analyzer is visible at all, so it's also impossible to inspect the generated code.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions