### PR TITLE
Add `DebuggerDisplay` and `DebuggerTypeProxy` for `EquatableArray<T>`

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Helpers/EquatableArray{T}.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Helpers/EquatableArray{T}.cs
@@ -74,19 +74,19 @@ internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnu
         get => AsImmutableArray().IsEmpty;
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public bool Equals(EquatableArray<T> array)
     {
         return AsSpan().SequenceEqual(array.AsSpan());
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public override bool Equals([NotNullWhen(true)] object? obj)
     {
         return obj is EquatableArray<T> array && Equals(this, array);
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public override int GetHashCode()
     {
         if (this.array is not T[] array)
@@ -134,7 +134,7 @@ internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnu
     }
 
     /// <summary>
-    /// Copies the contents of this <see cref="EquatableArray{T}"/> instance. to a mutable array.
+    /// Copies the contents of this <see cref="EquatableArray{T}"/> instance to a mutable array.
     /// </summary>
     /// <returns>The newly instantiated array.</returns>
     public T[] ToArray()
@@ -151,13 +151,13 @@ internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnu
         return AsImmutableArray().GetEnumerator();
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
         return ((IEnumerable<T>)AsImmutableArray()).GetEnumerator();
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator()
     {
         return ((IEnumerable)AsImmutableArray()).GetEnumerator();

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Helpers/EquatableArray{T}.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Helpers/EquatableArray{T}.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -34,6 +35,8 @@ internal static class EquatableArray
 /// An imutable, equatable array. This is equivalent to <see cref="ImmutableArray{T}"/> but with value equality support.
 /// </summary>
 /// <typeparam name="T">The type of values in the array.</typeparam>
+[DebuggerDisplay("Length = {array.Length,nq}")]
+[DebuggerTypeProxy(typeof(EquatableArray<>.DebugView))]
 internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>
     where T : IEquatable<T>
 {
@@ -198,5 +201,22 @@ internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnu
     public static bool operator !=(EquatableArray<T> left, EquatableArray<T> right)
     {
         return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Debug view for <see cref="EquatableArray{T}"/>.
+    /// Instead of internal state shows array view where each element is under its own index. 
+    /// </summary>
+    private sealed class DebugView
+    {
+        private readonly EquatableArray<T> array;
+
+        public DebugView(EquatableArray<T> array)
+        {
+            this.array = array;   
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items => this.array.ToArray();
     }
 }


### PR DESCRIPTION
This is just a simple QoL change for development that doesn't affect production code nearly at all, so I don't think this needs an issue upfront. Also fixed several typos in existing xml documentation

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] Every new API (including internal ones) has full XML docs - added docs to `DebugView`. I don't think I should add docs for `array` field saying, that this is an array, or... should I?
- [x] Code follows all style conventions

## Other information

**Before:**
![devenv_YbTfGbvbo0](https://github.com/CommunityToolkit/dotnet/assets/70431552/a108a054-fa54-4ca0-9f7e-d8bf5bdcd4be)

**After:**
![devenv_CMHsaqZ51O](https://github.com/CommunityToolkit/dotnet/assets/70431552/7ddffa77-4eb8-4230-b384-98d5e87fdc0d)
