### PR TITLE
Support for custom name in ObservablePropertyAttribute

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -38,12 +38,14 @@ partial class ObservablePropertyGenerator
         /// <param name="token">The cancellation token for the current operation.</param>
         /// <param name="propertyInfo">The resulting <see cref="PropertyInfo"/> value, if successfully retrieved.</param>
         /// <param name="diagnostics">The resulting diagnostics from the processing operation.</param>
+        /// <param name="PropertyName">Generated property name. If empty, the property name will be generated from the field name.</param>
         /// <returns>The resulting <see cref="PropertyInfo"/> instance for <paramref name="fieldSymbol"/>, if successful.</returns>
         public static bool TryGetInfo(
             FieldDeclarationSyntax fieldSyntax,
             IFieldSymbol fieldSymbol,
             SemanticModel semanticModel,
             CancellationToken token,
+            string PropertyName,
             [NotNullWhen(true)] out PropertyInfo? propertyInfo,
             out ImmutableArray<DiagnosticInfo> diagnostics)
         {
@@ -69,7 +71,8 @@ partial class ObservablePropertyGenerator
             // Get the property type and name
             string typeNameWithNullabilityAnnotations = fieldSymbol.Type.GetFullyQualifiedNameWithNullabilityAnnotations();
             string fieldName = fieldSymbol.Name;
-            string propertyName = GetGeneratedPropertyName(fieldSymbol);
+            // Generate if not specified
+            string propertyName = string.IsNullOrEmpty(PropertyName) ? GetGeneratedPropertyName(fieldSymbol) : PropertyName;
 
             // Check for name collisions
             if (fieldName == propertyName)

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
@@ -44,7 +44,9 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
 
                     token.ThrowIfCancellationRequested();
 
-                    _ = Execute.TryGetInfo(fieldDeclaration, fieldSymbol, context.SemanticModel, token, out PropertyInfo? propertyInfo, out ImmutableArray<DiagnosticInfo> diagnostics);
+                    string propertyName = context.Attributes.FirstOrDefault()?.GetConstructorArguments<string>().FirstOrDefault() ?? string.Empty;;
+
+                    _ = Execute.TryGetInfo(fieldDeclaration, fieldSymbol, context.SemanticModel, token, propertyName, out PropertyInfo? propertyInfo, out ImmutableArray<DiagnosticInfo> diagnostics);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/CommunityToolkit.Mvvm/ComponentModel/Attributes/ObservablePropertyAttribute.cs
+++ b/src/CommunityToolkit.Mvvm/ComponentModel/Attributes/ObservablePropertyAttribute.cs
@@ -49,9 +49,24 @@ namespace CommunityToolkit.Mvvm.ComponentModel;
 /// The generated properties will automatically use the <c>UpperCamelCase</c> format for their names,
 /// which will be derived from the field names. The generator can also recognize fields using either
 /// the <c>_lowerCamel</c> or <c>m_lowerCamel</c> naming scheme. Otherwise, the first character in the
-/// source field name will be converted to uppercase (eg. <c>isEnabled</c> to <c>IsEnabled</c>).
+/// source field name will be converted to uppercase (eg. <c>isEnabled</c> to <c>IsEnabled</c>). For
+/// custom property names use the <see cref="ObservablePropertyAttribute(string)"/>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 public sealed class ObservablePropertyAttribute : Attribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservablePropertyAttribute"/> class.
+    /// </summary>
+    public ObservablePropertyAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservablePropertyAttribute"/> class.
+    /// </summary>
+    /// <param name="name">Generated property name.</param>
+    public ObservablePropertyAttribute(string name)
+    {
+    }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -1101,6 +1101,22 @@ public partial class Test_ObservablePropertyAttribute
             .Value);
     }
 
+    // See https://github.com/CommunityToolkit/dotnet/issues/795
+    [TestMethod]
+    public void Test_ObservableProperty_ModelWithPropertyNames()
+    {
+        ModelWithPropertyNames model = new();
+
+        List<string?> propertyNames = new();
+
+        model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        CollectionAssert.AreEqual(new[]
+        {
+            nameof(model.fieldProp),
+        }, propertyNames);
+    }
+
     public abstract partial class BaseViewModel : ObservableObject
     {
         public string? Content { get; set; }
@@ -1796,5 +1812,12 @@ public partial class Test_ObservablePropertyAttribute
         private string? name;
 
         public string? FullName => "";
+    }
+
+    public partial class ModelWithPropertyNames : ObservableObject
+    {
+        // Inherited property
+        [ObservableProperty("fieldProp")]
+        private string? m_field;
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #795 **

Add overloaded constructor for ObservablePropertyAttribute, which takes the name of the newly generated property.

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->