### PR TITLE
Avoid auto-generating ObservableValidator.HasError

### DIFF
--- a/src/CommunityToolkit.Mvvm/ComponentModel/ObservableValidator.cs
+++ b/src/CommunityToolkit.Mvvm/ComponentModel/ObservableValidator.cs
@@ -123,6 +123,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     }
 
     /// <inheritdoc/>
+    [Display(AutoGenerateField = false)]
     public bool HasErrors => this.totalErrors > 0;
 
     /// <summary>

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservableValidator.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservableValidator.cs
@@ -607,7 +607,20 @@ public class Test_ObservableValidator
         Assert.IsFalse(model.HasErrors);
         Assert.IsTrue(events.Count == 1);
 
-        Assert.IsTrue(events.Any(e => e.PropertyName == nameof(DerivedModelWithValidatableProperties.Name)));    }
+        Assert.IsTrue(events.Any(e => e.PropertyName == nameof(DerivedModelWithValidatableProperties.Name)));
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/881
+    [TestMethod]
+    public void Test_ObservableValidator_HasErrors_IncludeNonAutogenerateAttribute()
+    {
+        DerivedModelWithValidatableProperties model = new();
+
+        DisplayAttribute? displayAttribute = model.GetType().GetProperty(nameof(ObservableValidator.HasErrors))?.GetCustomAttribute<DisplayAttribute>();
+
+        Assert.IsNotNull(displayAttribute);
+        Assert.IsFalse(displayAttribute.AutoGenerateField);
+    }
 
     public class Person : ObservableValidator
     {


### PR DESCRIPTION
**Closes #881**

The change adds the System.ComponentModel.DisplayAttribute to the property HasErrors of ObservableValidator class.

The property AutGenerateField of the Display attribute will be set to false. This way when objects having validation are bound to any UI control supporting DataAnnotations will not generate any UI for this property.