### PR TITLE
Resolve all needed symbols early in analyzers

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/FieldReferenceForObservablePropertyFieldAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/FieldReferenceForObservablePropertyFieldAnalyzer.cs
@@ -35,51 +35,59 @@ public sealed class FieldReferenceForObservablePropertyFieldAnalyzer : Diagnosti
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
         context.EnableConcurrentExecution();
 
-        context.RegisterOperationAction(static context =>
+        context.RegisterCompilationStartAction(static context =>
         {
-            // We're only looking for references to fields that could potentially be observable properties
-            if (context.Operation is not IFieldReferenceOperation
-                {
-                    Field: IFieldSymbol { IsStatic: false, IsConst: false, IsImplicitlyDeclared: false, ContainingType: INamedTypeSymbol } fieldSymbol,
-                    Instance.Type: ITypeSymbol typeSymbol
-                })
+            // Get the symbol for [ObservableProperty]
+            if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol)
             {
                 return;
             }
 
-            // Special case field references from within a constructor and don't ever emit warnings for them. The point of this
-            // analyzer is to prevent mistakes when users assign a field instead of a property and then get confused when the
-            // property changed event is not raised. But this would never be the case from a constructur anyway, given that
-            // no handler for that event would possibly be present. Suppressing warnings in this cases though will help to
-            // avoid scenarios where people get nullability warnings they cannot suppress, in case they were pushed by the
-            // analyzer in the MVVM Toolkit to not assign a field marked with a non-nullable reference type. Ideally this
-            // would be solved by habing the generated setter be marked with [MemberNotNullIfNotNull("field", "value")],
-            // but such an annotation does not currently exist.
-            if (context.ContainingSymbol is IMethodSymbol { MethodKind: MethodKind.Constructor, ContainingType: INamedTypeSymbol instanceType } &&
-                SymbolEqualityComparer.Default.Equals(instanceType, typeSymbol))
+            context.RegisterOperationAction(context =>
             {
-                return;
-            }
-
-            foreach (AttributeData attribute in fieldSymbol.GetAttributes())
-            {
-                // Look for the [ObservableProperty] attribute (there can only ever be one per field)
-                if (attribute.AttributeClass is { Name: "ObservablePropertyAttribute" } attributeClass &&
-                    context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is INamedTypeSymbol attributeSymbol &&
-                    SymbolEqualityComparer.Default.Equals(attributeClass, attributeSymbol))
+                // We're only looking for references to fields that could potentially be observable properties
+                if (context.Operation is not IFieldReferenceOperation
+                    {
+                        Field: IFieldSymbol { IsStatic: false, IsConst: false, IsImplicitlyDeclared: false, ContainingType: INamedTypeSymbol } fieldSymbol,
+                        Instance.Type: ITypeSymbol typeSymbol
+                    })
                 {
-                    // Emit a warning to redirect users to access the generated property instead
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        FieldReferenceForObservablePropertyFieldWarning,
-                        context.Operation.Syntax.GetLocation(),
-                        ImmutableDictionary.Create<string, string?>()
-                            .Add(FieldNameKey, fieldSymbol.Name)
-                            .Add(PropertyNameKey, ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol)),
-                        fieldSymbol));
-
                     return;
                 }
-            }
-        }, OperationKind.FieldReference);
+
+                // Special case field references from within a constructor and don't ever emit warnings for them. The point of this
+                // analyzer is to prevent mistakes when users assign a field instead of a property and then get confused when the
+                // property changed event is not raised. But this would never be the case from a constructur anyway, given that
+                // no handler for that event would possibly be present. Suppressing warnings in this cases though will help to
+                // avoid scenarios where people get nullability warnings they cannot suppress, in case they were pushed by the
+                // analyzer in the MVVM Toolkit to not assign a field marked with a non-nullable reference type. Ideally this
+                // would be solved by habing the generated setter be marked with [MemberNotNullIfNotNull("field", "value")],
+                // but such an annotation does not currently exist.
+                if (context.ContainingSymbol is IMethodSymbol { MethodKind: MethodKind.Constructor, ContainingType: INamedTypeSymbol instanceType } &&
+                    SymbolEqualityComparer.Default.Equals(instanceType, typeSymbol))
+                {
+                    return;
+                }
+
+                foreach (AttributeData attribute in fieldSymbol.GetAttributes())
+                {
+                    // Look for the [ObservableProperty] attribute (there can only ever be one per field)
+                    if (attribute.AttributeClass is { Name: "ObservablePropertyAttribute" } attributeClass &&
+                        SymbolEqualityComparer.Default.Equals(attributeClass, observablePropertySymbol))
+                    {
+                        // Emit a warning to redirect users to access the generated property instead
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            FieldReferenceForObservablePropertyFieldWarning,
+                            context.Operation.Syntax.GetLocation(),
+                            ImmutableDictionary.Create<string, string?>()
+                                .Add(FieldNameKey, fieldSymbol.Name)
+                                .Add(PropertyNameKey, ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol)),
+                            fieldSymbol));
+
+                        return;
+                    }
+                }
+            }, OperationKind.FieldReference);
+        });
     }
 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/InvalidClassLevelNotifyPropertyChangedRecipientsAttributeAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/InvalidClassLevelNotifyPropertyChangedRecipientsAttributeAnalyzer.cs
@@ -44,7 +44,7 @@ public sealed class InvalidClassLevelNotifyPropertyChangedRecipientsAttributeAna
                     return;
                 }
 
-                // Emit a diagnstic for types that use [NotifyPropertyChangedRecipients] but are neither inheriting from ObservableRecipient nor using [ObservableRecipient]
+                // Emit a diagnostic for types that use [NotifyPropertyChangedRecipients] but are neither inheriting from ObservableRecipient nor using [ObservableRecipient]
                 if (classSymbol.HasAttributeWithType(notifyPropertyChangedRecipientsAttributeSymbol) &&
                     !classSymbol.InheritsFromType(observableRecipientSymbol) &&
                     !classSymbol.HasOrInheritsAttributeWithType(observableRecipientAttributeSymbol))

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/CompilationExtensions.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/CompilationExtensions.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -86,5 +90,38 @@ internal static class CompilationExtensions
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Tries to build a map of <see cref="INamedTypeSymbol"/> instances form the input mapping of names.
+    /// </summary>
+    /// <typeparam name="T">The type of keys for each symbol.</typeparam>
+    /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>
+    /// <param name="typeNames">The input mapping of <typeparamref name="T"/> keys to fully qualified type names.</param>
+    /// <param name="typeSymbols">The resulting mapping of <typeparamref name="T"/> keys to resolved <see cref="INamedTypeSymbol"/> instances.</param>
+    /// <returns>Whether all requested <see cref="INamedTypeSymbol"/> instances could be resolved.</returns>
+    public static bool TryBuildNamedTypeSymbolMap<T>(
+        this Compilation compilation,
+        IEnumerable<KeyValuePair<T, string>> typeNames,
+        [NotNullWhen(true)] out ImmutableDictionary<T, INamedTypeSymbol>? typeSymbols)
+        where T : IEquatable<T>
+    {
+        ImmutableDictionary<T, INamedTypeSymbol>.Builder builder = ImmutableDictionary.CreateBuilder<T, INamedTypeSymbol>();
+
+        foreach (KeyValuePair<T, string> pair in typeNames)
+        {
+            if (compilation.GetTypeByMetadataName(pair.Value) is not INamedTypeSymbol attributeSymbol)
+            {
+                typeSymbols = null;
+
+                return false;
+            }
+
+            builder.Add(pair.Key, attributeSymbol);
+        }
+
+        typeSymbols = builder.ToImmutable();
+
+        return true;
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #586**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions