### PR TITLE
Add AOT support in WinRT scenarios to the MVVM Toolkit

### DIFF
--- a/src/CommunityToolkit.Mvvm/Collections/ObservableGroupedCollection{TKey,TElement}.cs
+++ b/src/CommunityToolkit.Mvvm/Collections/ObservableGroupedCollection{TKey,TElement}.cs
@@ -15,7 +15,7 @@ namespace CommunityToolkit.Mvvm.Collections;
 /// </summary>
 /// <typeparam name="TKey">The type of the group keys.</typeparam>
 /// <typeparam name="TElement">The type of elements in the collection.</typeparam>
-public sealed class ObservableGroupedCollection<TKey, TElement> : ObservableCollection<ObservableGroup<TKey, TElement>>, ILookup<TKey, TElement>
+public sealed partial class ObservableGroupedCollection<TKey, TElement> : ObservableCollection<ObservableGroup<TKey, TElement>>, ILookup<TKey, TElement>
     where TKey : notnull
 {
     /// <summary>

--- a/src/CommunityToolkit.Mvvm/Collections/ReadOnlyObservableGroupedCollection{TKey,TElement}.cs
+++ b/src/CommunityToolkit.Mvvm/Collections/ReadOnlyObservableGroupedCollection{TKey,TElement}.cs
@@ -17,7 +17,7 @@ namespace CommunityToolkit.Mvvm.Collections;
 /// </summary>
 /// <typeparam name="TKey">The type of the group keys.</typeparam>
 /// <typeparam name="TElement">The type of elements in the collection.</typeparam>
-public sealed class ReadOnlyObservableGroupedCollection<TKey, TElement> : ReadOnlyObservableCollection<ReadOnlyObservableGroup<TKey, TElement>>, ILookup<TKey, TElement>
+public sealed partial class ReadOnlyObservableGroupedCollection<TKey, TElement> : ReadOnlyObservableCollection<ReadOnlyObservableGroup<TKey, TElement>>, ILookup<TKey, TElement>
     where TKey : notnull
 {
     /// <summary>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -1,7 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net8.0-windows10.0.17763.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <!--
+    Windows-only properties (supporting AOT in WinRT scenarios requires actually using the Windows TFM,
+    because we need the source generators in CsWinRT to generate the supporting interop code for AOT).
+  -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows10.0.17763.0'))">
+    <WindowsSdkPackageVersion>10.0.17763.37-preview</WindowsSdkPackageVersion>
+
+    <!-- Enable AOT warnings for types implementing projected WinRT interfaces mapped to built-in types (eg. 'INotifyPropertyChanged') -->
+    <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -32,6 +43,11 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
+  <!-- Reference CsWinRT when targeting Windows, to get the latest source generators -->
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows10.0.17763.0'))">
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.0-prerelease.240801.1" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Reference the various multi-targeted versions of the source generator project (one per Roslyn version), and the code fixer -->
@@ -87,5 +103,4 @@
     <None Include="..\CommunityToolkit.Mvvm.CodeFixers\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Mvvm.CodeFixers.dll" PackagePath="analyzers\dotnet\roslyn4.0\cs" Pack="true" Visible="false" />
     <None Include="..\CommunityToolkit.Mvvm.CodeFixers\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Mvvm.CodeFixers.dll" PackagePath="analyzers\dotnet\roslyn4.3\cs" Pack="true" Visible="false" />
   </ItemGroup>
-
 </Project>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -11,6 +11,12 @@
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows10.0.17763.0'))">
     <WindowsSdkPackageVersion>10.0.17763.37-preview</WindowsSdkPackageVersion>
 
+    <!--
+      We're only referencing CsWinRT for the source generators, we don't need to read any WinRT metadata.
+      CsWinRT is in projection mode by default, so we want to disable it (or it'd need the Windows SDK).
+    -->
+    <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
+
     <!-- Enable AOT warnings for types implementing projected WinRT interfaces mapped to built-in types (eg. 'INotifyPropertyChanged') -->
     <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
   </PropertyGroup>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -9,7 +9,7 @@
     because we need the source generators in CsWinRT to generate the supporting interop code for AOT).
   -->
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows10.0.17763.0'))">
-    <WindowsSdkPackageVersion>10.0.17763.37-preview</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.39</WindowsSdkPackageVersion>
 
     <!--
       We're only referencing CsWinRT for the source generators, we don't need to read any WinRT metadata.

--- a/src/CommunityToolkit.Mvvm/DependencyInjection/Ioc.cs
+++ b/src/CommunityToolkit.Mvvm/DependencyInjection/Ioc.cs
@@ -41,7 +41,7 @@ namespace CommunityToolkit.Mvvm.DependencyInjection;
 /// Ioc.Default.GetService&lt;ILogger&gt;().Log("Hello world!");
 /// </code>
 /// </summary>
-public sealed class Ioc : IServiceProvider
+public sealed partial class Ioc : IServiceProvider
 {
     /// <summary>
     /// Gets the default <see cref="Ioc"/> instance.

--- a/src/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/src/CommunityToolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -20,7 +20,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// action, and providing an <see cref="ExecutionTask"/> property that notifies changes when
 /// <see cref="ExecuteAsync"/> is invoked and when the returned <see cref="Task"/> completes.
 /// </summary>
-public sealed class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCommand
+public sealed partial class AsyncRelayCommand : IAsyncRelayCommand, ICancellationAwareCommand
 {
     /// <summary>
     /// The cached <see cref="PropertyChangedEventArgs"/> for <see cref="ExecutionTask"/>.

--- a/src/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/src/CommunityToolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -18,7 +18,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// A generic command that provides a more specific version of <see cref="AsyncRelayCommand"/>.
 /// </summary>
 /// <typeparam name="T">The type of parameter being passed as input to the callbacks.</typeparam>
-public sealed class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationAwareCommand
+public sealed partial class AsyncRelayCommand<T> : IAsyncRelayCommand<T>, ICancellationAwareCommand
 {
     /// <summary>
     /// The <see cref="Func{TResult}"/> to invoke when <see cref="Execute(T)"/> is used.

--- a/src/CommunityToolkit.Mvvm/Input/Internals/CancelCommand.cs
+++ b/src/CommunityToolkit.Mvvm/Input/Internals/CancelCommand.cs
@@ -11,7 +11,7 @@ namespace CommunityToolkit.Mvvm.Input.Internals;
 /// <summary>
 /// A <see cref="ICommand"/> implementation wrapping <see cref="IAsyncRelayCommand"/> to support cancellation.
 /// </summary>
-internal sealed class CancelCommand : ICommand
+internal sealed partial class CancelCommand : ICommand
 {
     /// <summary>
     /// The wrapped <see cref="IAsyncRelayCommand"/> instance.

--- a/src/CommunityToolkit.Mvvm/Input/Internals/DisabledCommand.cs
+++ b/src/CommunityToolkit.Mvvm/Input/Internals/DisabledCommand.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.Mvvm.Input.Internals;
 /// <summary>
 /// A reusable <see cref="ICommand"/> instance that is always disabled.
 /// </summary>
-internal sealed class DisabledCommand : ICommand
+internal sealed partial class DisabledCommand : ICommand
 {
     /// <inheritdoc/>
     public event EventHandler? CanExecuteChanged

--- a/src/CommunityToolkit.Mvvm/Input/RelayCommand.cs
+++ b/src/CommunityToolkit.Mvvm/Input/RelayCommand.cs
@@ -16,7 +16,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// method is <see langword="true"/>. This type does not allow you to accept command parameters
 /// in the <see cref="Execute"/> and <see cref="CanExecute"/> callback methods.
 /// </summary>
-public sealed class RelayCommand : IRelayCommand
+public sealed partial class RelayCommand : IRelayCommand
 {
     /// <summary>
     /// The <see cref="Action"/> to invoke when <see cref="Execute"/> is used.

--- a/src/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/src/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -18,7 +18,7 @@ namespace CommunityToolkit.Mvvm.Input;
 /// in the <see cref="Execute(T)"/> and <see cref="CanExecute(T)"/> callback methods.
 /// </summary>
 /// <typeparam name="T">The type of parameter being passed as input to the callbacks.</typeparam>
-public sealed class RelayCommand<T> : IRelayCommand<T>
+public sealed partial class RelayCommand<T> : IRelayCommand<T>
 {
     /// <summary>
     /// The <see cref="Action"/> to invoke when <see cref="Execute(T)"/> is used.

--- a/src/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.Observables.cs
+++ b/src/CommunityToolkit.Mvvm/Messaging/IMessengerExtensions.Observables.cs
@@ -4,6 +4,14 @@
 
 using System;
 
+// This file has two types which implement interfaces that can be projected to WInRT, ie.
+// 'Observable<TMessage>.Recipient' and 'Observable<TMessage, TToken>.Recipient', which
+// implement 'IDisposable' (which is projected to 'IClosable'). These types are not meant
+// to be used in interop scenarios (including in eg. bindings), as they're only meant to
+// be used by code behind interacting with System.Reactive APIs. As such, we skip marking
+// them partial, as we don't need CCW vtables to be generated for them.
+#pragma warning disable CsWinRT1028
+
 namespace CommunityToolkit.Mvvm.Messaging;
 
 /// <inheritdoc/>


### PR DESCRIPTION
### Fixes #892

This PR adds the Windows TFM to the MVVM Toolkit, and makes it AOT compatible for WinRT interop.

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions