### PR TITLE
Fix TypeExtensions.ToTypeString method Exception.

### DIFF
--- a/tests/CommunityToolkit.Diagnostics.UnitTests/Extensions/Test_TypeExtensions.cs
+++ b/tests/CommunityToolkit.Diagnostics.UnitTests/Extensions/Test_TypeExtensions.cs
@@ -42,11 +42,25 @@ public class Test_TypeExtensions
     }
 
     [TestMethod]
+    [DataRow("System.Span<>", typeof(Span<>))]
+    [DataRow("System.Collections.Generic.List<>", typeof(List<>))]
+    [DataRow("System.Collections.Generic.Dictionary<,>", typeof(Dictionary<,>))]
+    [DataRow("(,)", typeof(ValueTuple<,>))]
+    [DataRow("(,,,,,)", typeof(ValueTuple<,,,,,>))]
+    [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Rabbit<>.Foo<>", typeof(Animal.Rabbit<>.Foo<>))]
+    [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Llama<,>.Foo<>", typeof(Animal.Llama<,>.Foo<>))]
+    public void Test_TypeExtensions_OpenGenericTypes(string name, Type type)
+    {
+        Assert.AreEqual(name, type.ToTypeString());
+    }
+
+    [TestMethod]
     [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal", typeof(Animal))]
     [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Cat", typeof(Animal.Cat))]
     [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Dog", typeof(Animal.Dog))]
     [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Rabbit<int?>", typeof(Animal.Rabbit<int?>))]
     [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Rabbit<string>", typeof(Animal.Rabbit<string>))]
+    [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Rabbit<CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Dog>", typeof(Animal.Rabbit<Animal.Dog>))]
     [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Rabbit<int>.Foo", typeof(Animal.Rabbit<int>.Foo))]
     [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Rabbit<(string, int)?>.Foo", typeof(Animal.Rabbit<(string, int)?>.Foo))]
     [DataRow("CommunityToolkit.Diagnostics.UnitTests.Extensions.Test_TypeExtensions.Animal.Rabbit<int>.Foo<string>", typeof(Animal.Rabbit<int>.Foo<string>))]


### PR DESCRIPTION
Fix TypeExtensions.ToTypeString method throws if invoked on a generic class without specifying the generic type.

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #609**

<!-- Add an overview of the changes here -->
Added a check on type.IsGenericParameter inside FormatDisplayString to avoid calling the method recursively given that, in this case, type.DeclaringType returns the parent class that defined the generic type parameter and this parent class was already taken into account by FormatDisplayString.

I've also added 2 tests for testing this case.

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


<!-- Please add any other information that might be helpful to reviewers. -->