### PR TITLE
Improve XML docs for Span2D<T>.Slice(int, int, int, int)

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -652,11 +652,12 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
     /// <param name="column">The target column to map within the current instance.</param>
     /// <param name="height">The height to map within the current instance.</param>
     /// <param name="width">The width to map within the current instance.</param>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when either <paramref name="height"/>, <paramref name="width"/> or <paramref name="height"/>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="Memory2D{T}"/> instance representing a slice of the current one.</returns>
+    /// <remarks>See additional remarks in the <see cref="Span2D{T}.Slice(int, int, int, int)"/> docs.</remarks>
     public unsafe Memory2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -665,11 +665,12 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
     /// <param name="column">The target column to map within the current instance.</param>
     /// <param name="height">The height to map within the current instance.</param>
     /// <param name="width">The width to map within the current instance.</param>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when either <paramref name="height"/>, <paramref name="width"/> or <paramref name="height"/>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="ReadOnlyMemory2D{T}"/> instance representing a slice of the current one.</returns>
+    /// <remarks>See additional remarks in the <see cref="Span2D{T}.Slice(int, int, int, int)"/> docs.</remarks>
     public unsafe ReadOnlyMemory2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -842,11 +842,12 @@ public readonly ref partial struct ReadOnlySpan2D<T>
     /// <param name="column">The target column to map within the current instance.</param>
     /// <param name="height">The height to map within the current instance.</param>
     /// <param name="width">The width to map within the current instance.</param>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when either <paramref name="height"/>, <paramref name="width"/> or <paramref name="height"/>
     /// are negative or not within the bounds that are valid for the current instance.
     /// </exception>
     /// <returns>A new <see cref="ReadOnlySpan2D{T}"/> instance representing a slice of the current one.</returns>
+    /// <remarks>See additional remarks in the <see cref="Span2D{T}.Slice(int, int, int, int)"/> docs.</remarks>
     public unsafe ReadOnlySpan2D<T> Slice(int row, int column, int height, int width)
     {
         if ((uint)row >= Height)


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #673**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions