### PR TITLE
Update SDK package checks for .NET 9 SDK

### DIFF
--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.WindowsSdk.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.WindowsSdk.targets
@@ -45,10 +45,21 @@
         <Recommended>10.0.$([System.Version]::Parse("$(WindowsSdkPackageVersion.Split('-')[0])").Build).$(_MvvmToolkitWindowsSdkPackageRecommendedBuild)</Recommended>
       </_MvvmToolkitWindowsSdkPackage>
         
-      <!-- Otherwise, validate against the framework reference package -->
+      <!--
+        Otherwise, validate against the framework reference package. We need to check for two different item specs:
+          - "Microsoft.Windows.SDK.NET.Ref": this is the default name for the framework reference for the Windows
+            SDK projections, used on .NET 8 and lower. It includes all Windows APIs, except for XAML.
+          - "Microsoft.Windows.SDK.NET.Ref.Windows": this is the same as bove, except it's the framework reference
+            name that is added by the .NET 9 SDK for projects targeting .NET 8 and above. This specifically includes
+            the "Windows" profile, which only references non-XAML APIs. This change was done for the UWP support for
+            .NET 9, which requires the .NET SDK to also be able to reference XAML types. Those will use a different
+            item spec (ie. "Microsoft.Windows.SDK.NET.Ref.Xaml"). We only need to check the base "Windows" reference.
+      -->
       <_MvvmToolkitWindowsSdkPackage
         Include="@(ResolvedFrameworkReference)"
-        Condition="'$(WindowsSdkPackageVersion)' == '' AND '@(ResolvedFrameworkReference)' != '' AND '%(Identity)' == 'Microsoft.Windows.SDK.NET.Ref'">
+        Condition="'$(WindowsSdkPackageVersion)' == '' AND
+                   '@(ResolvedFrameworkReference)' != '' AND
+                   ('%(Identity)' == 'Microsoft.Windows.SDK.NET.Ref' OR '%(Identity)' == 'Microsoft.Windows.SDK.NET.Ref.Windows')">
         <Referenced>%(ResolvedFrameworkReference.TargetingPackVersion)</Referenced>
         <Required>10.0.$([System.Version]::Parse("%(ResolvedFrameworkReference.TargetingPackVersion)").Build).$(_MvvmToolkitWindowsSdkPackageMinBuild)</Required>
         <Recommended>10.0.$([System.Version]::Parse("%(ResolvedFrameworkReference.TargetingPackVersion)").Build).$(_MvvmToolkitWindowsSdkPackageRecommendedBuild)</Recommended>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -61,7 +61,7 @@
 
   <!-- Reference CsWinRT when targeting Windows, to get the latest source generators -->
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows10.0.17763.0'))">
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Reference the various multi-targeted versions of the source generator project (one per Roslyn version), and the code fixer -->


### PR DESCRIPTION
This PR improves the Windows SDK package version validation logic added in #942 and makes them work correctly when using the .NET 9 SDK (starting from .NET 9 RC2, or a latest nightly, which include the UWP support for .NET 9 changes).

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions