### PR TITLE
Fix AV when indexing a sliced Memory2D<T> backed by custom MemoryManager<T>

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Buffers/Internals/ArrayMemoryManager{TFrom,TTo}.cs
+++ b/src/CommunityToolkit.HighPerformance/Buffers/Internals/ArrayMemoryManager{TFrom,TTo}.cs
@@ -75,15 +75,15 @@ internal sealed class ArrayMemoryManager<TFrom, TTo> : MemoryManager<TTo>, IMemo
             ThrowArgumentOutOfRangeExceptionForInvalidIndex();
         }
 
-        int bytePrefix = this.offset * sizeof(TFrom);
-        int byteSuffix = elementIndex * sizeof(TTo);
-        int byteOffset = bytePrefix + byteSuffix;
+        nint bytePrefix = this.offset * sizeof(TFrom);
+        nint byteSuffix = elementIndex * sizeof(TTo);
+        nint byteOffset = bytePrefix + byteSuffix;
 
         GCHandle handle = GCHandle.Alloc(this.array, GCHandleType.Pinned);
 
         ref TFrom r0 = ref this.array.DangerousGetReference();
         ref byte r1 = ref Unsafe.As<TFrom, byte>(ref r0);
-        ref byte r2 = ref Unsafe.Add(ref r1, byteOffset);
+        ref byte r2 = ref Unsafe.AddByteOffset(ref r1, byteOffset);
         void* pi = Unsafe.AsPointer(ref r2);
 
         return new(pi, handle);

--- a/src/CommunityToolkit.HighPerformance/Buffers/Internals/StringMemoryManager{TTo}.cs
+++ b/src/CommunityToolkit.HighPerformance/Buffers/Internals/StringMemoryManager{TTo}.cs
@@ -71,15 +71,15 @@ internal sealed class StringMemoryManager<TTo> : MemoryManager<TTo>, IMemoryMana
             ThrowArgumentOutOfRangeExceptionForInvalidIndex();
         }
 
-        int bytePrefix = this.offset * sizeof(char);
-        int byteSuffix = elementIndex * sizeof(TTo);
-        int byteOffset = bytePrefix + byteSuffix;
+        nint bytePrefix = this.offset * sizeof(char);
+        nint byteSuffix = elementIndex * sizeof(TTo);
+        nint byteOffset = bytePrefix + byteSuffix;
 
         GCHandle handle = GCHandle.Alloc(this.text, GCHandleType.Pinned);
 
         ref char r0 = ref this.text.DangerousGetReference();
         ref byte r1 = ref Unsafe.As<char, byte>(ref r0);
-        ref byte r2 = ref Unsafe.Add(ref r1, byteOffset);
+        ref byte r2 = ref Unsafe.AddByteOffset(ref r1, byteOffset);
         void* pi = Unsafe.AsPointer(ref r2);
 
         return new(pi, handle);

--- a/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -37,9 +37,9 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
     private readonly object? instance;
 
     /// <summary>
-    /// The initial offset within <see cref="instance"/>.
+    /// The initial byte offset within <see cref="instance"/>.
     /// </summary>
-    private readonly IntPtr offset;
+    private readonly nint offset;
 
     /// <summary>
     /// The height of the specified 2D region.
@@ -603,7 +603,7 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
                 if (this.instance is MemoryManager<T> memoryManager)
                 {
                     ref T r0 = ref memoryManager.GetSpan().DangerousGetReference();
-                    ref T r1 = ref Unsafe.Add(ref r0, this.offset);
+                    ref T r1 = ref Unsafe.AddByteOffset(ref r0, this.offset);
 
                     return new(ref r1, this.height, this.width, this.pitch);
                 }

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -34,9 +34,9 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
     private readonly object? instance;
 
     /// <summary>
-    /// The initial offset within <see cref="instance"/>.
+    /// The initial byte offset within <see cref="instance"/>.
     /// </summary>
-    private readonly IntPtr offset;
+    private readonly nint offset;
 
     /// <summary>
     /// The height of the specified 2D region.
@@ -615,7 +615,7 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
                 if (this.instance is MemoryManager<T> memoryManager)
                 {
                     ref T r0 = ref memoryManager.GetSpan().DangerousGetReference();
-                    ref T r1 = ref Unsafe.Add(ref r0, this.offset);
+                    ref T r1 = ref Unsafe.AddByteOffset(ref r0, this.offset);
 
                     return new(in r1, this.height, this.width, this.pitch);
                 }

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
@@ -109,9 +109,9 @@ partial struct ReadOnlySpan2D<T>
         private readonly object? instance;
 
         /// <summary>
-        /// The initial offset within <see cref="instance"/>.
+        /// The initial byte offset within <see cref="instance"/>.
         /// </summary>
-        private readonly IntPtr offset;
+        private readonly nint offset;
 
         /// <summary>
         /// The height of the specified 2D region.

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -50,9 +50,9 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     private readonly object? instance;
 
     /// <summary>
-    /// The initial offset within <see cref="instance"/>.
+    /// The initial byte offset within <see cref="instance"/>.
     /// </summary>
-    private readonly IntPtr offset;
+    private readonly nint offset;
 
     /// <summary>
     /// The height of the specified 2D region.

--- a/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
@@ -109,9 +109,9 @@ partial struct Span2D<T>
         private readonly object? instance;
 
         /// <summary>
-        /// The initial offset within <see cref="instance"/>.
+        /// The initial byte offset within <see cref="instance"/>.
         /// </summary>
-        private readonly IntPtr offset;
+        private readonly nint offset;
 
         /// <summary>
         /// The height of the specified 2D region.

--- a/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -82,9 +82,9 @@ public readonly ref partial struct Span2D<T>
     internal readonly object? Instance;
 
     /// <summary>
-    /// The initial offset within <see cref="Instance"/>.
+    /// The initial byte offset within <see cref="Instance"/>.
     /// </summary>
-    internal readonly IntPtr Offset;
+    internal readonly nint Offset;
 
     /// <summary>
     /// The height of the specified 2D region.

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_Memory2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_Memory2D{T}.cs
@@ -516,4 +516,29 @@ public class Test_Memory2DT
 
         Assert.AreEqual(text, expected);
     }
+
+#if NET6_0_OR_GREATER
+    // See https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/3536
+    [TestMethod]
+    [DataRow(720, 1280)]
+    public void Test_Memory2DT_CastAndSlice_WorksCorrectly(int height, int width)
+    {
+        Memory2D<int> data =
+            new byte[width * height * sizeof(int)]
+            .AsMemory()
+            .Cast<byte, int>()
+            .AsMemory2D(height: height, width: width);
+
+        Memory2D<int> slice = data.Slice(
+            row: height / 2,
+            column: 0,
+            height: height / 2,
+            width: width);
+
+        Assert.IsTrue(Unsafe.AreSame(ref data.Span[height / 2, 0], ref slice.Span[0, 0]));
+        Assert.IsTrue(Unsafe.AreSame(ref data.Span[height / 2, width - 1], ref slice.Span[0, width - 1]));
+        Assert.IsTrue(Unsafe.AreSame(ref data.Span[height - 1, 0], ref slice.Span[(height / 2) - 1, 0]));
+        Assert.IsTrue(Unsafe.AreSame(ref data.Span[height - 1, width - 1], ref slice.Span[(height / 2) - 1, width - 1]));
+    }
+#endif
 }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlyMemory2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlyMemory2D{T}.cs
@@ -464,4 +464,29 @@ public class Test_ReadOnlyMemory2DT
 
         Assert.AreEqual(text, expected);
     }
+
+#if NET6_0_OR_GREATER
+    // See https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/3536
+    [TestMethod]
+    [DataRow(720, 1280)]
+    public void Test_ReadOnlyMemory2DT_CastAndSlice_WorksCorrectly(int height, int width)
+    {
+        ReadOnlyMemory2D<int> data =
+            new byte[width * height * sizeof(int)]
+            .AsMemory()
+            .Cast<byte, int>()
+            .AsMemory2D(height: height, width: width);
+
+        ReadOnlyMemory2D<int> slice = data.Slice(
+            row: height / 2,
+            column: 0,
+            height: height / 2,
+            width: width);
+
+        Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in data.Span[height / 2, 0]), ref Unsafe.AsRef(in slice.Span[0, 0])));
+        Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in data.Span[height / 2, width - 1]), ref Unsafe.AsRef(in slice.Span[0, width - 1])));
+        Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in data.Span[height - 1, 0]), ref Unsafe.AsRef(in slice.Span[(height / 2) - 1, 0])));
+        Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in data.Span[height - 1, width - 1]), ref Unsafe.AsRef(in slice.Span[(height / 2) - 1, width - 1])));
+    }
+#endif
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #674**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions