### PR TITLE
Include sizeof(T) in offset calculation for Memory2D from MemoryManager

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -338,7 +338,7 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="memoryManager"/>.
     /// </exception>
-    public Memory2D(MemoryManager<T> memoryManager, int offset, int height, int width, int pitch)
+    public unsafe Memory2D(MemoryManager<T> memoryManager, int offset, int height, int width, int pitch)
     {
         int length = memoryManager.GetSpan().Length;
 
@@ -378,7 +378,7 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
         }
 
         this.instance = memoryManager;
-        this.offset = (nint)(uint)offset;
+        this.offset = (nint)(uint)offset * (nint)(uint)sizeof(T);
         this.height = height;
         this.width = width;
         this.pitch = pitch;
@@ -413,7 +413,7 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="memory"/>.
     /// </exception>
-    internal Memory2D(Memory<T> memory, int offset, int height, int width, int pitch)
+    internal unsafe Memory2D(Memory<T> memory, int offset, int height, int width, int pitch)
     {
         if ((uint)offset > (uint)memory.Length)
         {
@@ -477,7 +477,7 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
         else if (MemoryMarshal.TryGetMemoryManager<T, MemoryManager<T>>(memory, out MemoryManager<T>? memoryManager, out int memoryManagerStart, out _))
         {
             this.instance = memoryManager;
-            this.offset = (nint)(uint)(memoryManagerStart + offset);
+            this.offset = (nint)(uint)(memoryManagerStart + offset) * (nint)(uint)sizeof(T);
         }
         else
         {

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -358,7 +358,7 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="memoryManager"/>.
     /// </exception>
-    public ReadOnlyMemory2D(MemoryManager<T> memoryManager, int offset, int height, int width, int pitch)
+    public unsafe ReadOnlyMemory2D(MemoryManager<T> memoryManager, int offset, int height, int width, int pitch)
     {
         int length = memoryManager.GetSpan().Length;
 
@@ -398,7 +398,7 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
         }
 
         this.instance = memoryManager;
-        this.offset = (nint)(uint)offset;
+        this.offset = (nint)(uint)offset * (nint)(uint)sizeof(T);
         this.height = height;
         this.width = width;
         this.pitch = pitch;
@@ -433,7 +433,7 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
     /// <exception cref="ArgumentException">
     /// Thrown when the requested area is outside of bounds for <paramref name="memory"/>.
     /// </exception>
-    internal ReadOnlyMemory2D(ReadOnlyMemory<T> memory, int offset, int height, int width, int pitch)
+    internal unsafe ReadOnlyMemory2D(ReadOnlyMemory<T> memory, int offset, int height, int width, int pitch)
     {
         if ((uint)offset > (uint)memory.Length)
         {
@@ -489,7 +489,7 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
         else if (MemoryMarshal.TryGetMemoryManager(memory, out MemoryManager<T>? memoryManager, out int memoryManagerStart, out _))
         {
             this.instance = memoryManager;
-            this.offset = (nint)(uint)(memoryManagerStart + offset);
+            this.offset = (nint)(uint)(memoryManagerStart + offset) * (nint)(uint)sizeof(T);
         }
         else
         {


### PR DESCRIPTION
**Closes #742**

## Overview

`Memory2D<T>` and `ReadOnlyMemory2D<T>` instances created from a `MemoryManager` calculate the `offset` field in units of `T` instead of `byte` in the constructor. Since [this fix]( https://github.com/CommunityToolkit/dotnet/pull/675/commits/76da6895cad4db7209495efb35f4d7025c7675a4) in v8.2.1 [where `Span` creation was changed to `Unsafe.AddByteOffset`](https://github.com/CommunityToolkit/dotnet/blob/76da6895cad4db7209495efb35f4d7025c7675a4/src/CommunityToolkit.HighPerformance/Memory/Memory2D%7BT%7D.cs#L606), this causes incorrect indexing into the span.

Fixes were added for NET6 or greater.

## PR Checklist

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Code follows all style conventions