### PR TITLE
Fix forwarding enum values with negative values in attributes

### DIFF
--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsCodegen.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsCodegen.cs
@@ -1349,10 +1349,10 @@ public class Test_SourceGeneratorsCodegen
                     /// <inheritdoc cref="a"/>
                     [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator", <ASSEMBLY_VERSION>)]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)-1073741824)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)-9223372036854775808)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)-1234)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)-1)]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)(-1073741824))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)(-9223372036854775808))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)(-1234))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)(-1))]
                     public object? A
                     {
                         get => a;
@@ -1489,24 +1489,24 @@ public class Test_SourceGeneratorsCodegen
                     [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator", <ASSEMBLY_VERSION>)]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)0)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)-1073741824)]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)(-1073741824))]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)42)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)456)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)123)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)0)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)-9223372036854775808)]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)(-9223372036854775808))]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)42)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)456)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)123)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)1)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)-1234)]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)(-1234))]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)42)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)456)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)123)]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)1)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)-1)]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)(-1))]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)42)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)-56)]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)(-56))]
                     [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)123)]
                     public object? A
                     {
@@ -1792,18 +1792,18 @@ public class Test_SourceGeneratorsCodegen
                 {
                     /// <summary>The backing field for <see cref="TestCommand"/>.</summary>
                     [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.Mvvm.SourceGenerators.RelayCommandGenerator", <ASSEMBLY_VERSION>)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)-1073741824)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)-9223372036854775808)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)-1234)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)-1)]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)(-1073741824))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)(-9223372036854775808))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)(-1234))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)(-1))]
                     private global::CommunityToolkit.Mvvm.Input.RelayCommand? testCommand;
                     /// <summary>Gets an <see cref="global::CommunityToolkit.Mvvm.Input.IRelayCommand"/> instance wrapping <see cref="Test"/>.</summary>
                     [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.Mvvm.SourceGenerators.RelayCommandGenerator", <ASSEMBLY_VERSION>)]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)-1073741824)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)-9223372036854775808)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)-1234)]
-                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)-1)]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum1)(-1073741824))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum2)(-9223372036854775808))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum3)(-1234))]
+                    [global::MyApp.DefaultValueAttribute((global::MyApp.NegativeEnum4)(-1))]
                     public global::CommunityToolkit.Mvvm.Input.IRelayCommand TestCommand => testCommand ??= new global::CommunityToolkit.Mvvm.Input.RelayCommand(new global::System.Action(Test));
                 }
             }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -1051,6 +1051,23 @@ public partial class Test_ObservablePropertyAttribute
     }
 #endif
 
+    // See https://github.com/CommunityToolkit/dotnet/issues/731
+    [TestMethod]
+    public void Test_ObservableProperty_ForwardedAttributesWithNegativeValues()
+    {
+        Assert.AreEqual(PositiveEnum.Something,
+            typeof(ModelWithForwardedAttributesWithNegativeValues)
+            .GetProperty(nameof(ModelWithForwardedAttributesWithNegativeValues.Test2))!
+            .GetCustomAttribute<DefaultValueAttribute>()!
+            .Value);
+
+        Assert.AreEqual(NegativeEnum.Problem,
+            typeof(ModelWithForwardedAttributesWithNegativeValues)
+            .GetProperty(nameof(ModelWithForwardedAttributesWithNegativeValues.Test3))!
+            .GetCustomAttribute<DefaultValueAttribute>()!
+            .Value);
+    }
+
     public abstract partial class BaseViewModel : ObservableObject
     {
         public string? Content { get; set; }
@@ -1693,4 +1710,39 @@ public partial class Test_ObservablePropertyAttribute
         internal string name;
     }
 #endif
+
+    private partial class ModelWithForwardedAttributesWithNegativeValues : ObservableObject
+    {
+        [ObservableProperty]
+        private bool _test1;
+
+        [ObservableProperty]
+        [property: DefaultValue(PositiveEnum.Something)]
+        private PositiveEnum _test2;
+
+        [ObservableProperty]
+        [property: DefaultValue(NegativeEnum.Problem)]
+        private NegativeEnum _test3;
+
+        [ObservableProperty]
+        private int _test4;
+
+        public ModelWithForwardedAttributesWithNegativeValues()
+        {
+            Test1 = true;
+            Test2 = PositiveEnum.Else;
+        }
+    }
+
+    public enum PositiveEnum
+    {
+        Something = 0,
+        Else = 1
+    }
+
+    public enum NegativeEnum
+    {
+        Problem = -1,
+        OK = 0
+    }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #731**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions