### PR TITLE
Add .targets to validate the Windows SDK version

### DIFF
--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.WindowsSdk.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.WindowsSdk.targets
@@ -21,8 +21,20 @@
   <Target Name="MvvmToolkitVerifyWindowsSdkPackageVersion" DependsOnTargets="ResolveAssemblyReferences">
     <PropertyGroup>
 
-      <!-- The minimum build version for the Windows SDK package -->
-      <_MvvmToolkitWindowsSdkPackageMinBuild>41</_MvvmToolkitWindowsSdkPackageMinBuild>
+      <!--
+        The minimum build versions for the Windows SDK package. We keep track of up to 3 different versions:
+          - The minimum Windows SDK package for which we don't want to emit a build error.
+          - The recommended Windows SDK package for UWP projects using the .NET 9 SDK (with UWP XAML projections).
+          - The recommended Windows SDK package for WindowsAppSDK projects (ie. without UWP XAML projections). 
+      -->
+      <_MvvmToolkitWindowsSdkPackageMinBuild>38</_MvvmToolkitWindowsSdkPackageMinBuild>
+      <_MvvmToolkitWindowsSdkPackageRecommendedUwpBuild>39</_MvvmToolkitWindowsSdkPackageRecommendedUwpBuild>
+      <_MvvmToolkitWindowsSdkPackageRecommendedWindowsAppSDKBuild>41</_MvvmToolkitWindowsSdkPackageRecommendedWindowsAppSDKBuild>
+
+      <!-- Switch on the recommended one based on configuration -->
+      <_MvvmToolkitWindowsSdkPackageRecommendedBuild>$(_MvvmToolkitWindowsSdkPackageMinBuild)</_MvvmToolkitWindowsSdkPackageRecommendedBuild>
+      <_MvvmToolkitWindowsSdkPackageRecommendedBuild Condition="'$(UseUwp)' == 'true'">$(_MvvmToolkitWindowsSdkPackageRecommendedUwpBuild)</_MvvmToolkitWindowsSdkPackageRecommendedBuild>
+      <_MvvmToolkitWindowsSdkPackageRecommendedBuild Condition="'$(UseUwp)' != 'true'">$(_MvvmToolkitWindowsSdkPackageRecommendedWindowsAppSDKBuild)</_MvvmToolkitWindowsSdkPackageRecommendedBuild>
     </PropertyGroup>
     <ItemGroup>
         
@@ -30,6 +42,7 @@
       <_MvvmToolkitWindowsSdkPackage Include="$(WindowsSdkPackageVersion)" Condition="'$(WindowsSdkPackageVersion)' != ''">
         <Referenced>$(WindowsSdkPackageVersion)</Referenced>
         <Required>10.0.$([System.Version]::Parse("$(WindowsSdkPackageVersion.Split('-')[0])").Build).$(_MvvmToolkitWindowsSdkPackageMinBuild)</Required>
+        <Recommended>10.0.$([System.Version]::Parse("$(WindowsSdkPackageVersion.Split('-')[0])").Build).$(_MvvmToolkitWindowsSdkPackageRecommendedBuild)</Recommended>
       </_MvvmToolkitWindowsSdkPackage>
         
       <!-- Otherwise, validate against the framework reference package -->
@@ -38,6 +51,7 @@
         Condition="'$(WindowsSdkPackageVersion)' == '' AND '@(ResolvedFrameworkReference)' != '' AND '%(Identity)' == 'Microsoft.Windows.SDK.NET.Ref'">
         <Referenced>%(ResolvedFrameworkReference.TargetingPackVersion)</Referenced>
         <Required>10.0.$([System.Version]::Parse("%(ResolvedFrameworkReference.TargetingPackVersion)").Build).$(_MvvmToolkitWindowsSdkPackageMinBuild)</Required>
+        <Recommended>10.0.$([System.Version]::Parse("%(ResolvedFrameworkReference.TargetingPackVersion)").Build).$(_MvvmToolkitWindowsSdkPackageRecommendedBuild)</Recommended>
       </_MvvmToolkitWindowsSdkPackage>
         
       <!-- Check whether the referenced Windows SDK package is compatible -->
@@ -47,8 +61,9 @@
     </ItemGroup>
     <PropertyGroup>
         
-      <!-- Extract the required Windows SDK package version (to show if the one in use is not compatible) -->
+      <!-- Extract the required and recommended Windows SDK package version (to show if the one in use is not compatible) -->
       <_MvvmToolkitWindowsSdkPackageRequired>@(_MvvmToolkitWindowsSdkPackage->'%(Required)')</_MvvmToolkitWindowsSdkPackageRequired>
+      <_MvvmToolkitWindowsSdkPackageRecommended>@(_MvvmToolkitWindowsSdkPackage->'%(Recommended)')</_MvvmToolkitWindowsSdkPackageRecommended>
     </PropertyGroup>
 
     <!-- Emit an error if the Windows SDK package version isn't valid -->
@@ -56,7 +71,7 @@
       Condition="'@(_MvvmToolkitCompatibleWindowsSdkPackages)' == ''"
       Code="MVVMTKCFG0003"
       HelpLink="https://aka.ms/mvvmtoolkit/errors/mvvmtkcfg0003"
-      Text="This version of the MVVM Toolkit requires 'Microsoft.Windows.SDK.NET.Ref' version '$(_MvvmToolkitWindowsSdkPackageRequired)' or later. Please update to .NET SDK 8.0.109, 8.0.305 or 8.0.402 (or later). Alternatively, use a temporary 'Microsoft.Windows.SDK.NET.Ref' reference, which can be done by setting the 'WindowsSdkPackageVersion' property in your .csproj file to '$(_MvvmToolkitWindowsSdkPackageRequired)'." />
+      Text="This version of the MVVM Toolkit requires 'Microsoft.Windows.SDK.NET.Ref' version '$(_MvvmToolkitWindowsSdkPackageRequired)' or later. Please update to .NET SDK 8.0.109, 8.0.305 or 8.0.402 (or later). Alternatively, use a temporary 'Microsoft.Windows.SDK.NET.Ref' reference, which can be done by setting the 'WindowsSdkPackageVersion' property in your .csproj file. For your project configuration, it is recommended to set the package version to '$(_MvvmToolkitWindowsSdkPackageRecommended)'." />
   </Target>
 
 </Project>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.WindowsSdk.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.WindowsSdk.targets
@@ -1,0 +1,62 @@
+<Project>
+
+  <PropertyGroup>
+
+    <!-- Verification of the Windows SDK package version is enabled by default-->
+    <MvvmToolkitEnableWindowsSdkPackageVersionValidation Condition="'$(MvvmToolkitEnableWindowsSdkPackageVersionValidation)' == ''">true</MvvmToolkitEnableWindowsSdkPackageVersionValidation>
+
+    <!--
+      Wired up the Windows SDK package version verification target, if enabled.
+      This only applies to TFMs targeting Windows 10 or later.
+    -->
+    <ResolveReferencesDependsOn Condition="'$(MSBuildProjectExtension)' == '.csproj' AND
+                                           '$(MvvmToolkitVerifyWindowsSdkPackageVersion)' != 'false' AND
+                                           '$(MvvmToolkitEnableWindowsSdkPackageVersionValidation)' != 'false' AND
+                                           $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows10.0.17763.0'))">
+      $(ResolveReferencesDependsOn);MvvmToolkitVerifyWindowsSdkPackageVersion
+    </ResolveReferencesDependsOn>
+  </PropertyGroup>
+  
+  <!-- Custom target to verify the Windows SDK package version -->
+  <Target Name="MvvmToolkitVerifyWindowsSdkPackageVersion" DependsOnTargets="ResolveAssemblyReferences">
+    <PropertyGroup>
+
+      <!-- The minimum build version for the Windows SDK package -->
+      <_MvvmToolkitWindowsSdkPackageMinBuild>41</_MvvmToolkitWindowsSdkPackageMinBuild>
+    </PropertyGroup>
+    <ItemGroup>
+        
+      <!-- If 'WindowsSdkPackageVersion' is explicitly set, validate against that -->
+      <_MvvmToolkitWindowsSdkPackage Include="$(WindowsSdkPackageVersion)" Condition="'$(WindowsSdkPackageVersion)' != ''">
+        <Referenced>$(WindowsSdkPackageVersion)</Referenced>
+        <Required>10.0.$([System.Version]::Parse("$(WindowsSdkPackageVersion.Split('-')[0])").Build).$(_MvvmToolkitWindowsSdkPackageMinBuild)</Required>
+      </_MvvmToolkitWindowsSdkPackage>
+        
+      <!-- Otherwise, validate against the framework reference package -->
+      <_MvvmToolkitWindowsSdkPackage
+        Include="@(ResolvedFrameworkReference)"
+        Condition="'$(WindowsSdkPackageVersion)' == '' AND '@(ResolvedFrameworkReference)' != '' AND '%(Identity)' == 'Microsoft.Windows.SDK.NET.Ref'">
+        <Referenced>%(ResolvedFrameworkReference.TargetingPackVersion)</Referenced>
+        <Required>10.0.$([System.Version]::Parse("%(ResolvedFrameworkReference.TargetingPackVersion)").Build).$(_MvvmToolkitWindowsSdkPackageMinBuild)</Required>
+      </_MvvmToolkitWindowsSdkPackage>
+        
+      <!-- Check whether the referenced Windows SDK package is compatible -->
+      <_MvvmToolkitCompatibleWindowsSdkPackages
+        Include="@(_MvvmToolkitWindowsSdkPackage)"
+        Condition="'@(_MvvmToolkitWindowsSdkPackage)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals(%(Referenced), %(Required)))" />
+    </ItemGroup>
+    <PropertyGroup>
+        
+      <!-- Extract the required Windows SDK package version (to show if the one in use is not compatible) -->
+      <_MvvmToolkitWindowsSdkPackageRequired>@(_MvvmToolkitWindowsSdkPackage->'%(Required)')</_MvvmToolkitWindowsSdkPackageRequired>
+    </PropertyGroup>
+
+    <!-- Emit an error if the Windows SDK package version isn't valid -->
+    <Error
+      Condition="'@(_MvvmToolkitCompatibleWindowsSdkPackages)' == ''"
+      Code="MVVMTKCFG0003"
+      HelpLink="https://aka.ms/mvvmtoolkit/errors/mvvmtkcfg0003"
+      Text="This version of the MVVM Toolkit requires 'Microsoft.Windows.SDK.NET.Ref' version '$(_MvvmToolkitWindowsSdkPackageRequired)' or later. Please update to .NET SDK 8.0.109, 8.0.305 or 8.0.402 (or later). Alternatively, use a temporary 'Microsoft.Windows.SDK.NET.Ref' reference, which can be done by setting the 'WindowsSdkPackageVersion' property in your .csproj file to '$(_MvvmToolkitWindowsSdkPackageRequired)'." />
+  </Target>
+
+</Project>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -99,9 +99,11 @@
     <!-- Include the custom .targets files (shared across TFMs) -->
     <None Include="CommunityToolkit.Mvvm.FeatureSwitches.targets" PackagePath="build" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.SourceGenerators.targets" PackagePath="build" Pack="true" />
+    <None Include="CommunityToolkit.Mvvm.WindowsSdk.targets" PackagePath="build" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="build" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.FeatureSwitches.targets" PackagePath="buildTransitive" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.SourceGenerators.targets" PackagePath="buildTransitive" Pack="true" />
+    <None Include="CommunityToolkit.Mvvm.WindowsSdk.targets" PackagePath="buildTransitive" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="buildTransitive" Pack="true" />
 
     <!--

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
@@ -4,10 +4,12 @@
   <PropertyGroup>
     <_CommunityToolkitMvvmFeatureSwitchesTargets>$(MSBuildThisFileDirectory)CommunityToolkit.Mvvm.FeatureSwitches.targets</_CommunityToolkitMvvmFeatureSwitchesTargets>
     <_CommunityToolkitMvvmSourceGeneratorsTargets>$(MSBuildThisFileDirectory)CommunityToolkit.Mvvm.SourceGenerators.targets</_CommunityToolkitMvvmSourceGeneratorsTargets>
+    <_CommunityToolkitMvvmWindowsSdkTargets>$(MSBuildThisFileDirectory)CommunityToolkit.Mvvm.WindowsSdk.targets</_CommunityToolkitMvvmWindowsSdkTargets>
   </PropertyGroup>
 
   <!-- Import all available .targets -->
   <Import Project="$(_CommunityToolkitMvvmFeatureSwitchesTargets)" />
   <Import Project="$(_CommunityToolkitMvvmSourceGeneratorsTargets)" />
+  <Import Project="$(_CommunityToolkitMvvmWindowsSdkTargets)" />
 
 </Project>


### PR DESCRIPTION
This PR adds a new .targets to validate the Windows SDK package version and emit an error if not valid.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions