### PR TITLE
Add warning when using packages.config for MVVM Toolkit

### DIFF
--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
@@ -102,15 +102,19 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if packages.config is used -->
+  <!--
+    Inform the user if packages.config is used (as the analyzers and the source generators
+    won't work at all). Since packages.config can only be used with legacy-style projects,
+    the entire package can be skipped if an SDK-style project is used.
+  -->
   <Target Name="MVVMToolkitWarnForPackagesConfigUse"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
-          DependsOnTargets="MVVMToolkitGatherAnalyzers">
+          Condition="'$(UsingMicrosoftNetSDK)' != 'true'">
     
     <!--
       Check whether packages are being restored via packages.config, by reading the associated MSBuild property.
       This happens when either the project style is using packages.config, or when explicitly requested.
-      See https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#restoring-packagereference-and-packagesconfig-projects-with-msbuild.
+      See https://learn.microsoft.com/nuget/reference/msbuild-targets#restoring-packagereference-and-packagesconfig-projects-with-msbuild.
     -->
     <PropertyGroup>
       <MVVMToolkitIsTargetProjectUsingPackagesConfig Condition ="'$(RestorePackagesConfig)' == 'true' OR '$(RestoreProjectStyle)' == 'PackagesConfig'">true</MVVMToolkitIsTargetProjectUsingPackagesConfig>
@@ -120,6 +124,8 @@
       If no packages.config properties are set, also try to manually find the packages.config file.
       This will be in the @(None) elements, if present. Doing so makes sure this works in builds as
       well, since the implicit targets populating the properties above only run when restoring.
+      Since the packages.config file will always be in the root of the project, if present, we will
+      match with the full item spec (see https://learn.microsoft.com/nuget/reference/packages-config).
     -->
     <FindInList ItemSpecToFind="packages.config"
                 List="@(None)"

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
@@ -54,7 +54,10 @@
       emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
       disabled, and that the rest of the MVVM Toolkit will still keep working as intended, just without additional features.
     -->
-    <Warning Condition ="'$(MVVMToolkitCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The MVVM Toolkit source generators have been disabled on the current configuration, as they need Roslyn 4.x in order to work. The MVVM Toolkit will work just fine, but features relying on the source generators will not be available."/>
+    <Warning Condition ="'$(MVVMToolkitCurrentCompilerVersionIsNotNewEnough)' == 'true'"
+             Code="MVVMTKCFG0001"
+             HelpLink="https://aka.ms/mvvmtoolkit/errors/mvvmtkcfg0001"
+             Text="The MVVM Toolkit source generators have been disabled on the current configuration, as they need Roslyn 4.x in order to work. The MVVM Toolkit will work just fine, but features relying on the source generators will not be available."/>
   
     <PropertyGroup>
 
@@ -109,7 +112,10 @@
       This happens when either the project style is using packages.config, or when explicitly requested.
       See https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#restoring-packagereference-and-packagesconfig-projects-with-msbuild.
     -->
-    <Warning Condition ="'$(RestorePackagesConfig)' == 'true' OR '$(RestoreProjectStyle)' == 'PackagesConfig'" Text="The MVVM Toolkit source generators might not be loaded correctly, as the current project is using the packages.config setup to restore NuGet packages. Source generators require PackageReference to be used (either in a legacy-style or SDK-style .csproj project, both are supported as long as PackageReference is used)."/>
+    <Warning Condition ="'$(RestorePackagesConfig)' == 'true' OR '$(RestoreProjectStyle)' == 'PackagesConfig'"
+             Code="MVVMTKCFG0002"
+             HelpLink="https://aka.ms/mvvmtoolkit/errors/mvvmtkcfg0002"
+             Text="The MVVM Toolkit source generators might not be loaded correctly, as the current project is using the packages.config setup to restore NuGet packages. Source generators require PackageReference to be used (either in a legacy-style or SDK-style .csproj project, both are supported as long as PackageReference is used)."/>
   </Target>
 
 </Project>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
@@ -99,4 +99,17 @@
     </ItemGroup>
   </Target>
 
+  <!-- Remove the analyzer if packages.config is used -->
+  <Target Name="MVVMToolkitWarnForPackagesConfigUse"
+          AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
+          DependsOnTargets="MVVMToolkitGatherAnalyzers">
+
+    <!--
+      Emit a warning in case packages.config is used, by reading the associated MSBuild property.
+      This happens when either the project style is using packages.config, or when explicitly requested.
+      See https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#restoring-packagereference-and-packagesconfig-projects-with-msbuild.
+    -->
+    <Warning Condition ="'$(RestorePackagesConfig)' == 'true' OR '$(RestoreProjectStyle)' == 'PackagesConfig'" Text="The MVVM Toolkit source generators might not be loaded correctly, as the current project is using the packages.config setup to restore NuGet packages. Source generators require PackageReference to be used (either in a legacy-style or SDK-style .csproj project, both are supported as long as PackageReference is used)."/>
+  </Target>
+
 </Project>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
@@ -106,13 +106,35 @@
   <Target Name="MVVMToolkitWarnForPackagesConfigUse"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
           DependsOnTargets="MVVMToolkitGatherAnalyzers">
-
+    
     <!--
-      Emit a warning in case packages.config is used, by reading the associated MSBuild property.
+      Check whether packages are being restored via packages.config, by reading the associated MSBuild property.
       This happens when either the project style is using packages.config, or when explicitly requested.
       See https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#restoring-packagereference-and-packagesconfig-projects-with-msbuild.
     -->
-    <Warning Condition ="'$(RestorePackagesConfig)' == 'true' OR '$(RestoreProjectStyle)' == 'PackagesConfig'"
+    <PropertyGroup>
+      <MVVMToolkitIsTargetProjectUsingPackagesConfig Condition ="'$(RestorePackagesConfig)' == 'true' OR '$(RestoreProjectStyle)' == 'PackagesConfig'">true</MVVMToolkitIsTargetProjectUsingPackagesConfig>
+    </PropertyGroup>
+
+    <!--
+      If no packages.config properties are set, also try to manually find the packages.config file.
+      This will be in the @(None) elements, if present. Doing so makes sure this works in builds as
+      well, since the implicit targets populating the properties above only run when restoring.
+    -->
+    <FindInList ItemSpecToFind="packages.config"
+                List="@(None)"
+                MatchFileNameOnly="false"
+                Condition="'$(MVVMToolkitIsTargetProjectUsingPackagesConfig)' != 'true'">
+      <Output TaskParameter="ItemFound" PropertyName="MVVMToolkitPackagesConfigFile"/>
+    </FindInList>
+
+    <!-- Make sure to update the MSBuild property if the above task did find something -->
+    <PropertyGroup>
+      <MVVMToolkitIsTargetProjectUsingPackagesConfig Condition ="'$(MVVMToolkitPackagesConfigFile)' == 'packages.config'">true</MVVMToolkitIsTargetProjectUsingPackagesConfig>
+    </PropertyGroup>
+
+    <!-- Emit a warning in case packages.config is used -->
+    <Warning Condition ="'$(MVVMToolkitIsTargetProjectUsingPackagesConfig)' == 'true'"
              Code="MVVMTKCFG0002"
              HelpLink="https://aka.ms/mvvmtoolkit/errors/mvvmtkcfg0002"
              Text="The MVVM Toolkit source generators might not be loaded correctly, as the current project is using the packages.config setup to restore NuGet packages. Source generators require PackageReference to be used (either in a legacy-style or SDK-style .csproj project, both are supported as long as PackageReference is used)."/>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #695**

This PR adds a warning from the imported .targets file if using the MVVM Toolkit via packages.config.
Also adds warning codes and help links to all warnings emitted by the bundled .targets file.

![](https://github.com/CommunityToolkit/dotnet/assets/10199417/9f2905d1-d214-4af0-a51e-3ce5cea5e660)

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions