### PR TITLE
Update Windows SDK package version

### DIFF
--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -9,7 +9,7 @@
     because we need the source generators in CsWinRT to generate the supporting interop code for AOT).
   -->
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows10.0.17763.0'))">
-    <WindowsSdkPackageVersion>10.0.17763.39</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.41</WindowsSdkPackageVersion>
 
     <!--
       We're only referencing CsWinRT for the source generators, we don't need to read any WinRT metadata.


### PR DESCRIPTION
This PR fixes the Windows SDK package version for .NET 8 to use the correct one.