### PR TITLE
Don't generate 'INotifyPropertyChanging' code if not requested

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -55,6 +55,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CompilationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DiagnosticsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\INamedTypeSymbolExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\GeneratorAttributeSyntaxContextWithOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\IncrementalGeneratorInitializationContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\IncrementalValuesProviderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\MethodDeclarationSyntaxExtensions.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
@@ -25,8 +25,7 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
     {
         // Gather info for all annotated fields
         IncrementalValuesProvider<(HierarchyInfo Hierarchy, Result<PropertyInfo?> Info)> propertyInfoWithErrors =
-            context.SyntaxProvider
-            .ForAttributeWithMetadataName(
+            context.ForAttributeWithMetadataNameAndOptions(
                 "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute",
                 static (node, _) => node is VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Parent: FieldDeclarationSyntax { Parent: ClassDeclarationSyntax or RecordDeclarationSyntax, AttributeLists.Count: > 0 } } },
                 static (context, token) =>
@@ -44,7 +43,14 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
 
                     token.ThrowIfCancellationRequested();
 
-                    _ = Execute.TryGetInfo(fieldDeclaration, fieldSymbol, context.SemanticModel, token, out PropertyInfo? propertyInfo, out ImmutableArray<DiagnosticInfo> diagnostics);
+                    _ = Execute.TryGetInfo(
+                        fieldDeclaration,
+                        fieldSymbol,
+                        context.SemanticModel,
+                        context.GlobalOptions,
+                        token,
+                        out PropertyInfo? propertyInfo,
+                        out ImmutableArray<DiagnosticInfo> diagnostics);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/GeneratorAttributeSyntaxContextWithOptions.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/GeneratorAttributeSyntaxContextWithOptions.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+
+/// <summary>
+/// <inheritdoc cref="GeneratorAttributeSyntaxContext" path="/summary/node()"/>
+/// </summary>
+/// <param name="syntaxContext">The original <see cref="GeneratorAttributeSyntaxContext"/> value.</param>
+/// <param name="globalOptions">The original <see cref="AnalyzerConfigOptions"/> value.</param>
+internal readonly struct GeneratorAttributeSyntaxContextWithOptions(
+    GeneratorAttributeSyntaxContext syntaxContext,
+    AnalyzerConfigOptions globalOptions)
+{
+    /// <inheritdoc cref="GeneratorAttributeSyntaxContext.TargetNode"/>
+    public SyntaxNode TargetNode { get; } = syntaxContext.TargetNode;
+
+    /// <inheritdoc cref="GeneratorAttributeSyntaxContext.TargetSymbol"/>
+    public ISymbol TargetSymbol { get; } = syntaxContext.TargetSymbol;
+
+    /// <inheritdoc cref="GeneratorAttributeSyntaxContext.SemanticModel"/>
+    public SemanticModel SemanticModel { get; } = syntaxContext.SemanticModel;
+
+    /// <inheritdoc cref="GeneratorAttributeSyntaxContext.Attributes"/>
+    public ImmutableArray<AttributeData> Attributes { get; } = syntaxContext.Attributes;
+
+    /// <inheritdoc cref="AnalyzerConfigOptionsProvider.GlobalOptions"/>
+    public AnalyzerConfigOptions GlobalOptions { get; } = globalOptions;
+}

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/IncrementalGeneratorInitializationContextExtensions.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/IncrementalGeneratorInitializationContextExtensions.cs
@@ -4,7 +4,11 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+#pragma warning disable CS1574
 
 namespace CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 
@@ -13,6 +17,31 @@ namespace CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 /// </summary>
 internal static class IncrementalGeneratorInitializationContextExtensions
 {
+    /// <inheritdoc cref="SyntaxValueProvider.ForAttributeWithMetadataName"/>
+    public static IncrementalValuesProvider<T> ForAttributeWithMetadataNameAndOptions<T>(
+        this IncrementalGeneratorInitializationContext context,
+        string fullyQualifiedMetadataName,
+        Func<SyntaxNode, CancellationToken, bool> predicate,
+        Func<GeneratorAttributeSyntaxContextWithOptions, CancellationToken, T> transform)
+    {
+        // Invoke 'ForAttributeWithMetadataName' normally, but just return the context directly
+        IncrementalValuesProvider<GeneratorAttributeSyntaxContext> syntaxContext = context.SyntaxProvider.ForAttributeWithMetadataName(
+            fullyQualifiedMetadataName,
+            predicate,
+            static (context, token) => context);
+
+        // Do the same for the analyzer config options
+        IncrementalValueProvider<AnalyzerConfigOptions> configOptions = context.AnalyzerConfigOptionsProvider.Select(static (provider, token) => provider.GlobalOptions);
+
+        // Merge the two and invoke the provided transform on these two values. Neither value
+        // is equatable, meaning the pipeline will always re-run until this point. This is
+        // intentional: we don't want any symbols or other expensive objects to be kept alive
+        // across incremental steps, especially if they could cause entire compilations to be
+        // rooted, which would significantly increase memory use and introduce more GC pauses.
+        // In this specific case, flowing non equatable values in a pipeline is therefore fine.
+        return syntaxContext.Combine(configOptions).Select((input, token) => transform(new GeneratorAttributeSyntaxContextWithOptions(input.Left, input.Right), token));
+    }
+
     /// <summary>
     /// Conditionally invokes <see cref="IncrementalGeneratorInitializationContext.RegisterSourceOutput{TSource}(IncrementalValueProvider{TSource}, Action{SourceProductionContext, TSource})"/>
     /// if the value produced by the input <see cref="IncrementalValueProvider{TValue}"/> is <see langword="true"/>.

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.FeatureSwitches.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.FeatureSwitches.targets
@@ -6,6 +6,14 @@
   </PropertyGroup>
 
   <!--
+    Make the properties visible to the source generators as well, to allow
+    them to emit optimized codegen ahead of time depending on their values.
+  -->
+  <ItemGroup>
+    <CompilerVisibleProperty Include="MvvmToolkitEnableINotifyPropertyChangingSupport" />
+  </ItemGroup>
+
+  <!--
     Configuration for the feature switches (to support IL trimming).
     See the 'ILLink.Substitutions.xml' file for more details on that.
     We only include these on .NET 6 and above (no .xml file otherwise).


### PR DESCRIPTION
Follow up to #911, this PR also makes the MVVM Toolkit generator follow the user settings for enabled features.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions