### PR TITLE
Add MVVM Toolkit analyzers for WinRT scenarios

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -84,7 +84,9 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 MVVMTK0041 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0041
 MVVMTK0042 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Info | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0042
-MVVMTK0043| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0043
-MVVMTK0044| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0044
-MVVMTK0045| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0045
+MVVMTK0043 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0043
+MVVMTK0044 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0044
+MVVMTK0045 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0045
 MVVMTK0046 | CommunityToolkit.Mvvm.SourceGenerators.RelayCommandGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0046
+MVVMTK0047 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0047
+MVVMTK0048 | CommunityToolkit.Mvvm.SourceGenerators.RelayCommandGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0048

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -85,4 +85,5 @@ Rule ID | Category | Severity | Notes
 MVVMTK0041 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0041
 MVVMTK0042 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Info | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0042
 MVVMTK0043| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0043
-MVVMTK0044| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0043
+MVVMTK0044| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0044
+MVVMTK0045| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0045

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -87,3 +87,4 @@ MVVMTK0042 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator 
 MVVMTK0043| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0043
 MVVMTK0044| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0044
 MVVMTK0045| CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0045
+MVVMTK0046 | CommunityToolkit.Mvvm.SourceGenerators.RelayCommandGenerator | Warning | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0046

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.Execute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AsyncVoidReturningRelayCommandMethodAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\PropertyNameCollisionObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidTargetObservablePropertyAttributeAnalyzer.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.Execute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AsyncVoidReturningRelayCommandMethodAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\PropertyNameCollisionObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidTargetObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidClassLevelNotifyDataErrorInfoAttributeAnalyzer.cs" />
@@ -58,6 +59,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Suppressors\ObservablePropertyAttributeWithSupportedTargetDiagnosticSuppressor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\DiagnosticDescriptors.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\SuppressionDescriptors.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\AnalyzerConfigOptionsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AccessibilityExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AttributeDataExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CompilationExtensions.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.Execute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AsyncVoidReturningRelayCommandMethodAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\PropertyNameCollisionObservablePropertyAttributeAnalyzer.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -153,8 +153,9 @@ partial class ObservablePropertyGenerator
 
             token.ThrowIfCancellationRequested();
 
-            // Override the property changing support if explicitly disabled
-            shouldInvokeOnPropertyChanging &= GetEnableINotifyPropertyChangingSupport(options);
+            // Override the property changing support if explicitly disabled.
+            // This setting is enabled by default, for backwards compatibility.
+            shouldInvokeOnPropertyChanging &= options.GetMSBuildBooleanPropertyValue("MvvmToolkitEnableINotifyPropertyChangingSupport", defaultValue: true);
 
             token.ThrowIfCancellationRequested();
 
@@ -375,27 +376,6 @@ partial class ObservablePropertyGenerator
 
             diagnostics = builder.ToImmutable();
 
-            return true;
-        }
-
-        /// <summary>
-        /// Gets the value for the "MvvmToolkitEnableINotifyPropertyChangingSupport" property.
-        /// </summary>
-        /// <param name="options">The options in use for the generator.</param>
-        /// <returns>The value for the "MvvmToolkitEnableINotifyPropertyChangingSupport" property.</returns>
-        public static bool GetEnableINotifyPropertyChangingSupport(AnalyzerConfigOptions options)
-        {
-            if (options.TryGetValue("build_property.MvvmToolkitEnableINotifyPropertyChangingSupport", out string? propertyValue))
-            {
-                if (bool.TryParse(propertyValue, out bool enableINotifyPropertyChangingSupport))
-                {
-                    return enableINotifyPropertyChangingSupport;
-                }
-            }
-
-            // This setting is enabled by default, for backwards compatibility.
-            // Note that this path should never be reached, as the default
-            // value is also set in a .targets file bundled in the package.
             return true;
         }
 

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnPartialPropertyAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnPartialPropertyAnalyzer.cs
@@ -36,6 +36,12 @@ public sealed class UseObservablePropertyOnPartialPropertyAnalyzer : DiagnosticA
                 return;
             }
 
+            // If CsWinRT is in AOT-optimization mode, disable this analyzer, as the WinRT one will produce a warning instead
+            if (context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.IsCsWinRTAotOptimizerEnabled(context.Compilation))
+            {
+                return;
+            }
+
             // Get the symbol for [ObservableProperty]
             if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol)
             {

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnPartialPropertyAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnPartialPropertyAnalyzer.cs
@@ -79,7 +79,7 @@ public sealed class UseObservablePropertyOnPartialPropertyAnalyzer : DiagnosticA
                         .Add(FieldReferenceForObservablePropertyFieldAnalyzer.FieldNameKey, fieldSymbol.Name)
                         .Add(FieldReferenceForObservablePropertyFieldAnalyzer.PropertyNameKey, ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol)),
                     fieldSymbol.ContainingType,
-                    fieldSymbol));
+                    fieldSymbol.Name));
             }, SymbolKind.Field);
         });
     }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if ROSLYN_4_11_0_OR_GREATER
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error when <c>[GeneratedBindableCustomProperty]</c> is used on types with invalid generated base members.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        WinRTGeneratedBindableCustomPropertyWithBaseObservablePropertyOnField,
+        WinRTGeneratedBindableCustomPropertyWithBaseRelayCommand);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer is only enabled when CsWinRT is also used
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.IsUsingWindowsRuntimePack())
+            {
+                return;
+            }
+
+            // Get the symbol for [ObservableProperty], [RelayCommand] and [GeneratedBindableCustomProperty]
+            if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol ||
+                context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.Input.RelayCommandAttribute") is not INamedTypeSymbol relayCommandSymbol ||
+                context.Compilation.GetTypeByMetadataName("WinRT.GeneratedBindableCustomPropertyAttribute") is not INamedTypeSymbol generatedBindableCustomPropertySymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Ensure we do have a valid type
+                if (context.Symbol is not INamedTypeSymbol typeSymbol)
+                {
+                    return;
+                }
+
+                // We only care about it if it's using [GeneratedBindableCustomProperty]
+                if (!typeSymbol.TryGetAttributeWithType(generatedBindableCustomPropertySymbol, out AttributeData? generatedBindableCustomPropertyAttribute))
+                {
+                    return;
+                }
+
+                // Warn on all [ObservableProperty] fields
+                foreach (IFieldSymbol fieldSymbol in FindObservablePropertyFields(typeSymbol, relayCommandSymbol))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        WinRTGeneratedBindableCustomPropertyWithBaseObservablePropertyOnField,
+                        generatedBindableCustomPropertyAttribute.GetLocation(),
+                        typeSymbol,
+                        fieldSymbol.ContainingType,
+                        fieldSymbol.Name));
+                }
+
+                // Warn on all [RelayCommand] methods
+                foreach (IMethodSymbol methodSymbol in FindRelayCommandMethods(typeSymbol, relayCommandSymbol))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        WinRTGeneratedBindableCustomPropertyWithBaseRelayCommand,
+                        generatedBindableCustomPropertyAttribute.GetLocation(),
+                        typeSymbol,
+                        methodSymbol));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+
+    /// <summary>
+    /// Finds all methods in the base types that have the <c>[RelayCommand]</c> attribute.
+    /// </summary>
+    /// <param name="typeSymbol">The <see cref="INamedTypeSymbol"/> instance to inspect.</param>
+    /// <param name="relayCommandSymbol">The symbol for the <c>[RelayCommand]</c></param>
+    /// <returns>All <see cref="IMethodSymbol"/> instances for matching members.</returns>
+    private static IEnumerable<IMethodSymbol> FindRelayCommandMethods(INamedTypeSymbol typeSymbol, INamedTypeSymbol relayCommandSymbol)
+    {
+        // Check whether the base type (if any) is from the same assembly, and stop if it isn't. We do not
+        // want to include methods from the same type, as those will already be caught by another analyzer.
+        if (!SymbolEqualityComparer.Default.Equals(typeSymbol.ContainingAssembly, typeSymbol.BaseType))
+        {
+            yield break;
+        }
+
+        foreach (ISymbol memberSymbol in typeSymbol.BaseType.GetAllMembersFromSameAssembly())
+        {
+            if (memberSymbol is IMethodSymbol methodSymbol &&
+                methodSymbol.HasAttributeWithType(relayCommandSymbol))
+            {
+                yield return methodSymbol;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Finds all fields in the base types that have the <c>[ObservableProperty]</c> attribute.
+    /// </summary>
+    /// <param name="typeSymbol">The <see cref="INamedTypeSymbol"/> instance to inspect.</param>
+    /// <param name="observablePropertySymbol">The symbol for the <c>[ObservableProperty]</c></param>
+    /// <returns>All <see cref="IFieldSymbol"/> instances for matching members.</returns>
+    private static IEnumerable<IFieldSymbol> FindObservablePropertyFields(INamedTypeSymbol typeSymbol, INamedTypeSymbol observablePropertySymbol)
+    {
+        foreach (ISymbol memberSymbol in typeSymbol.GetAllMembersFromSameAssembly())
+        {
+            if (memberSymbol is IFieldSymbol fieldSymbol &&
+                fieldSymbol.HasAttributeWithType(observablePropertySymbol))
+            {
+                yield return fieldSymbol;
+            }
+        }
+    }
+}
+
+#endif

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if ROSLYN_4_11_0_OR_GREATER
+
+using System.Collections.Immutable;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error when <c>[ObservableProperty]</c> is used on a field in a scenario where it wouldn't be AOT compatible.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(WinRTObservablePropertyOnFieldsIsNotAotCompatible);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer is only enabled in cases where CsWinRT is producing AOT-compatible code
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.IsCsWinRTAotOptimizerEnabled(context.Compilation))
+            {
+                return;
+            }
+
+            // Get the symbol for [ObservableProperty]
+            if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol)
+            {
+                return;
+            }
+
+            bool isLanguageVersionPreview = context.Compilation.IsLanguageVersionPreview();
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Ensure we do have a valid field
+                if (context.Symbol is not IFieldSymbol fieldSymbol)
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if the field is using the [ObservableProperty] attribute
+                if (fieldSymbol.TryGetAttributeWithType(observablePropertySymbol, out AttributeData? observablePropertyAttribute))
+                {
+                    // If the C# version is preview, we can include the necessary information to trigger the
+                    // code fixer. If that is not the case, we shouldn't do that, to avoid the code fixer
+                    // changing the code to invalid C# (as without the preview version, it wouldn't compile).
+                    if (isLanguageVersionPreview)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            WinRTObservablePropertyOnFieldsIsNotAotCompatible,
+                            observablePropertyAttribute.GetLocation(),
+                            ImmutableDictionary.Create<string, string?>()
+                                .Add(FieldReferenceForObservablePropertyFieldAnalyzer.FieldNameKey, fieldSymbol.Name)
+                                .Add(FieldReferenceForObservablePropertyFieldAnalyzer.PropertyNameKey, ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol)),
+                            fieldSymbol.ContainingType,
+                            fieldSymbol.Name));
+                    }
+                    else
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            WinRTObservablePropertyOnFieldsIsNotAotCompatible,
+                            observablePropertyAttribute.GetLocation(),
+                            fieldSymbol.ContainingType,
+                            fieldSymbol.Name));
+                    }
+                }
+            }, SymbolKind.Field);
+        });
+    }
+}
+
+#endif

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs
@@ -41,8 +41,6 @@ public sealed class WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer : 
                 return;
             }
 
-            bool isLanguageVersionPreview = context.Compilation.IsLanguageVersionPreview();
-
             context.RegisterSymbolAction(context =>
             {
                 // Ensure we do have a valid field
@@ -54,28 +52,14 @@ public sealed class WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer : 
                 // Emit a diagnostic if the field is using the [ObservableProperty] attribute
                 if (fieldSymbol.TryGetAttributeWithType(observablePropertySymbol, out AttributeData? observablePropertyAttribute))
                 {
-                    // If the C# version is preview, we can include the necessary information to trigger the
-                    // code fixer. If that is not the case, we shouldn't do that, to avoid the code fixer
-                    // changing the code to invalid C# (as without the preview version, it wouldn't compile).
-                    if (isLanguageVersionPreview)
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(
-                            WinRTObservablePropertyOnFieldsIsNotAotCompatible,
-                            observablePropertyAttribute.GetLocation(),
-                            ImmutableDictionary.Create<string, string?>()
-                                .Add(FieldReferenceForObservablePropertyFieldAnalyzer.FieldNameKey, fieldSymbol.Name)
-                                .Add(FieldReferenceForObservablePropertyFieldAnalyzer.PropertyNameKey, ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol)),
-                            fieldSymbol.ContainingType,
-                            fieldSymbol.Name));
-                    }
-                    else
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(
-                            WinRTObservablePropertyOnFieldsIsNotAotCompatible,
-                            observablePropertyAttribute.GetLocation(),
-                            fieldSymbol.ContainingType,
-                            fieldSymbol.Name));
-                    }
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        WinRTObservablePropertyOnFieldsIsNotAotCompatible,
+                        observablePropertyAttribute.GetLocation(),
+                        ImmutableDictionary.Create<string, string?>()
+                            .Add(FieldReferenceForObservablePropertyFieldAnalyzer.FieldNameKey, fieldSymbol.Name)
+                            .Add(FieldReferenceForObservablePropertyFieldAnalyzer.PropertyNameKey, ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol)),
+                        fieldSymbol.ContainingType,
+                        fieldSymbol.Name));
                 }
             }, SymbolKind.Field);
         });

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error when <c>[RelayCommand]</c> is used on a method inside a type with <c>[GeneratedBindableCustomProperty]</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatible);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // This analyzer is only enabled when CsWinRT is also used
+            if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.IsUsingWindowsRuntimePack())
+            {
+                return;
+            }
+
+            // Get the symbol for [RelayCommand] and [GeneratedBindableCustomProperty]
+            if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.Input.RelayCommandAttribute") is not INamedTypeSymbol relayCommandSymbol ||
+                context.Compilation.GetTypeByMetadataName("WinRT.GeneratedBindableCustomPropertyAttribute") is not INamedTypeSymbol generatedBindableCustomPropertySymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Ensure we do have a valid method with a containing type we can reference
+                if (context.Symbol is not IMethodSymbol { ContainingType: INamedTypeSymbol typeSymbol } methodSymbol)
+                {
+                    return;
+                }
+
+                // If the method is not using [RelayCommand], we can skip it
+                if (!methodSymbol.TryGetAttributeWithType(relayCommandSymbol, out AttributeData? relayCommandAttribute))
+                {
+                    return;
+                }
+
+                // If the containing type is using [GeneratedBindableCustomProperty], emit a warning
+                if (typeSymbol.HasAttributeWithType(generatedBindableCustomPropertySymbol))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatible,
+                        relayCommandAttribute.GetLocation(),
+                        methodSymbol));
+                }
+            }, SymbolKind.Method);
+        });
+    }
+}

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -750,7 +750,7 @@ internal static class DiagnosticDescriptors
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0044");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for a CanvasEffect property with invalid accessors.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when <c>[ObservableProperty]</c> is used on a field in WinRT scenarios.
     /// <para>
     /// Format: <c>"The field {0}.{1} using [ObservableProperty] will generate code that is not AOT compatible in WinRT scenarios (such as UWP XAML and WinUI 3 apps), and a partial property should be used instead (as it allows the CsWinRT generators to correctly produce the necessary WinRT marshalling code)"</c>.
     /// </para>
@@ -764,4 +764,20 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Fields using [ObservableProperty] will generate code that is not AOT compatible in WinRT scenarios (such as UWP XAML and WinUI 3 apps), and partial properties should be used instead (as they allow the CsWinRT generators to correctly produce the necessary WinRT marshalling code).",
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0045");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when <c>[RelayCommand]</c> is used on a method in types where <c>[GeneratedBindableCustomProperty]</c> is used.
+    /// <para>
+    /// Format: <c>"The method {0} using [RelayCommand] within a type also using [GeneratedBindableCustomProperty], which is not supported, and a manually declared command property should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated command property that is produced by the MVVM Toolkit generator)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatible = new(
+        id: "MVVMTK0046",
+        title: "Using [RelayCommand] is not compatible with [GeneratedBindableCustomProperty]",
+        messageFormat: """The method {0} using [RelayCommand] within a type also using [GeneratedBindableCustomProperty], which is not supported, and a manually declared command property should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated command property that is produced by the MVVM Toolkit generator)""",
+        category: typeof(RelayCommandGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Using [RelayCommand] on methods within a type also using [GeneratedBindableCustomProperty] is not supported, and a manually declared command property should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated command property that is produced by the MVVM Toolkit generator).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0046");
 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -780,4 +780,36 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Using [RelayCommand] on methods within a type also using [GeneratedBindableCustomProperty] is not supported, and a manually declared command property should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated command property that is produced by the MVVM Toolkit generator).",
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0046");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when <c>[GeneratedBindableCustomProperty]</c> is used on a type that also uses <c>[ObservableProperty]</c> on any declared or inherited fields.
+    /// <para>
+    /// Format: <c>"The type {0} using [GeneratedBindableCustomProperty] is also using [ObservableProperty] on its declared (or inherited) field {1}.{2}: combining the two generators is not supported, and partial properties should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated property that is produced by the MVVM Toolkit generator)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor WinRTGeneratedBindableCustomPropertyWithBaseObservablePropertyOnField = new(
+        id: "MVVMTK0047",
+        title: "Using [GeneratedBindableCustomProperty] is not compatible with [ObservableProperty] on fields",
+        messageFormat: """The type {0} using [GeneratedBindableCustomProperty] is also using [RelayCommand] on its declared (or inherited) method {1}: combining the two generators is not supported, and a manually declared command property should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated property that is produced by the MVVM Toolkit generator)""",
+        category: typeof(ObservablePropertyGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Using [GeneratedBindableCustomProperty] on types that also use [ObservableProperty] on any declared (or inherited) fields is not supported, and partial properties should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated property that is produced by the MVVM Toolkit generator).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0047");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when <c>[GeneratedBindableCustomProperty]</c> is used on a type that also uses <c>[RelayCommand]</c> on any declared or inherited methods.
+    /// <para>
+    /// Format: <c>"The type {0} using [GeneratedBindableCustomProperty] is also using [RelayCommand] on its inherited method {1}: combining the two generators is not supported, and a manually declared command property should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated property that is produced by the MVVM Toolkit generator)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor WinRTGeneratedBindableCustomPropertyWithBaseRelayCommand = new(
+        id: "MVVMTK0048",
+        title: "Using [GeneratedBindableCustomProperty] is not compatible with [RelayCommand]",
+        messageFormat: """The type {0} using [GeneratedBindableCustomProperty] is also using [RelayCommand] on its inherited method {1}: combining the two generators is not supported, and a manually declared command property should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated property that is produced by the MVVM Toolkit generator)""",
+        category: typeof(RelayCommandGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Using [GeneratedBindableCustomProperty] on types that also use [RelayCommand] on any inherited methods is not supported, and a manually declared command property should be used instead (the [GeneratedBindableCustomProperty] generator cannot see the generated property that is produced by the MVVM Toolkit generator).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0048");
 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -40,6 +40,11 @@ internal static class DiagnosticDescriptors
     public const string UseObservablePropertyOnPartialPropertyId = "MVVMTK0042";
 
     /// <summary>
+    /// The diagnostic id for <see cref="WinRTObservablePropertyOnFieldsIsNotAotCompatible"/>.
+    /// </summary>
+    public const string WinRTObservablePropertyOnFieldsIsNotAotCompatibleId = "MVVMTK0045";
+
+    /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a duplicate declaration of <see cref="INotifyPropertyChanged"/> would happen.
     /// <para>
     /// Format: <c>"Cannot apply [INotifyPropertyChangedAttribute] to type {0}, as it already declares the INotifyPropertyChanged interface"</c>.
@@ -681,7 +686,7 @@ internal static class DiagnosticDescriptors
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0040");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for a CanvasEffect property with invalid accessors.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for the C# language version not being sufficient for <c>[ObservableProperty]</c> on partial properties.
     /// <para>
     /// Format: <c>"Using [ObservableProperty] on partial properties requires the C# language version to be set to 'preview', as support for the 'field' keyword is needed by the source generators to emit valid code (add <LangVersion>preview</LangVersion> to your .csproj/.props file)"</c>.
     /// </para>
@@ -697,7 +702,7 @@ internal static class DiagnosticDescriptors
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0041");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for a CanvasEffect property with invalid accessors.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when <c>[ObservableProperty]</c> on a field should be converted to a partial property.
     /// <para>
     /// Format: <c>"The field {0}.{1} using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)"</c>.
     /// </para>
@@ -743,4 +748,20 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Using [ObservableProperty] with (partial) properties requires a higher version of Roslyn (remove [ObservableProperty] or target a field instead, or upgrade to at least Visual Studio 2022 version 17.12 and the .NET 9 SDK).",
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0044");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a CanvasEffect property with invalid accessors.
+    /// <para>
+    /// Format: <c>"The field {0}.{1} using [ObservableProperty] will generate code that is not AOT compatible in WinRT scenarios (such as UWP XAML and WinUI 3 apps), and a partial property should be used instead (as it allows the CsWinRT generators to correctly produce the necessary WinRT marshalling code)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor WinRTObservablePropertyOnFieldsIsNotAotCompatible = new(
+        id: WinRTObservablePropertyOnFieldsIsNotAotCompatibleId,
+        title: "Using [ObservableProperty] on fields is not AOT compatible for WinRT",
+        messageFormat: """The field {0}.{1} using [ObservableProperty] will generate code that is not AOT compatible in WinRT scenarios (such as UWP XAML and WinUI 3 apps), and a partial property should be used instead (as it allows the CsWinRT generators to correctly produce the necessary WinRT marshalling code)""",
+        category: typeof(ObservablePropertyGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Fields using [ObservableProperty] will generate code that is not AOT compatible in WinRT scenarios (such as UWP XAML and WinUI 3 apps), and partial properties should be used instead (as they allow the CsWinRT generators to correctly produce the necessary WinRT marshalling code).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0045");
 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AnalyzerConfigOptionsExtensions.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AnalyzerConfigOptionsExtensions.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+
+/// <summary>
+/// Extension methods for the <see cref="AnalyzerConfigOptions"/> type.
+/// </summary>
+internal static class AnalyzerConfigOptionsExtensions
+{
+    /// <summary>
+    /// Checks whether the Windows runtime pack is being used (ie. if the target framework is <c>net8.0-windows10.0.17763.0</c> or above).
+    /// </summary>
+    /// <param name="options">The input <see cref="AnalyzerConfigOptions"/> instance.</param>
+    /// <returns>Whether the Windows runtime pack is being used.</returns>
+    public static bool IsUsingWindowsRuntimePack(this AnalyzerConfigOptions options)
+    {
+        return options.GetMSBuildBooleanPropertyValue("_MvvmToolkitIsUsingWindowsRuntimePack");
+    }
+
+    /// <summary>
+    /// Checks whether CsWinRT is configured in AOT support mode.
+    /// </summary>
+    /// <param name="options">The input <see cref="AnalyzerConfigOptions"/> instance.</param>
+    /// <param name="compilation">The input <see cref="Compilation"/> instance in use.</param>
+    /// <returns>Whether CsWinRT is configured in AOT support mode.</returns>
+    public static bool IsCsWinRTAotOptimizerEnabled(this AnalyzerConfigOptions options, Compilation compilation)
+    {
+        // If the runtime pack isn't being used, CsWinRT won't be used either. Technically speaking it's possible
+        // to reference CsWinRT without targeting Windows, but that's not a scenario that is supported anyway.
+        if (!options.IsUsingWindowsRuntimePack())
+        {
+            return false;
+        }
+
+        if (options.TryGetValue("build_property.CsWinRTAotOptimizerEnabled", out string? csWinRTAotOptimizerEnabled))
+        {
+            // If the generators are in opt-in mode, we will not show warnings
+            if (string.Equals(csWinRTAotOptimizerEnabled, "OptIn", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // The automatic mode will generate marshalling code for all possible scenarios
+            if (string.Equals(csWinRTAotOptimizerEnabled, "Auto", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // The default value of "true" will run in automatic mode for some scenarios, which we have to check
+            if (bool.TryParse(csWinRTAotOptimizerEnabled, out bool isCsWinRTAotOptimizerEnabled) && isCsWinRTAotOptimizerEnabled)
+            {
+                // The CsWinRT generator will be enabled for AOT scenarios in the following cases:
+                //   - The project is producing a WinRT component
+                //   - The 'CsWinRTAotWarningLevel' is set to '2', ie. all marshalling code even for built-in types should be produced
+                //   - The app is either UWP XAML or WinUI 3 (which is detected by the presence of the 'Button' type
+                // For additional reference, see the source code at https://github.com/microsoft/CsWinRT.
+                return
+                    options.GetMSBuildBooleanPropertyValue("CsWinRTComponent") ||
+                    options.GetMSBuildInt32PropertyValue("CsWinRTAotWarningLevel") == 2 ||
+                    compilation.GetTypeByMetadataName("Microsoft.UI.Xaml.Controls.Button") is not null ||
+                    compilation.GetTypeByMetadataName("Windows.UI.Xaml.Controls.Button") is not null;
+                       
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the boolean value of a given MSBuild property from an input <see cref="AnalyzerConfigOptions"/> instance.
+    /// </summary>
+    /// <param name="options">The input <see cref="AnalyzerConfigOptions"/> instance.</param>
+    /// <param name="propertyName">The name of the target MSBuild property.</param>
+    /// <param name="defaultValue">The default value to return if the property is not found or cannot be parsed.</param>
+    /// <returns>The value of the target MSBuild property.</returns>
+    public static bool GetMSBuildBooleanPropertyValue(this AnalyzerConfigOptions options, string propertyName, bool defaultValue = false)
+    {
+        if (options.TryGetValue($"build_property.{propertyName}", out string? propertyValue))
+        {
+            if (bool.TryParse(propertyValue, out bool booleanPropertyValue))
+            {
+                return booleanPropertyValue;
+            }
+        }
+
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Gets the integer value of a given MSBuild property from an input <see cref="AnalyzerConfigOptions"/> instance.
+    /// </summary>
+    /// <param name="options">The input <see cref="AnalyzerConfigOptions"/> instance.</param>
+    /// <param name="propertyName">The name of the target MSBuild property.</param>
+    /// <param name="defaultValue">The default value to return if the property is not found or cannot be parsed.</param>
+    /// <returns>The value of the target MSBuild property.</returns>
+    public static int GetMSBuildInt32PropertyValue(this AnalyzerConfigOptions options, string propertyName, int defaultValue = 0)
+    {
+        if (options.TryGetValue($"build_property.{propertyName}", out string? propertyValue))
+        {
+            if (int.TryParse(propertyValue, out int int32PropertyValue))
+            {
+                return int32PropertyValue;
+            }
+        }
+
+        return defaultValue;
+    }
+}

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AnalyzerConfigOptionsExtensions.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/AnalyzerConfigOptionsExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -38,7 +39,7 @@ internal static class AnalyzerConfigOptionsExtensions
             return false;
         }
 
-        if (options.TryGetValue("build_property.CsWinRTAotOptimizerEnabled", out string? csWinRTAotOptimizerEnabled))
+        if (options.TryGetMSBuildStringPropertyValue("CsWinRTAotOptimizerEnabled", out string? csWinRTAotOptimizerEnabled))
         {
             // If the generators are in opt-in mode, we will not show warnings
             if (string.Equals(csWinRTAotOptimizerEnabled, "OptIn", StringComparison.OrdinalIgnoreCase))
@@ -81,7 +82,7 @@ internal static class AnalyzerConfigOptionsExtensions
     /// <returns>The value of the target MSBuild property.</returns>
     public static bool GetMSBuildBooleanPropertyValue(this AnalyzerConfigOptions options, string propertyName, bool defaultValue = false)
     {
-        if (options.TryGetValue($"build_property.{propertyName}", out string? propertyValue))
+        if (options.TryGetMSBuildStringPropertyValue(propertyName, out string? propertyValue))
         {
             if (bool.TryParse(propertyValue, out bool booleanPropertyValue))
             {
@@ -101,7 +102,7 @@ internal static class AnalyzerConfigOptionsExtensions
     /// <returns>The value of the target MSBuild property.</returns>
     public static int GetMSBuildInt32PropertyValue(this AnalyzerConfigOptions options, string propertyName, int defaultValue = 0)
     {
-        if (options.TryGetValue($"build_property.{propertyName}", out string? propertyValue))
+        if (options.TryGetMSBuildStringPropertyValue(propertyName, out string? propertyValue))
         {
             if (int.TryParse(propertyValue, out int int32PropertyValue))
             {
@@ -110,5 +111,17 @@ internal static class AnalyzerConfigOptionsExtensions
         }
 
         return defaultValue;
+    }
+
+    /// <summary>
+    /// Tries to get a <see cref="string"/> value of a given MSBuild property from an input <see cref="AnalyzerConfigOptions"/> instance.
+    /// </summary>
+    /// <param name="options">The input <see cref="AnalyzerConfigOptions"/> instance.</param>
+    /// <param name="propertyName">The name of the target MSBuild property.</param>
+    /// <param name="propertyValue">The resulting property value.</param>
+    /// <returns>Whether the property value was retrieved..</returns>
+    public static bool TryGetMSBuildStringPropertyValue(this AnalyzerConfigOptions options, string propertyName, [NotNullWhen(true)] out string? propertyValue)
+    {
+        return options.TryGetValue($"build_property.{propertyName}", out propertyValue);
     }
 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/INamedTypeSymbolExtensions.cs
@@ -29,6 +29,28 @@ internal static class INamedTypeSymbolExtensions
     }
 
     /// <summary>
+    /// Gets all member symbols from a given <see cref="INamedTypeSymbol"/> instance, including inherited ones, only if they are declared in source.
+    /// </summary>
+    /// <param name="symbol">The input <see cref="INamedTypeSymbol"/> instance.</param>
+    /// <returns>A sequence of all member symbols for <paramref name="symbol"/>.</returns>
+    public static IEnumerable<ISymbol> GetAllMembersFromSameAssembly(this INamedTypeSymbol symbol)
+    {
+        for (INamedTypeSymbol? currentSymbol = symbol; currentSymbol is { SpecialType: not SpecialType.System_Object }; currentSymbol = currentSymbol.BaseType)
+        {
+            // Stop early when we reach a base type from another assembly
+            if (!SymbolEqualityComparer.Default.Equals(currentSymbol.ContainingAssembly, symbol.ContainingAssembly))
+            {
+                yield break;
+            }   
+
+            foreach (ISymbol memberSymbol in currentSymbol.GetMembers())
+            {
+                yield return memberSymbol;
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets all member symbols from a given <see cref="INamedTypeSymbol"/> instance, including inherited ones.
     /// </summary>
     /// <param name="symbol">The input <see cref="INamedTypeSymbol"/> instance.</param>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.Windows.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.Windows.targets
@@ -1,0 +1,17 @@
+<Project>
+
+  <!-- Allows the generators and analyzers to determine whether the current project is targeting Windows on modern .NET -->
+  <PropertyGroup>
+    <_MvvmToolkitIsUsingWindowsRuntimePack>false</_MvvmToolkitIsUsingWindowsRuntimePack>
+    <_MvvmToolkitIsUsingWindowsRuntimePack Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows10.0.17763.0'))">true</_MvvmToolkitIsUsingWindowsRuntimePack>
+  </PropertyGroup>
+
+  <!-- MSBuild properties that generators and analyzers need access to -->
+  <ItemGroup>
+    <CompilerVisibleProperty Include="_MvvmToolkitIsUsingWindowsRuntimePack" />
+    <CompilerVisibleProperty Include="CsWinRTComponent" />
+    <CompilerVisibleProperty Include="CsWinRTAotOptimizerEnabled" />
+    <CompilerVisibleProperty Include="CsWinRTAotWarningLevel" />
+  </ItemGroup>
+
+</Project>

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -101,10 +101,12 @@
     <!-- Include the custom .targets files (shared across TFMs) -->
     <None Include="CommunityToolkit.Mvvm.FeatureSwitches.targets" PackagePath="build" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.SourceGenerators.targets" PackagePath="build" Pack="true" />
+    <None Include="CommunityToolkit.Mvvm.Windows.targets" PackagePath="build" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.WindowsSdk.targets" PackagePath="build" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="build" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.FeatureSwitches.targets" PackagePath="buildTransitive" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.SourceGenerators.targets" PackagePath="buildTransitive" Pack="true" />
+    <None Include="CommunityToolkit.Mvvm.Windows.targets" PackagePath="buildTransitive" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.WindowsSdk.targets" PackagePath="buildTransitive" Pack="true" />
     <None Include="CommunityToolkit.Mvvm.targets" PackagePath="buildTransitive" Pack="true" />
 

--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.targets
@@ -4,12 +4,14 @@
   <PropertyGroup>
     <_CommunityToolkitMvvmFeatureSwitchesTargets>$(MSBuildThisFileDirectory)CommunityToolkit.Mvvm.FeatureSwitches.targets</_CommunityToolkitMvvmFeatureSwitchesTargets>
     <_CommunityToolkitMvvmSourceGeneratorsTargets>$(MSBuildThisFileDirectory)CommunityToolkit.Mvvm.SourceGenerators.targets</_CommunityToolkitMvvmSourceGeneratorsTargets>
+    <_CommunityToolkitMvvmWindowsTargets>$(MSBuildThisFileDirectory)CommunityToolkit.Mvvm.Windows.targets</_CommunityToolkitMvvmWindowsTargets>
     <_CommunityToolkitMvvmWindowsSdkTargets>$(MSBuildThisFileDirectory)CommunityToolkit.Mvvm.WindowsSdk.targets</_CommunityToolkitMvvmWindowsSdkTargets>
   </PropertyGroup>
 
   <!-- Import all available .targets -->
   <Import Project="$(_CommunityToolkitMvvmFeatureSwitchesTargets)" />
   <Import Project="$(_CommunityToolkitMvvmSourceGeneratorsTargets)" />
+  <Import Project="$(_CommunityToolkitMvvmWindowsTargets)" />
   <Import Project="$(_CommunityToolkitMvvmWindowsSdkTargets)" />
 
 </Project>

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.SourceGenerators.UnitTests.Helpers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -270,5 +271,461 @@ partial class Test_SourceGeneratorsDiagnostics
             """;
 
         await VerifyAnalyzerDiagnosticsAndSuccessfulGeneration<UseObservablePropertyOnPartialPropertyAnalyzer>(source, LanguageVersion.Preview);
+    }
+
+    [TestMethod]
+    public async Task UseObservablePropertyOnPartialPropertyAnalyzer_CsWinRTAotOptimizerEnabled_Auto_DoesNotWarn()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [ObservableProperty]            
+                    private static string name;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<UseObservablePropertyOnPartialPropertyAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.Preview,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true), ("CsWinRTAotOptimizerEnabled", "auto")]);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_NotTargetingWindows_DoesNotWarn()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [ObservableProperty]            
+                    private string name;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: []);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_TargetingWindows_CsWinRTAotOptimizerEnabled_OptIn_DoesNotWarn()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [ObservableProperty]            
+                    private string name;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_TargetingWindows_CsWinRTAotOptimizerEnabled_False_DoesNotWarn()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [ObservableProperty]            
+                    private string name;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true), ("CsWinRTAotOptimizerEnabled", "false")]);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_TargetingWindows_CsWinRTAotOptimizerEnabled_Auto_Warns()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [{|MVVMTK0045:ObservableProperty|}]            
+                    private string name;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.Preview,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true), ("CsWinRTAotOptimizerEnabled", "auto")]);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_TargetingWindows_CsWinRTAotOptimizerEnabled_True_NoXaml_Level1_DoesNotWarn()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [ObservableProperty]            
+                    private string name;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.Preview,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true), ("CsWinRTAotOptimizerEnabled", "true"), ("CsWinRTAotWarningLevel", 1)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_TargetingWindows_CsWinRTAotOptimizerEnabled_True_NoXaml_Level2_Warns()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [{|MVVMTK0045:ObservableProperty|}]            
+                    private string name;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.Preview,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true), ("CsWinRTAotOptimizerEnabled", "true"), ("CsWinRTAotWarningLevel", 2)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_TargetingWindows_CsWinRTAotOptimizerEnabled_True_NoXaml_1_Component_Warns()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [{|MVVMTK0045:ObservableProperty|}]            
+                    private string name;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.Preview,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true), ("CsWinRTAotOptimizerEnabled", "true"), ("CsWinRTAotWarningLevel", 1), ("CsWinRTComponent", true)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_TargetingWindows_CsWinRTAotOptimizerEnabled_True_UwpXaml_Level1_Warns()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [{|MVVMTK0045:ObservableProperty|}]            
+                    private string name;
+                }
+            }
+
+            namespace Windows.UI.Xaml.Controls
+            {
+                public class Button;
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.Preview,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true), ("CsWinRTAotOptimizerEnabled", "true"), ("CsWinRTAotWarningLevel", 1)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer_TargetingWindows_CsWinRTAotOptimizerEnabled_True_WinUIXaml_Level1_Warns()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [{|MVVMTK0045:ObservableProperty|}]            
+                    private string name;
+                }
+            }
+
+            namespace Microsoft.UI.Xaml.Controls
+            {
+                public class Button;
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.Preview,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true), ("CsWinRTAotOptimizerEnabled", "true"), ("CsWinRTAotWarningLevel", 1)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer_NotTargetingWindows_DoesNotWarn()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using CommunityToolkit.Mvvm.Input;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [RelayCommand]
+                    private void DoStuff()
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: []);
+    }
+
+    [TestMethod]
+    public async Task WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer_TargetingWindows_DoesNotWarn()
+    {
+        const string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using CommunityToolkit.Mvvm.Input;
+            
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [RelayCommand]
+                    private void DoStuff()
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer_TargetingWindows_Bindable_Warns()
+    {
+        const string source = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using CommunityToolkit.Mvvm.Input;
+            using WinRT;
+            
+            namespace MyApp
+            {
+                [GeneratedBindableCustomProperty]
+                public partial class SampleViewModel : ObservableObject
+                {            
+                    [{|MVVMTK0046:RelayCommand|}]
+                    private void DoStuff()
+                    {
+                    }
+                }
+            }
+
+            namespace WinRT
+            {
+                public class GeneratedBindableCustomPropertyAttribute : Attribute;
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer_NotTargetingWindows_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using CommunityToolkit.Mvvm.Input;
+            using WinRT;
+            
+            namespace MyApp
+            {
+                [GeneratedBindableCustomProperty]
+                public partial class SampleViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    private string name;
+
+                    [RelayCommand]
+                    private void DoStuff()
+                    {
+                    }
+                }
+            }
+
+            namespace WinRT
+            {
+                public class GeneratedBindableCustomPropertyAttribute : Attribute;
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: []);
+    }
+
+    [TestMethod]
+    public async Task WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer_TargetingWindows_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using CommunityToolkit.Mvvm.Input;
+            using WinRT;
+            
+            namespace MyApp
+            {
+                [GeneratedBindableCustomProperty]
+                public partial class SampleViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    private string name;
+
+                    [RelayCommand]
+                    private void DoStuff()
+                    {
+                    }
+                }
+            }
+
+            namespace WinRT
+            {
+                public class GeneratedBindableCustomPropertyAttribute : Attribute;
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer_TargetingWindows_BaseType_Field_Warns()
+    {
+        const string source = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using WinRT;
+            
+            namespace MyApp
+            {
+                [{|MVVMTK0047:GeneratedBindableCustomProperty|}]
+                public partial class SampleViewModel : BaseViewModel
+                {                    
+                }
+
+                public partial class BaseViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    private string name;
+                }
+            }
+
+            namespace WinRT
+            {
+                public class GeneratedBindableCustomPropertyAttribute : Attribute;
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true)]);
+    }
+
+    [TestMethod]
+    public async Task WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer_TargetingWindows_BaseType_Method_Warns()
+    {
+        const string source = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using CommunityToolkit.Mvvm.Input;
+            using WinRT;
+            
+            namespace MyApp
+            {
+                [{|MVVMTK0048:GeneratedBindableCustomProperty|}]
+                public partial class SampleViewModel : BaseViewModel
+                {                    
+                }
+
+                public partial class BaseViewModel : ObservableObject
+                {            
+                    [RelayCommand]
+                    private void DoStuff()
+                    {
+                    }
+                }
+            }
+
+            namespace WinRT
+            {
+                public class GeneratedBindableCustomPropertyAttribute : Attribute;
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer>.VerifyAnalyzerAsync(
+            source,
+            LanguageVersion.CSharp12,
+            editorconfig: [("_MvvmToolkitIsUsingWindowsRuntimePack", true)]);
     }
 }

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_UsePartialPropertyForObservablePropertyCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_UsePartialPropertyForObservablePropertyCodeFixer.cs
@@ -54,8 +54,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -102,8 +102,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -152,8 +152,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -204,8 +204,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -275,8 +275,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(7,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 6, 7, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(7,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 6, 7, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -323,8 +323,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -373,8 +373,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(7,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 6, 7, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(7,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 6, 7, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -427,8 +427,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(9,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(9, 6, 9, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(9,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(9, 6, 9, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -487,8 +487,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -533,8 +533,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -584,8 +584,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.C.items using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "C.items"),
+            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.items using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "items"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -635,8 +635,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.C.items using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "C.items"),
+            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.items using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "items"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -685,8 +685,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.C.foo using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "C.foo"),
+            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.foo using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "foo"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -755,8 +755,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "C.i"),
+            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]


### PR DESCRIPTION
**Related to https://github.com/microsoft/CsWinRT/pull/1861**

This PR adds two new analyzers for WinRT scenarios:
- Warn on `[ObservableProperty]` on fields in WinRT AOT scenarios
- Warn on `[RelayCommand]` on methods within types using `[GeneratedBindableCustomProperty]`

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->