### PR TITLE
Disable IID optimizer in MVVM Toolkit

### DIFF
--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -17,6 +17,9 @@
     -->
     <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
 
+    <!-- We'll never have any IIDs to patch in this library -->
+    <CsWinRTIIDOptimizerOptOut>true</CsWinRTIIDOptimizerOptOut>
+
     <!-- Enable AOT warnings for types implementing projected WinRT interfaces mapped to built-in types (eg. 'INotifyPropertyChanged') -->
     <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
This PR disables the IID optimizer in the MVVM Toolkit. Isn't not doing anything, this speeds up the build a tiny bit.

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventionsrs. -->