### PR TITLE
Add .NET 8 TFM to all projects and AOT annotations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.128" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="All" />
   </ItemGroup>
 
   <Choose>
@@ -39,7 +39,7 @@
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
       </ItemGroup>
     </When>
   </Choose>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,10 @@ jobs:
 
   # Test solution #
 
+    # Run .NET 8 unit tests
+  - script: dotnet test --no-build -c $(Build.Configuration) -f net8.0 -l "trx;LogFileName=VSTestResults_net8.0.trx"
+    displayName: Run .NET 8 unit tests
+
   # Run .NET 7 unit tests
   - script: dotnet test --no-build -c $(Build.Configuration) -f net7.0 -l "trx;LogFileName=VSTestResults_net7.0.trx"
     displayName: Run .NET 7 unit tests

--- a/build/Community.Toolkit.Common.props
+++ b/build/Community.Toolkit.Common.props
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
 
     <!--

--- a/build/Community.Toolkit.Common.targets
+++ b/build/Community.Toolkit.Common.targets
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <!-- TODO: Dynamically generate Title if one wasn't set -->
     <Title Condition="'$(Title)' == ''">$(Product) Asset</Title>
   </PropertyGroup>
 

--- a/src/CommunityToolkit.Common/CommunityToolkit.Common.csproj
+++ b/src/CommunityToolkit.Common/CommunityToolkit.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/CommunityToolkit.Diagnostics/CommunityToolkit.Diagnostics.csproj
+++ b/src/CommunityToolkit.Diagnostics/CommunityToolkit.Diagnostics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/CommunityToolkit.HighPerformance/CommunityToolkit.HighPerformance.csproj
+++ b/src/CommunityToolkit.HighPerformance/CommunityToolkit.HighPerformance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/NullableExtensions.cs
@@ -48,7 +48,7 @@ public static class NullableExtensions
     /// <typeparam name="T">The type of the underlying value.</typeparam>
     /// <param name="value">The <see cref="Nullable{T}"/>.</param>
     /// <returns>A reference to the value of the input <see cref="Nullable{T}"/> instance, or a <see langword="null"/> <typeparamref name="T"/> reference.</returns>
-    /// <remarks>The returned reference can be tested for <see langword="null"/> using <see cref="Unsafe.IsNullRef{T}(ref T)"/>.</remarks>
+    /// <remarks>The returned reference can be tested for <see langword="null"/> using <see cref="Unsafe.IsNullRef"/>.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref T DangerousGetValueOrNullReference<T>(ref this T? value)
         where T : struct

--- a/src/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
@@ -213,7 +213,7 @@ public static class ReadOnlySpanExtensions
     public static unsafe int IndexOf<T>(this ReadOnlySpan<T> span, in T value)
     {
         ref T r0 = ref MemoryMarshal.GetReference(span);
-        ref T r1 = ref Unsafe.AsRef(value);
+        ref T r1 = ref Unsafe.AsRef(in value);
         IntPtr byteOffset = Unsafe.ByteOffset(ref r0, ref r1);
 
         nint elementOffset = byteOffset / (nint)(uint)sizeof(T);

--- a/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/StreamExtensions.cs
@@ -275,7 +275,7 @@ public static class StreamExtensions
         where T : unmanaged
     {
 #if NETSTANDARD2_1_OR_GREATER
-        ref T r0 = ref Unsafe.AsRef(value);
+        ref T r0 = ref Unsafe.AsRef(in value);
         ref byte r1 = ref Unsafe.As<T, byte>(ref r0);
         int length = sizeof(T);
 

--- a/src/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/StringExtensions.cs
@@ -27,7 +27,7 @@ public static class StringExtensions
     public static ref char DangerousGetReference(this string text)
     {
 #if NET6_0_OR_GREATER
-        return ref Unsafe.AsRef(text.GetPinnableReference());
+        return ref Unsafe.AsRef(in text.GetPinnableReference());
 #else
         return ref MemoryMarshal.GetReference(text.AsSpan());
 #endif
@@ -44,7 +44,7 @@ public static class StringExtensions
     public static ref char DangerousGetReferenceAt(this string text, int i)
     {
 #if NET6_0_OR_GREATER
-        ref char r0 = ref Unsafe.AsRef(text.GetPinnableReference());
+        ref char r0 = ref Unsafe.AsRef(in text.GetPinnableReference());
 #else
         ref char r0 = ref MemoryMarshal.GetReference(text.AsSpan());
 #endif

--- a/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.For.IAction.cs
+++ b/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.For.IAction.cs
@@ -172,7 +172,7 @@ public static partial class ParallelHelper
         {
             for (int i = start; i < end; i++)
             {
-                Unsafe.AsRef(action).Invoke(i);
+                Unsafe.AsRef(in action).Invoke(i);
             }
 
             return;
@@ -225,7 +225,7 @@ public static partial class ParallelHelper
 
             for (int j = low; j < stop; j++)
             {
-                Unsafe.AsRef(this.action).Invoke(j);
+                Unsafe.AsRef(in this.action).Invoke(j);
             }
         }
     }

--- a/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.For.IAction2D.cs
+++ b/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.For.IAction2D.cs
@@ -257,7 +257,7 @@ partial class ParallelHelper
             {
                 for (int x = left; x < right; x++)
                 {
-                    Unsafe.AsRef(action).Invoke(y, x);
+                    Unsafe.AsRef(in action).Invoke(y, x);
                 }
             }
 
@@ -319,7 +319,7 @@ partial class ParallelHelper
             {
                 for (int x = this.startX; x < this.endX; x++)
                 {
-                    Unsafe.AsRef(this.action).Invoke(y, x);
+                    Unsafe.AsRef(in this.action).Invoke(y, x);
                 }
             }
         }

--- a/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction.cs
+++ b/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction.cs
@@ -91,7 +91,7 @@ partial class ParallelHelper
         {
             foreach (TItem? item in memory.Span)
             {
-                Unsafe.AsRef(action).Invoke(item);
+                Unsafe.AsRef(in action).Invoke(item);
             }
 
             return;
@@ -144,7 +144,7 @@ partial class ParallelHelper
 
             while (Unsafe.IsAddressLessThan(ref rStart, ref rEnd))
             {
-                Unsafe.AsRef(this.action).Invoke(in rStart);
+                Unsafe.AsRef(in this.action).Invoke(in rStart);
 
                 rStart = ref Unsafe.Add(ref rStart, 1);
             }

--- a/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction2D.cs
+++ b/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction2D.cs
@@ -144,7 +144,7 @@ partial class ParallelHelper
 
                 while (Unsafe.IsAddressLessThan(ref rStart, ref rEnd))
                 {
-                    Unsafe.AsRef(this.action).Invoke(in rStart);
+                    Unsafe.AsRef(in this.action).Invoke(in rStart);
 
                     rStart = ref Unsafe.Add(ref rStart, 1);
                 }

--- a/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction.cs
+++ b/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction.cs
@@ -91,7 +91,7 @@ partial class ParallelHelper
         {
             foreach (ref TItem item in memory.Span)
             {
-                Unsafe.AsRef(action).Invoke(ref item);
+                Unsafe.AsRef(in action).Invoke(ref item);
             }
 
             return;
@@ -144,7 +144,7 @@ partial class ParallelHelper
 
             while (Unsafe.IsAddressLessThan(ref rStart, ref rEnd))
             {
-                Unsafe.AsRef(this.action).Invoke(ref rStart);
+                Unsafe.AsRef(in this.action).Invoke(ref rStart);
 
                 rStart = ref Unsafe.Add(ref rStart, 1);
             }

--- a/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction2D.cs
+++ b/src/CommunityToolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction2D.cs
@@ -151,7 +151,7 @@ partial class ParallelHelper
 
                 while (Unsafe.IsAddressLessThan(ref rStart, ref rEnd))
                 {
-                    Unsafe.AsRef(this.action).Invoke(ref rStart);
+                    Unsafe.AsRef(in this.action).Invoke(ref rStart);
 
                     rStart = ref Unsafe.Add(ref rStart, 1);
                 }

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -65,7 +65,7 @@
 
   <ItemGroup Label="Package">
 
-    <!-- Include the custom .targets file to check the source generator (.NET 6 is not needed as it guarantees Roslyn 4.x) -->
+    <!-- Include the custom .targets file to check the source generator (.NET 6 and 8 are not needed as they guarantee Roslyn 4.x) -->
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="buildTransitive\netstandard2.1" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="build\netstandard2.0" Pack="true" />

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -55,6 +55,7 @@
       System.Diagnostics.CodeAnalysis.NotNullAttribute;
       System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute;
       System.Diagnostics.CodeAnalysis.NotNullWhenAttribute;
+      System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute;
       System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute;
       System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute;
       System.Runtime.CompilerServices.CallerArgumentExpressionAttribute;

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -22,7 +22,7 @@
 
   <!-- .NET Standard 2.0 doesn't have the Span<T> and IAsyncEnumerable<T> types -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/src/CommunityToolkit.Mvvm/ComponentModel/ObservableRecipient.cs
+++ b/src/CommunityToolkit.Mvvm/ComponentModel/ObservableRecipient.cs
@@ -64,6 +64,12 @@ public abstract class ObservableRecipient : ObservableObject
             "If this type is removed by the linker, or if the target recipient was created dynamically and was missed by the source generator, a slower fallback " +
             "path using a compiled LINQ expression will be used. This will have more overhead in the first invocation of this method for any given recipient type. " +
             "Alternatively, OnActivated() can be manually overwritten, and registration can be done individually for each required message for this recipient.")]
+        [RequiresDynamicCode(
+            "When this property is set to true, the OnActivated() method will be invoked, which will register all necessary message handlers for this recipient. " +
+            "This method requires the generated CommunityToolkit.Mvvm.Messaging.__Internals.__IMessengerExtensions type not to be removed to use the fast path. " +
+            "If that is present, the method is AOT safe, as the only methods being invoked to register the messages will be the ones produced by the source generator. " +
+            "If it isn't, this method will need to dynamically create the generic methods to register messages, which might not be available at runtime. " +
+            "Alternatively, OnActivated() can be manually overwritten, and registration can be done individually for each required message for this recipient.")]
         set
         {
             if (SetProperty(ref this.isActive, value, true))
@@ -95,6 +101,11 @@ public abstract class ObservableRecipient : ObservableObject
         "This method requires the generated CommunityToolkit.Mvvm.Messaging.__Internals.__IMessengerExtensions type not to be removed to use the fast path. " +
         "If this type is removed by the linker, or if the target recipient was created dynamically and was missed by the source generator, a slower fallback " +
         "path using a compiled LINQ expression will be used. This will have more overhead in the first invocation of this method for any given recipient type. " +
+        "Alternatively, OnActivated() can be manually overwritten, and registration can be done individually for each required message for this recipient.")]
+    [RequiresDynamicCode(
+        "This method requires the generated CommunityToolkit.Mvvm.Messaging.__Internals.__IMessengerExtensions type not to be removed to use the fast path. " +
+        "If that is present, the method is AOT safe, as the only methods being invoked to register the messages will be the ones produced by the source generator. " +
+        "If it isn't, this method will need to dynamically create the generic methods to register messages, which might not be available at runtime. " +
         "Alternatively, OnActivated() can be manually overwritten, and registration can be done individually for each required message for this recipient.")]
     protected virtual void OnActivated()
     {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <!-- Include PolySharp to generate polyfills for all projects (on their .NET Standard 2.x targets) -->
   <ItemGroup>
-    <PackageReference Include="PolySharp" Version="1.13.1">
+    <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,16 +3,21 @@
   <Import Project="..\Directory.Build.targets" />
 
   <!-- Define NETSTANDARD2_1_OR_GREATER for .NET Standard 2.1 targets and above -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
     <DefineConstants>NETSTANDARD2_1_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <!-- Configure trimming for projects on .NET 6 and above -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+  </PropertyGroup>
+
+  <!-- Set the AOT property directly on .NET 8 and above -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <!--

--- a/tests/CommunityToolkit.Common.UnitTests/CommunityToolkit.Common.UnitTests.csproj
+++ b/tests/CommunityToolkit.Common.UnitTests/CommunityToolkit.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Common.UnitTests/CommunityToolkit.Common.UnitTests.csproj
+++ b/tests/CommunityToolkit.Common.UnitTests/CommunityToolkit.Common.UnitTests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Diagnostics.UnitTests/CommunityToolkit.Diagnostics.UnitTests.csproj
+++ b/tests/CommunityToolkit.Diagnostics.UnitTests/CommunityToolkit.Diagnostics.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Diagnostics.UnitTests/CommunityToolkit.Diagnostics.UnitTests.csproj
+++ b/tests/CommunityToolkit.Diagnostics.UnitTests/CommunityToolkit.Diagnostics.UnitTests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/CommunityToolkit.HighPerformance.UnitTests.csproj
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/CommunityToolkit.HighPerformance.UnitTests.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/CommunityToolkit.HighPerformance.UnitTests.csproj
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/CommunityToolkit.HighPerformance.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <NoWarn>$(NoWarn);CA2252</NoWarn>
   </PropertyGroup>

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayExtensions.1D.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ArrayExtensions.1D.cs
@@ -23,8 +23,8 @@ public partial class Test_ArrayExtensions
         // item if we use "DangerousGetReferenceAt". So all these tests just invoke the API and then
         // compare the returned reference against an existing baseline (like the built-in array indexer)
         // to ensure that the two are the same. These are all managed references, so no need for pinning.
-        ref string r0 = ref Unsafe.AsRef(tokens.DangerousGetReference());
-        ref string r1 = ref Unsafe.AsRef(tokens[0]);
+        ref string r0 = ref Unsafe.AsRef(in tokens.DangerousGetReference());
+        ref string r1 = ref Unsafe.AsRef(in tokens[0]);
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }
@@ -34,8 +34,8 @@ public partial class Test_ArrayExtensions
     {
         string[] tokens = "aa,bb,cc,dd,ee,ff,gg,hh,ii".Split(',');
 
-        ref string r0 = ref Unsafe.AsRef(tokens.DangerousGetReference());
-        ref string r1 = ref Unsafe.AsRef(tokens.DangerousGetReferenceAt(0));
+        ref string r0 = ref Unsafe.AsRef(in tokens.DangerousGetReference());
+        ref string r1 = ref Unsafe.AsRef(in tokens.DangerousGetReferenceAt(0));
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }
@@ -45,8 +45,8 @@ public partial class Test_ArrayExtensions
     {
         string[] tokens = "aa,bb,cc,dd,ee,ff,gg,hh,ii".Split(',');
 
-        ref string r0 = ref Unsafe.AsRef(tokens.DangerousGetReferenceAt(5));
-        ref string r1 = ref Unsafe.AsRef(tokens[5]);
+        ref string r0 = ref Unsafe.AsRef(in tokens.DangerousGetReferenceAt(5));
+        ref string r1 = ref Unsafe.AsRef(in tokens[5]);
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.cs
@@ -25,7 +25,7 @@ public partial class Test_ReadOnlySpanExtensions
         ReadOnlySpan<int> data = owner.GetSpan();
 
         ref int r0 = ref data.DangerousGetReference();
-        ref int r1 = ref Unsafe.AsRef(data[0]);
+        ref int r1 = ref Unsafe.AsRef(in data[0]);
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }
@@ -51,7 +51,7 @@ public partial class Test_ReadOnlySpanExtensions
         ReadOnlySpan<int> data = owner.GetSpan();
 
         ref int r0 = ref data.DangerousGetReferenceAt(5);
-        ref int r1 = ref Unsafe.AsRef(data[5]);
+        ref int r1 = ref Unsafe.AsRef(in data[5]);
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }
@@ -79,13 +79,13 @@ public partial class Test_ReadOnlySpanExtensions
             0, 0, 0, 0, 0, 0, 1, 0, 1
         };
 
-        ref byte ri = ref Unsafe.AsRef(table.DangerousGetLookupReferenceAt(i));
+        ref byte ri = ref Unsafe.AsRef(in table.DangerousGetLookupReferenceAt(i));
 
         bool isInRange = (uint)i < (uint)table.Length;
 
         if (isInRange)
         {
-            Assert.IsTrue(Unsafe.AreSame(ref ri, ref Unsafe.AsRef(table[i])));
+            Assert.IsTrue(Unsafe.AreSame(ref ri, ref Unsafe.AsRef(in table[i])));
         }
         else
         {
@@ -186,7 +186,7 @@ public partial class Test_ReadOnlySpanExtensions
 
         foreach (HighPerformance.Enumerables.ReadOnlySpanEnumerable<int>.Item item in data.Enumerate())
         {
-            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(data[i]), ref Unsafe.AsRef(item.Value)));
+            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in data[i]), ref Unsafe.AsRef(in item.Value)));
             Assert.AreEqual(i, item.Index);
 
             i++;

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_SpanExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_SpanExtensions.cs
@@ -18,8 +18,8 @@ public class Test_SpanExtensions
     {
         Span<int> data = new[] { 1, 2, 3, 4, 5, 6, 7 };
 
-        ref int r0 = ref Unsafe.AsRef(data.DangerousGetReference());
-        ref int r1 = ref Unsafe.AsRef(data[0]);
+        ref int r0 = ref Unsafe.AsRef(in data.DangerousGetReference());
+        ref int r1 = ref Unsafe.AsRef(in data[0]);
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }
@@ -29,8 +29,8 @@ public class Test_SpanExtensions
     {
         Span<int> data = new[] { 1, 2, 3, 4, 5, 6, 7 };
 
-        ref int r0 = ref Unsafe.AsRef(data.DangerousGetReference());
-        ref int r1 = ref Unsafe.AsRef(data.DangerousGetReferenceAt(0));
+        ref int r0 = ref Unsafe.AsRef(in data.DangerousGetReference());
+        ref int r1 = ref Unsafe.AsRef(in data.DangerousGetReferenceAt(0));
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }
@@ -40,8 +40,8 @@ public class Test_SpanExtensions
     {
         Span<int> data = new[] { 1, 2, 3, 4, 5, 6, 7 };
 
-        ref int r0 = ref Unsafe.AsRef(data.DangerousGetReferenceAt(5));
-        ref int r1 = ref Unsafe.AsRef(data[5]);
+        ref int r0 = ref Unsafe.AsRef(in data.DangerousGetReferenceAt(5));
+        ref int r1 = ref Unsafe.AsRef(in data[5]);
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_StringExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_StringExtensions.cs
@@ -18,7 +18,7 @@ public class Test_StringExtensions
         string text = "Hello, world!";
 
         ref char r0 = ref text.DangerousGetReference();
-        ref char r1 = ref Unsafe.AsRef(text.AsSpan()[0]);
+        ref char r1 = ref Unsafe.AsRef(in text.AsSpan()[0]);
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }
@@ -40,7 +40,7 @@ public class Test_StringExtensions
         string text = "Hello, world!";
 
         ref char r0 = ref text.DangerousGetReferenceAt(5);
-        ref char r1 = ref Unsafe.AsRef(text.AsSpan()[5]);
+        ref char r1 = ref Unsafe.AsRef(in text.AsSpan()[5]);
 
         Assert.IsTrue(Unsafe.AreSame(ref r0, ref r1));
     }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlyMemory2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlyMemory2D{T}.cs
@@ -298,7 +298,7 @@ public class Test_ReadOnlyMemory2DT
 #else
         Assert.IsTrue(success);
         Assert.AreEqual(memory.Length, array.Length);
-        Assert.IsTrue(Unsafe.AreSame(ref array[0, 0], ref Unsafe.AsRef(memory.Span[0])));
+        Assert.IsTrue(Unsafe.AreSame(ref array[0, 0], ref Unsafe.AsRef(in memory.Span[0])));
 #endif
     }
 

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlySpan2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlySpan2D{T}.cs
@@ -550,10 +550,10 @@ public class Test_ReadOnlySpan2DT
         ReadOnlySpan<int> span = span2d.GetRowSpan(1);
 
         Assert.IsTrue(Unsafe.AreSame(
-            ref Unsafe.AsRef(span[0]),
+            ref Unsafe.AsRef(in span[0]),
             ref array[1, 0]));
         Assert.IsTrue(Unsafe.AreSame(
-            ref Unsafe.AsRef(span[2]),
+            ref Unsafe.AsRef(in span[2]),
             ref array[1, 2]));
 
         _ = Assert.ThrowsException<ArgumentOutOfRangeException>(() => new ReadOnlySpan2D<int>(array).GetRowSpan(-1));
@@ -783,7 +783,7 @@ public class Test_ReadOnlySpan2DT
         int i = 0;
         foreach (ref readonly int value in new ReadOnlySpan2D<int>(array).GetRow(1))
         {
-            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(value), ref array[1, i++]));
+            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in value), ref array[1, i++]));
         }
 
         ReadOnlyRefEnumerable<int> enumerable = new ReadOnlySpan2D<int>(array).GetRow(1);
@@ -815,7 +815,7 @@ public class Test_ReadOnlySpan2DT
         int i = 0;
         foreach (ref readonly int value in new ReadOnlySpan2D<int>(array, 2, 3, 0).GetRow(1))
         {
-            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(value), ref array[3 + i++]));
+            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in value), ref array[3 + i++]));
         }
 
         ReadOnlyRefEnumerable<int> enumerable = new ReadOnlySpan2D<int>(array, 2, 3, 0).GetRow(1);
@@ -841,7 +841,7 @@ public class Test_ReadOnlySpan2DT
         int i = 0;
         foreach (ref readonly int value in new ReadOnlySpan2D<int>(array).GetColumn(1))
         {
-            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(value), ref array[i++, 1]));
+            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in value), ref array[i++, 1]));
         }
 
         ReadOnlyRefEnumerable<int> enumerable = new ReadOnlySpan2D<int>(array).GetColumn(2);
@@ -871,7 +871,7 @@ public class Test_ReadOnlySpan2DT
         int i = 0;
         foreach (ref readonly int value in new ReadOnlySpan2D<int>(array, 2, 3, 0).GetColumn(1))
         {
-            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(value), ref array[(i++ * 3) + 1]));
+            Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in value), ref array[(i++ * 3) + 1]));
         }
 
         ReadOnlyRefEnumerable<int> enumerable = new ReadOnlySpan2D<int>(array, 2, 3, 0).GetColumn(2);

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableReadOnlyRef{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Test_NullableReadOnlyRef{T}.cs
@@ -20,7 +20,7 @@ public class Test_NullableReadOnlyRefOfT
         NullableReadOnlyRef<int> reference = new(value);
 
         Assert.IsTrue(reference.HasValue);
-        Assert.IsTrue(Unsafe.AreSame(ref value, ref Unsafe.AsRef(reference.Value)));
+        Assert.IsTrue(Unsafe.AreSame(ref value, ref Unsafe.AsRef(in reference.Value)));
     }
 
     [TestMethod]
@@ -50,7 +50,7 @@ public class Test_NullableReadOnlyRefOfT
         NullableReadOnlyRef<int> nullableRef = reference;
 
         Assert.IsTrue(nullableRef.HasValue);
-        Assert.IsTrue(Unsafe.AreSame(ref reference.Value, ref Unsafe.AsRef(nullableRef.Value)));
+        Assert.IsTrue(Unsafe.AreSame(ref reference.Value, ref Unsafe.AsRef(in nullableRef.Value)));
     }
 
     [TestMethod]
@@ -61,7 +61,7 @@ public class Test_NullableReadOnlyRefOfT
         NullableReadOnlyRef<int> nullableRef = reference;
 
         Assert.IsTrue(nullableRef.HasValue);
-        Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(reference.Value), ref Unsafe.AsRef(nullableRef.Value)));
+        Assert.IsTrue(Unsafe.AreSame(ref Unsafe.AsRef(in reference.Value), ref Unsafe.AsRef(in nullableRef.Value)));
     }
 
     [TestMethod]
@@ -72,7 +72,7 @@ public class Test_NullableReadOnlyRefOfT
         NullableReadOnlyRef<int> nullableRef = reference;
 
         Assert.IsTrue(nullableRef.HasValue);
-        Assert.IsTrue(Unsafe.AreSame(ref reference.Value, ref Unsafe.AsRef(nullableRef.Value)));
+        Assert.IsTrue(Unsafe.AreSame(ref reference.Value, ref Unsafe.AsRef(in nullableRef.Value)));
     }
 
     [TestMethod]

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Test_ReadOnlyRef{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Test_ReadOnlyRef{T}.cs
@@ -18,7 +18,7 @@ public class Test_ReadOnlyRefOfT
         int value = 1;
         ReadOnlyRef<int> reference = new(value);
 
-        Assert.IsTrue(Unsafe.AreSame(ref value, ref Unsafe.AsRef(reference.Value)));
+        Assert.IsTrue(Unsafe.AreSame(ref value, ref Unsafe.AsRef(in reference.Value)));
     }
 }
 

--- a/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests/CommunityToolkit.Mvvm.DisableINotifyPropertyChanging.UnitTests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.Internals.UnitTests/CommunityToolkit.Mvvm.Internals.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Internals.UnitTests/CommunityToolkit.Mvvm.Internals.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.Internals.UnitTests/CommunityToolkit.Mvvm.Internals.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Internals.UnitTests/CommunityToolkit.Mvvm.Internals.UnitTests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.Roslyn401.UnitTests/CommunityToolkit.Mvvm.Roslyn401.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Roslyn401.UnitTests/CommunityToolkit.Mvvm.Roslyn401.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/tests/CommunityToolkit.Mvvm.Roslyn401.UnitTests/CommunityToolkit.Mvvm.Roslyn401.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Roslyn401.UnitTests/CommunityToolkit.Mvvm.Roslyn401.UnitTests.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="Dbs.Signed3.Nito.AsyncEx.Context" Version="5.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.Roslyn431.UnitTests/CommunityToolkit.Mvvm.Roslyn431.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Roslyn431.UnitTests/CommunityToolkit.Mvvm.Roslyn431.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/tests/CommunityToolkit.Mvvm.Roslyn431.UnitTests/CommunityToolkit.Mvvm.Roslyn431.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Roslyn431.UnitTests/CommunityToolkit.Mvvm.Roslyn431.UnitTests.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="Dbs.Signed3.Nito.AsyncEx.Context" Version="5.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2-beta1.23509.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests.csproj
@@ -2,12 +2,16 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <RestoreSources>
+      https://api.nuget.org/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
+    </RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2-beta1.23509.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/Test_AsyncVoidReturningRelayCommandMethodCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/Test_AsyncVoidReturningRelayCommandMethodCodeFixer.cs
@@ -53,7 +53,7 @@ public class Test_AsyncVoidReturningRelayCommandMethodCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(RelayCommand).Assembly);
@@ -98,7 +98,7 @@ public class Test_AsyncVoidReturningRelayCommandMethodCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(RelayCommand).Assembly);

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/Test_ClassUsingAttributeInsteadOfInheritanceCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/Test_ClassUsingAttributeInsteadOfInheritanceCodeFixer.cs
@@ -48,7 +48,7 @@ public class ClassUsingAttributeInsteadOfInheritanceCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
@@ -97,7 +97,7 @@ public class ClassUsingAttributeInsteadOfInheritanceCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
@@ -150,7 +150,7 @@ public class ClassUsingAttributeInsteadOfInheritanceCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
@@ -203,7 +203,7 @@ public class ClassUsingAttributeInsteadOfInheritanceCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
@@ -260,7 +260,7 @@ public class ClassUsingAttributeInsteadOfInheritanceCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
@@ -312,7 +312,7 @@ public class ClassUsingAttributeInsteadOfInheritanceCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/Test_FieldReferenceForObservablePropertyFieldCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn401.UnitTests/Test_FieldReferenceForObservablePropertyFieldCodeFixer.cs
@@ -59,7 +59,7 @@ public class Test_FieldReferenceForObservablePropertyFieldCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
@@ -123,7 +123,7 @@ public class Test_FieldReferenceForObservablePropertyFieldCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
@@ -195,7 +195,7 @@ public class Test_FieldReferenceForObservablePropertyFieldCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
@@ -265,7 +265,7 @@ public class Test_FieldReferenceForObservablePropertyFieldCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests.csproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);ROSLYN_4_3_1_OR_GREATER</DefineConstants>
   </PropertyGroup>
 

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn431.UnitTests.csproj
@@ -3,10 +3,14 @@
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);ROSLYN_4_3_1_OR_GREATER</DefineConstants>
+    <RestoreSources>
+      https://api.nuget.org/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
+    </RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
@@ -50,7 +50,9 @@ internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpA
     {
         CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> test = new(languageVersion) { TestCode = source };
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
+        test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+#elif NET6_0_OR_GREATER
         test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
 #else
         test.TestState.ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default;

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -1046,8 +1046,8 @@ public partial class Test_ObservablePropertyAttribute
     {
         ModelWithDependentPropertyAndPropertyChanging model = new();
 
-        List<string> changingArgs = new();
-        List<string> changedArgs = new();
+        List<string?> changingArgs = new();
+        List<string?> changedArgs = new();
 
         model.PropertyChanging += (s, e) => changingArgs.Add(e.PropertyName);
         model.PropertyChanged += (s, e) => changedArgs.Add(e.PropertyName);
@@ -1064,7 +1064,7 @@ public partial class Test_ObservablePropertyAttribute
     {
         ModelWithDependentPropertyAndNoPropertyChanging model = new();
 
-        List<string> changedArgs = new();
+        List<string?> changedArgs = new();
 
         model.PropertyChanged += (s, e) => changedArgs.Add(e.PropertyName);
 


### PR DESCRIPTION
This PR adds the .NET 8 TFM to all projects, enables tests on .NET 8, and adds AOT annotations where necessary.

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventionsther information that might be helpful to reviewers.