### PR TITLE
Add diagnostics for invalid expressions for forwarded attributes

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -57,3 +57,12 @@ MVVMTK0035 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 MVVMTK0036 | CommunityToolkit.Mvvm.SourceGenerators.RelayCommandGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0036
+
+## Release 8.2.1
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MVVMTK0037 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0037
+MVVMTK0038 | CommunityToolkit.Mvvm.SourceGenerators.RelayCommandGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0038

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -598,11 +598,43 @@ internal static class DiagnosticDescriptors
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidFieldOrPropertyTargetedAttributeOnRelayCommandMethod = new DiagnosticDescriptor(
         id: "MVVMTK0036",
-        title: "Invalid field targeted attribute type",
+        title: "Invalid field or property targeted attribute type",
         messageFormat: "The method {0} annotated with [RelayCommand] is using attribute \"{1}\" which was not recognized as a valid type (are you missing a using directive?)",
         category: typeof(RelayCommandGenerator).FullName,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "All attributes targeting the generated field or property for a method annotated with [RelayCommand] must correctly be resolved to valid types.",
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0036");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a field with <c>[ObservableProperty]</c> is using an invalid attribute expression targeting the property.
+    /// <para>
+    /// Format: <c>"The field {0} annotated with [ObservableProperty] is using attribute "{1}" with an invalid expression (are you passing any incorrect parameters to the attribute constructor?)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidPropertyTargetedAttributeExpressionOnObservablePropertyField = new DiagnosticDescriptor(
+        id: "MVVMTK0037",
+        title: "Invalid property targeted attribute expression",
+        messageFormat: "The field {0} annotated with [ObservableProperty] is using attribute \"{1}\" with an invalid expression (are you passing any incorrect parameters to the attribute constructor?)",
+        category: typeof(ObservablePropertyGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "All attributes targeting the generated property for a field annotated with [ObservableProperty] must be using valid expressions.",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0037");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a method with <c>[RelayCommand]</c> is using an invalid attribute targeting the field or property.
+    /// <para>
+    /// Format: <c>"The method {0} annotated with [RelayCommand] is using attribute "{1}" with an invalid expression (are you passing any incorrect parameters to the attribute constructor?)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidFieldOrPropertyTargetedAttributeExpressionOnRelayCommandMethod = new DiagnosticDescriptor(
+        id: "MVVMTK0038",
+        title: "Invalid field or property targeted attribute expression",
+        messageFormat: "The method {0} annotated with [RelayCommand] is using attribute \"{1}\" with an invalid expression (are you passing any incorrect parameters to the attribute constructor?)",
+        category: typeof(RelayCommandGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "All attributes targeting the generated field or property for a method annotated with [RelayCommand] must be using valid expressions.",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0038");
 }

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -1672,6 +1672,30 @@ public class Test_SourceGeneratorsDiagnostics
         VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0035");
     }
 
+    // See https://github.com/CommunityToolkit/dotnet/issues/683
+    [TestMethod]
+    public void InvalidPropertyTargetedAttributeOnObservablePropertyField_InvalidExpression()
+    {
+        string source = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            public partial class MyViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                [property: Test(TestAttribute.M)]
+                private int number;
+            }
+
+            public class TestAttribute : Attribute
+            {
+                public static string M => "";
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0037");
+    }
+
     [TestMethod]
     public void InvalidPropertyTargetedAttributeOnRelayCommandMethod_MissingUsingDirective()
     {
@@ -1723,6 +1747,58 @@ public class Test_SourceGeneratorsDiagnostics
             """;
 
         VerifyGeneratedDiagnostics<RelayCommandGenerator>(source, "MVVMTK0036");
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/683
+    [TestMethod]
+    public void InvalidPropertyTargetedAttributeOnRelayCommandMethod_InvalidExpressionOnFieldAttribute()
+    {
+        string source = """
+            using System;
+            using CommunityToolkit.Mvvm.Input;
+
+            public partial class MyViewModel
+            {
+                [RelayCommand]
+                [field: Test(TestAttribute.M)]
+                private void Test()
+                {
+                }
+            }
+
+            public class TestAttribute : Attribute
+            {
+                public static string M => "";
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<RelayCommandGenerator>(source, "MVVMTK0038");
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/683
+    [TestMethod]
+    public void InvalidPropertyTargetedAttributeOnRelayCommandMethod_InvalidExpressionOnPropertyAttribute()
+    {
+        string source = """
+            using System;
+            using CommunityToolkit.Mvvm.Input;
+
+            public partial class MyViewModel
+            {
+                [RelayCommand]
+                [property: Test(TestAttribute.M)]
+                private void Test()
+                {
+                }
+            }
+
+            public class TestAttribute : Attribute
+            {
+                public static string M => "";
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<RelayCommandGenerator>(source, "MVVMTK0038");
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #683**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions