### PR TITLE
Hide stack traces from Guard and ThrowHelper

### DIFF
--- a/src/CommunityToolkit.Diagnostics/Guard.cs
+++ b/src/CommunityToolkit.Diagnostics/Guard.cs
@@ -13,6 +13,7 @@ namespace CommunityToolkit.Diagnostics;
 /// Helper methods to verify conditions when running code.
 /// </summary>
 [DebuggerStepThrough]
+[StackTraceHidden]
 public static partial class Guard
 {
     /// <summary>

--- a/src/CommunityToolkit.Diagnostics/ThrowHelper.cs
+++ b/src/CommunityToolkit.Diagnostics/ThrowHelper.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -14,6 +15,7 @@ namespace CommunityToolkit.Diagnostics;
 /// <summary>
 /// Helper methods to efficiently throw exceptions.
 /// </summary>
+[StackTraceHidden]
 public static partial class ThrowHelper
 {
     /// <summary>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #35**

<!-- Add an overview of the changes here -->

Exceptions go from:

```
Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parameter 'myValue')
   at CommunityToolkit.Diagnostics.ThrowHelper.ThrowArgumentNullException(String name) in [...]/community-toolkit-dotnet/src/CommunityToolkit.Diagnostics/ThrowHelper.cs:line 130
   at Program.<Main>$(String[] args) in [...]/community-toolkit-dotnet/ConsoleApp1/Program.cs:line 9
```

to (the less cluttered)

```
Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parameter 'myValue')
   at Program.<Main>$(String[] args) in [...]/community-toolkit-dotnet/ConsoleApp1/Program.cs:line 9
```

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [ ] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [ ] Based off latest main branch of toolkit
- [ ] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [ ] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

The attribute on `Guard` creates no observed behaviour change because all methods are aggressively inlined - but the attribute is nice to have to be sure (e.g., if, for some reason, the methods were not inlined).