### PR TITLE
Move some diagnostics to analyzers

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.Execute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AsyncVoidReturningRelayCommandMethodAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidTargetObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidClassLevelNotifyDataErrorInfoAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AutoPropertyWithFieldTargetedObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidClassLevelNotifyPropertyChangedRecipientsAttributeAnalyzer.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.Execute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AsyncVoidReturningRelayCommandMethodAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\PropertyNameCollisionObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidTargetObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidClassLevelNotifyDataErrorInfoAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AutoPropertyWithFieldTargetedObservablePropertyAttributeAnalyzer.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.Execute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AsyncVoidReturningRelayCommandMethodAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\PropertyNameCollisionObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidTargetObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidClassLevelNotifyDataErrorInfoAttributeAnalyzer.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -180,12 +180,6 @@ partial class ObservablePropertyGenerator
             // Check for special cases that are explicitly not allowed
             if (IsGeneratedPropertyInvalid(propertyName, GetPropertyType(memberSymbol)))
             {
-                builder.Add(
-                    InvalidObservablePropertyError,
-                    memberSymbol,
-                    memberSymbol.ContainingType,
-                    memberSymbol.Name);
-
                 propertyInfo = null;
                 diagnostics = builder.ToImmutable();
 
@@ -427,7 +421,7 @@ partial class ObservablePropertyGenerator
         /// <param name="propertyName">The property name.</param>
         /// <param name="propertyType">The property type.</param>
         /// <returns>Whether the generated property is invalid.</returns>
-        private static bool IsGeneratedPropertyInvalid(string propertyName, ITypeSymbol propertyType)
+        public static bool IsGeneratedPropertyInvalid(string propertyName, ITypeSymbol propertyType)
         {
             // If the generated property name is called "Property" and the type is either object or it is PropertyChangedEventArgs or
             // PropertyChangingEventArgs (or a type derived from either of those two types), consider it invalid. This is needed because
@@ -1493,7 +1487,7 @@ partial class ObservablePropertyGenerator
         /// </summary>
         /// <param name="memberSymbol">The input <see cref="ISymbol"/> instance to process.</param>
         /// <returns>The type of <paramref name="memberSymbol"/>.</returns>
-        private static ITypeSymbol GetPropertyType(ISymbol memberSymbol)
+        public static ITypeSymbol GetPropertyType(ISymbol memberSymbol)
         {
             // Check if the member is a property first
             if (memberSymbol is IPropertySymbol propertySymbol)

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -166,12 +166,6 @@ partial class ObservablePropertyGenerator
             // Check for name collisions (only for fields)
             if (fieldName == propertyName && memberSyntax.IsKind(SyntaxKind.FieldDeclaration))
             {
-                builder.Add(
-                    ObservablePropertyNameCollisionError,
-                    memberSymbol,
-                    memberSymbol.ContainingType,
-                    memberSymbol.Name);
-
                 propertyInfo = null;
                 diagnostics = builder.ToImmutable();
 

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -145,13 +145,6 @@ partial class ObservablePropertyGenerator
             // Validate the target type
             if (!IsTargetTypeValid(memberSymbol, out bool shouldInvokeOnPropertyChanging))
             {
-                builder.Add(
-                    InvalidContainingTypeForObservablePropertyMemberError,
-                    memberSymbol,
-                    memberSyntax.Kind().ToFieldOrPropertyKeyword(),
-                    memberSymbol.ContainingType,
-                    memberSymbol.Name);
-
                 propertyInfo = null;
                 diagnostics = builder.ToImmutable();
 

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error when a field or property with <c>[ObservableProperty]</c> is not valid (special cases)
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidObservablePropertyError);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the symbol for [ObservableProperty] and the event args we need
+            if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol ||
+                context.Compilation.GetTypeByMetadataName("System.ComponentModel.PropertyChangedEventArgs") is not INamedTypeSymbol propertyChangedEventArgsSymbol ||
+                context.Compilation.GetTypeByMetadataName("System.ComponentModel.PropertyChangingEventArgs") is not INamedTypeSymbol propertyChangingEventArgsSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Validate that we do have a field or a property
+                if (context.Symbol is not (IFieldSymbol or IPropertySymbol))
+                {
+                    return;
+                }
+
+                // Ensure we do have the [ObservableProperty] attribute
+                if (!context.Symbol.HasAttributeWithType(observablePropertySymbol))
+                {
+                    return;
+                }
+
+                ITypeSymbol propertyType = ObservablePropertyGenerator.Execute.GetPropertyType(context.Symbol);
+                string propertyName = ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(context.Symbol);
+
+                // Same logic as 'IsGeneratedPropertyInvalid' in the generator
+                if (propertyName == "Property")
+                {
+                    // Check for collisions with the generated helpers and the property, only happens with these 3 types
+                    if (propertyType.SpecialType == SpecialType.System_Object ||
+                        propertyType.HasOrInheritsFromType(propertyChangedEventArgsSymbol) ||
+                        propertyType.HasOrInheritsFromType(propertyChangingEventArgsSymbol))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            InvalidObservablePropertyError,
+                            context.Symbol.Locations.FirstOrDefault(),
+                            context.Symbol.Kind.ToFieldOrPropertyKeyword(),
+                            context.Symbol.ContainingType,
+                            context.Symbol.Name));
+                    }
+                }
+            }, SymbolKind.Field, SymbolKind.Property);
+        });
+    }
+}

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/InvalidTargetObservablePropertyAttributeAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/InvalidTargetObservablePropertyAttributeAnalyzer.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error when a field or property with <c>[ObservableProperty]</c> is not a valid target.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidTargetObservablePropertyAttributeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidContainingTypeForObservablePropertyMemberError);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the required symbols for the analyzer
+            if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol ||
+                context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservableObject") is not INamedTypeSymbol observableObjectSymbol ||
+                context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservableObjectAttribute") is not INamedTypeSymbol observableObjectAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.INotifyPropertyChangedAttribute") is not INamedTypeSymbol notifyPropertyChangedAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Validate that we do have a field or a property
+                if (context.Symbol is not (IFieldSymbol or IPropertySymbol))
+                {
+                    return;
+                }
+
+                // Ensure we do have the [ObservableProperty] attribute
+                if (!context.Symbol.TryGetAttributeWithType(observablePropertySymbol, out AttributeData? attributeDataobservablePropertyAttribute))
+                {
+                    return;
+                }
+
+                // Same logic as in 'IsTargetTypeValid' in the generator
+                bool isObservableObject = context.Symbol.ContainingType.InheritsFromType(observableObjectSymbol);
+                bool hasObservableObjectAttribute = context.Symbol.ContainingType.HasOrInheritsAttributeWithType(observableObjectAttributeSymbol);
+                bool hasINotifyPropertyChangedAttribute = context.Symbol.ContainingType.HasOrInheritsAttributeWithType(notifyPropertyChangedAttributeSymbol);
+
+                // Emit the diagnostic if the target is not valid
+                if (!isObservableObject && !hasObservableObjectAttribute && !hasINotifyPropertyChangedAttribute)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                       InvalidContainingTypeForObservablePropertyMemberError,
+                       context.Symbol.Locations.FirstOrDefault(),
+                       context.Symbol.Kind.ToFieldOrPropertyKeyword(),
+                       context.Symbol.ContainingType,
+                       context.Symbol.Name));
+                }
+            }, SymbolKind.Field, SymbolKind.Property);
+        });
+    }
+}

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/InvalidTargetObservablePropertyAttributeAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/InvalidTargetObservablePropertyAttributeAnalyzer.cs
@@ -46,7 +46,7 @@ public sealed class InvalidTargetObservablePropertyAttributeAnalyzer : Diagnosti
                 }
 
                 // Ensure we do have the [ObservableProperty] attribute
-                if (!context.Symbol.TryGetAttributeWithType(observablePropertySymbol, out AttributeData? attributeDataobservablePropertyAttribute))
+                if (!context.Symbol.HasAttributeWithType(observablePropertySymbol))
                 {
                     return;
                 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/PropertyNameCollisionObservablePropertyAttributeAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/PropertyNameCollisionObservablePropertyAttributeAnalyzer.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error when a generated property from <c>[ObservableProperty]</c> would collide with the field name.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PropertyNameCollisionObservablePropertyAttributeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ObservablePropertyNameCollisionError);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the symbol for [ObservableProperty]
+            if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Ensure we do have a valid field
+                if (context.Symbol is not IFieldSymbol fieldSymbol)
+                {
+                    return;
+                }
+
+                // We only care if the field has [ObservableProperty]
+                if (!fieldSymbol.HasAttributeWithType(observablePropertySymbol))
+                {
+                    return;
+                }
+
+                // Emit the diagnostic if there is a name collision
+                if (fieldSymbol.Name == ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        ObservablePropertyNameCollisionError,
+                        fieldSymbol.Locations.FirstOrDefault(),
+                        fieldSymbol.ContainingType,
+                        fieldSymbol.Name));
+                }
+            }, SymbolKind.Field);
+        });
+    }
+}

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -407,17 +407,17 @@ internal static class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a generated property created with <c>[ObservableProperty]</c> would cause conflicts with other generated members.
     /// <para>
-    /// Format: <c>"The field {0}.{1} cannot be used to generate an observable property, as its name or type would cause conflicts with other generated members"</c>.
+    /// Format: <c>"The {0} {1}.{2} cannot be used to generate an observable property, as its name or type would cause conflicts with other generated members"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidObservablePropertyError = new DiagnosticDescriptor(
         id: "MVVMTK0024",
         title: "Invalid generated property declaration",
-        messageFormat: "The field {0}.{1} cannot be used to generate an observable property, as its name or type would cause conflicts with other generated members",
+        messageFormat: "The {0} {1}.{2} cannot be used to generate an observable property, as its name or type would cause conflicts with other generated members",
         category: typeof(ObservablePropertyGenerator).FullName,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The fields annotated with [ObservableProperty] cannot result in a property name or have a type that would cause conflicts with other generated members.",
+        description: "The fields and properties annotated with [ObservableProperty] cannot result in a property name or have a type that would cause conflicts with other generated members.",
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0024");
 
     /// <summary>

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/ITypeSymbolExtensions.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/ITypeSymbolExtensions.cs
@@ -34,6 +34,25 @@ internal static class ITypeSymbolExtensions
     }
 
     /// <summary>
+    /// Checks whether or not a given <see cref="ITypeSymbol"/> has or inherits from a specified type.
+    /// </summary>
+    /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>
+    /// <param name="baseTypeSymbol">The type to check for inheritance.</param>
+    /// <returns>Whether or not <paramref name="typeSymbol"/> is or inherits from <paramref name="baseTypeSymbol"/>.</returns>
+    public static bool HasOrInheritsFromType(this ITypeSymbol typeSymbol, ITypeSymbol baseTypeSymbol)
+    {
+        for (ITypeSymbol? currentType = typeSymbol; currentType is not null; currentType = currentType.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(currentType, baseTypeSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Checks whether or not a given <see cref="ITypeSymbol"/> inherits from a specified type.
     /// </summary>
     /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>
@@ -60,7 +79,7 @@ internal static class ITypeSymbolExtensions
     /// Checks whether or not a given <see cref="ITypeSymbol"/> inherits from a specified type.
     /// </summary>
     /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>
-    /// <param name="baseTypeSymbol">The <see cref="ITypeSymbol"/> instane to check for inheritance from.</param>
+    /// <param name="baseTypeSymbol">The <see cref="ITypeSymbol"/> instance to check for inheritance from.</param>
     /// <returns>Whether or not <paramref name="typeSymbol"/> inherits from <paramref name="baseTypeSymbol"/>.</returns>
     public static bool InheritsFromType(this ITypeSymbol typeSymbol, ITypeSymbol baseTypeSymbol)
     {

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -1006,9 +1006,10 @@ public partial class Test_SourceGeneratorsDiagnostics
     }
 
     [TestMethod]
-    public void InvalidContainingTypeForObservablePropertyFieldError()
+    public async Task InvalidContainingTypeForObservableProperty_OnField_Warns()
     {
         string source = """
+            using System.ComponentModel;
             using CommunityToolkit.Mvvm.ComponentModel;
 
             namespace MyApp
@@ -1016,14 +1017,74 @@ public partial class Test_SourceGeneratorsDiagnostics
                 public partial class MyViewModel : INotifyPropertyChanged
                 {
                     [ObservableProperty]
-                    public int number;
+                    public int {|MVVMTK0019:number|};
 
                     public event PropertyChangedEventHandler PropertyChanged;
                 }
             }
             """;
 
-        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0019");
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidTargetObservablePropertyAttributeAnalyzer>(source, LanguageVersion.CSharp8);
+    }
+
+    [TestMethod]
+    public async Task InvalidContainingTypeForObservableProperty_OnField_InValidType_DoesNotWarn()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class MyViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    public int number;
+                }
+            }
+            """;
+
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidTargetObservablePropertyAttributeAnalyzer>(source, LanguageVersion.CSharp8);
+    }
+
+    [TestMethod]
+    public async Task InvalidContainingTypeForObservableProperty_OnPartialProperty_Warns()
+    {
+        string source = """
+            using System.ComponentModel;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class MyViewModel : INotifyPropertyChanged
+                {
+                    [ObservableProperty]
+                    public int {|MVVMTK0019:Number|} { get; set; }
+
+                    public event PropertyChangedEventHandler PropertyChanged;
+                }
+            }
+            """;
+
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidTargetObservablePropertyAttributeAnalyzer>(source, LanguageVersion.CSharp8);
+    }
+
+    [TestMethod]
+    public async Task InvalidContainingTypeForObservableProperty_OnPartialProperty_InValidType_DoesNotWarn()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class MyViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    public int Number { get; set; }
+                }
+            }
+            """;
+
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidTargetObservablePropertyAttributeAnalyzer>(source, LanguageVersion.CSharp8);
     }
 
     [TestMethod]

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -1306,7 +1306,7 @@ public partial class Test_SourceGeneratorsDiagnostics
     }
 
     [TestMethod]
-    public void InvalidObservablePropertyError_Object()
+    public async Task InvalidObservablePropertyError_Object()
     {
         string source = """
             using CommunityToolkit.Mvvm.ComponentModel;
@@ -1316,16 +1316,35 @@ public partial class Test_SourceGeneratorsDiagnostics
                 public partial class MyViewModel : ObservableObject
                 {
                     [ObservableProperty]
-                    public object property;
+                    public object {|MVVMTK0024:property|};
                 }
             }
             """;
 
-        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0024");
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer>(source, LanguageVersion.CSharp9);
     }
 
     [TestMethod]
-    public void InvalidObservablePropertyError_PropertyChangingEventArgs()
+    public async Task InvalidObservablePropertyError_Object_WithProperty()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class MyViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    public object {|MVVMTK0024:Property|} { get; set; }
+                }
+            }
+            """;
+
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer>(source, LanguageVersion.Preview);
+    }
+
+    [TestMethod]
+    public async Task InvalidObservablePropertyError_PropertyChangingEventArgs()
     {
         string source = """
             using System.ComponentModel;
@@ -1336,16 +1355,16 @@ public partial class Test_SourceGeneratorsDiagnostics
                 public partial class MyViewModel : ObservableObject
                 {
                     [ObservableProperty]
-                    public PropertyChangingEventArgs property;
+                    public PropertyChangingEventArgs {|MVVMTK0024:property|};
                 }
             }
             """;
 
-        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0024");
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer>(source, LanguageVersion.CSharp9);
     }
 
     [TestMethod]
-    public void InvalidObservablePropertyError_PropertyChangedEventArgs()
+    public async Task InvalidObservablePropertyError_PropertyChangedEventArgs()
     {
         string source = """
             using System.ComponentModel;
@@ -1356,16 +1375,16 @@ public partial class Test_SourceGeneratorsDiagnostics
                 public partial class MyViewModel : ObservableObject
                 {
                     [ObservableProperty]
-                    public PropertyChangedEventArgs property;
+                    public PropertyChangedEventArgs {|MVVMTK0024:property|};
                 }
             }
             """;
 
-        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0024");
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer>(source, LanguageVersion.CSharp9);
     }
 
     [TestMethod]
-    public void InvalidObservablePropertyError_CustomTypeDerivedFromPropertyChangedEventArgs()
+    public async Task InvalidObservablePropertyError_CustomTypeDerivedFromPropertyChangedEventArgs()
     {
         string source = """
             using System.ComponentModel;
@@ -1384,12 +1403,12 @@ public partial class Test_SourceGeneratorsDiagnostics
                 public partial class MyViewModel : ObservableObject
                 {
                     [ObservableProperty]
-                    public MyPropertyChangedEventArgs property;
+                    public MyPropertyChangedEventArgs {|MVVMTK0024:property|};
                 }
             }
             """;
 
-        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0024");
+        await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer>(source, LanguageVersion.CSharp9);
     }
 
     [TestMethod]


### PR DESCRIPTION
This PR moves some diagnostics from the `[ObservableProperty]` generator, to diagnostic analyzers.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions