### PR TITLE
Add missing StrongReferenceMessenger registration fast path

### DIFF
--- a/src/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.cs
+++ b/src/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.cs
@@ -256,6 +256,10 @@ public static partial class IMessengerExtensions
         {
             weakReferenceMessenger.Register<TMessage, Unit>(recipient, default);
         }
+        else if (messenger is StrongReferenceMessenger strongReferenceMessenger)
+        {
+            strongReferenceMessenger.Register<TMessage, Unit>(recipient, default);
+        }
         else
         {
             messenger.Register<IRecipient<TMessage>, TMessage, Unit>(recipient, default, static (r, m) => r.Receive(m));


### PR DESCRIPTION
This PR adds a missing fast path check when registering `IRecipient<T>` recipients with `StrongReferenceMessenger`.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions