### PR TITLE
Remove 'this.' expressions in partial property code fixer

### DIFF
--- a/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForObservablePropertyCodeFixer.cs
+++ b/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForObservablePropertyCodeFixer.cs
@@ -287,8 +287,16 @@ public sealed class UsePartialPropertyForObservablePropertyCodeFixer : CodeFixPr
                 continue;
             }
 
-            // Replace the field reference with a reference to the new property
-            editor.ReplaceNode(identifierSyntax, IdentifierName(propertyName));
+            // Special case for 'this.<FIELD_NAME>' accesses: we want to drop the 'this.' prefix
+            if (identifierSyntax.Parent is MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax } thisExpressionSyntax)
+            {
+                editor.ReplaceNode(thisExpressionSyntax, IdentifierName(propertyName));
+            }
+            else
+            {
+                // Replace the field reference with a reference to the new property
+                editor.ReplaceNode(identifierSyntax, IdentifierName(propertyName));
+            }
         }
 
         return document.WithSyntaxRoot(editor.GetChangedRoot());

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_UsePartialPropertyForObservablePropertyCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_UsePartialPropertyForObservablePropertyCodeFixer.cs
@@ -697,4 +697,74 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
 
         await test.RunAsync();
     }
+
+    [TestMethod]
+    public async Task SimpleFieldWithSomeReferences_WithSomeThisExpressions()
+    {
+        string original = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            partial class C : ObservableObject
+            {
+                [ObservableProperty]
+                private int i;
+
+                public void M()
+                {
+                    i = 42;
+                    this.i = 42;
+                }
+
+                public int N() => i;
+
+                public int P() => this.i + Q(i) + Q(this.i);
+
+                private int Q(int i) => this.i + i;
+            }
+            """;
+
+        string @fixed = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            partial class C : ObservableObject
+            {
+                [ObservableProperty]
+                public partial int I { get; set; }
+            
+                public void M()
+                {
+                    I = 42;
+                    I = 42;
+                }
+            
+                public int N() => I;
+            
+                public int P() => I + Q(I) + Q(I);
+            
+                private int Q(int i) => I + i;
+            }
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "C.i"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(6,24): error CS9248: Partial property 'C.I' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(6, 24, 6, 25).WithArguments("C.I"),
+        });
+
+        await test.RunAsync();
+    }
 }


### PR DESCRIPTION
This PR tweaks the code fixer to automatically drop 'this.' expressions in field references.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions