### PR TITLE
Fix IBufferWriterExtensions Write for unmanaged types

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Extensions/IBufferWriterExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/IBufferWriterExtensions.cs
@@ -48,10 +48,9 @@ public static class IBufferWriterExtensions
     public static unsafe void Write<T>(this IBufferWriter<byte> writer, T value)
         where T : unmanaged
     {
-        int length = sizeof(T);
-        Span<byte> span = writer.GetSpan(1);
+        Span<byte> span = writer.GetSpan(sizeof(T));
 
-        if (span.Length < length)
+        if (span.Length < sizeof(T))
         {
             ThrowArgumentExceptionForEndOfBuffer();
         }
@@ -60,7 +59,7 @@ public static class IBufferWriterExtensions
 
         Unsafe.WriteUnaligned(ref r0, value);
 
-        writer.Advance(length);
+        writer.Advance(sizeof(T));
     }
 
     /// <summary>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_IBufferWriterExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_IBufferWriterExtensions.cs
@@ -118,4 +118,22 @@ public class Test_IBufferWriterExtensions
 
         Assert.IsTrue(span.SequenceEqual(buffer.AsSpan()));
     }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/798
+    [TestMethod]
+    public void Test_IBufferWriterExtensions_WriteExceedingFreeCapacity()
+    {
+        ArrayPoolBufferWriter<byte> writer = new();
+
+        // Leave only one byte of free capacity
+        int count = writer.Capacity - 1;
+        
+        for (int i = 0; i < count; i++)
+        {
+            writer.Write<byte>(0);
+        }
+
+        // Write 4 bytes
+        writer.Write(1);
+    }
 }


### PR DESCRIPTION
**Closes #798**

Fixes extension method and adds a test to ensure a correct bahavior.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions