### PR TITLE
Remove unnecessary temporary array allocation

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -961,7 +961,7 @@ partial class ObservablePropertyGenerator
                         .AddArgumentListArguments(
                             Argument(fieldExpression),
                             Argument(IdentifierName("value")))),
-                    Block(setterStatements.ToArray()));
+                    Block(setterStatements.AsEnumerable()));
 
             // Prepare the forwarded attributes, if any
             ImmutableArray<AttributeListSyntax> forwardedAttributes =


### PR DESCRIPTION
## Overview

This PR adds an API to enumerate items in an array builder without allocating a whole array.
It also uses this API when creating a `BlockSyntax`, to avoid wasting an array just to enumerate items.
The returned enumerable is readonly, ensuring mutations must go through the actual builder.

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions