### PR TITLE
Improve locations resolution for new analyzers

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UnsupportedCSharpLanguageVersionAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UnsupportedCSharpLanguageVersionAnalyzer.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -76,7 +75,7 @@ public sealed class UnsupportedCSharpLanguageVersionAnalyzer : DiagnosticAnalyze
                         typeSymbols.TryGetValue(attributeName, out INamedTypeSymbol? attributeSymbol) &&
                         SymbolEqualityComparer.Default.Equals(attributeClass, attributeSymbol))
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(UnsupportedCSharpLanguageVersionError, context.Symbol.Locations.FirstOrDefault()));
+                        context.ReportDiagnostic(Diagnostic.Create(UnsupportedCSharpLanguageVersionError, context.Symbol.GetLocationFromAttributeDataOrDefault(attribute)));
 
                         // If we created a diagnostic for this symbol, we can stop. Even if there's multiple attributes, no need for repeated errors
                         return;

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UnsupportedRoslynVersionForPartialPropertyAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UnsupportedRoslynVersionForPartialPropertyAnalyzer.cs
@@ -5,6 +5,7 @@
 #if !ROSLYN_4_11_0_OR_GREATER
 
 using System.Collections.Immutable;
+using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -44,11 +45,11 @@ public sealed class UnsupportedRoslynVersionForPartialPropertyAnalyzer : Diagnos
                 }
 
                 // If the property has [ObservableProperty], emit an error in all cases
-                if (propertySymbol.TryGetAttributeWithType(observablePropertySymbol, out AttributeData? observablePropertyAttribute))
+                if (propertySymbol.HasAttributeWithType(observablePropertySymbol))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         UnsupportedRoslynVersionForObservablePartialPropertySupport,
-                        observablePropertyAttribute.GetLocation(),
+                        propertySymbol.Locations.FirstOrDefault(),
                         propertySymbol.ContainingType,
                         propertySymbol));
                 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnPartialPropertyAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnPartialPropertyAnalyzer.cs
@@ -5,6 +5,7 @@
 #if ROSLYN_4_11_0_OR_GREATER
 
 using System.Collections.Immutable;
+using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -57,7 +58,7 @@ public sealed class UseObservablePropertyOnPartialPropertyAnalyzer : DiagnosticA
                 }
 
                 // Check that we are in fact using [ObservableProperty]
-                if (!fieldSymbol.TryGetAttributeWithType(observablePropertySymbol, out AttributeData? observablePropertyAttribute))
+                if (!fieldSymbol.HasAttributeWithType(observablePropertySymbol))
                 {
                     return;
                 }
@@ -74,7 +75,7 @@ public sealed class UseObservablePropertyOnPartialPropertyAnalyzer : DiagnosticA
                 // Emit the diagnostic for this field to suggest changing to a partial property instead
                 context.ReportDiagnostic(Diagnostic.Create(
                     UseObservablePropertyOnPartialProperty,
-                    observablePropertyAttribute.GetLocation(),
+                    fieldSymbol.Locations.FirstOrDefault(),
                     ImmutableDictionary.Create<string, string?>()
                         .Add(FieldReferenceForObservablePropertyFieldAnalyzer.FieldNameKey, fieldSymbol.Name)
                         .Add(FieldReferenceForObservablePropertyFieldAnalyzer.PropertyNameKey, ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol)),

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTClassUsingNotifyPropertyChangedAttributesAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTClassUsingNotifyPropertyChangedAttributesAnalyzer.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -79,7 +78,7 @@ public sealed class WinRTClassUsingNotifyPropertyChangedAttributesAnalyzer : Dia
                     {
                         context.ReportDiagnostic(Diagnostic.Create(
                             GeneratorAttributeNamesToDiagnosticsMap[attributeClass.Name],
-                            context.Symbol.Locations.FirstOrDefault(),
+                            context.Symbol.GetLocationFromAttributeDataOrDefault(attribute),
                             context.Symbol));
                     }
                 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -55,7 +56,7 @@ public sealed class WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer 
                 }
 
                 // We only care about it if it's using [GeneratedBindableCustomProperty]
-                if (!typeSymbol.TryGetAttributeWithType(generatedBindableCustomPropertySymbol, out AttributeData? generatedBindableCustomPropertyAttribute))
+                if (!typeSymbol.HasAttributeWithType(generatedBindableCustomPropertySymbol))
                 {
                     return;
                 }
@@ -65,7 +66,7 @@ public sealed class WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer 
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         WinRTGeneratedBindableCustomPropertyWithBaseObservablePropertyOnField,
-                        generatedBindableCustomPropertyAttribute.GetLocation(),
+                        typeSymbol.Locations.FirstOrDefault(),
                         typeSymbol,
                         fieldSymbol.ContainingType,
                         fieldSymbol.Name));
@@ -76,7 +77,7 @@ public sealed class WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer 
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         WinRTGeneratedBindableCustomPropertyWithBaseRelayCommand,
-                        generatedBindableCustomPropertyAttribute.GetLocation(),
+                        typeSymbol.Locations.FirstOrDefault(),
                         typeSymbol,
                         methodSymbol));
                 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -56,7 +55,7 @@ public sealed class WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer 
                 }
 
                 // We only care about it if it's using [GeneratedBindableCustomProperty]
-                if (!typeSymbol.HasAttributeWithType(generatedBindableCustomPropertySymbol))
+                if (!typeSymbol.TryGetAttributeWithType(generatedBindableCustomPropertySymbol, out AttributeData? generatedBindableCustomPropertyAttribute))
                 {
                     return;
                 }
@@ -66,7 +65,7 @@ public sealed class WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer 
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         WinRTGeneratedBindableCustomPropertyWithBaseObservablePropertyOnField,
-                        typeSymbol.Locations.FirstOrDefault(),
+                        typeSymbol.GetLocationFromAttributeDataOrDefault(generatedBindableCustomPropertyAttribute),
                         typeSymbol,
                         fieldSymbol.ContainingType,
                         fieldSymbol.Name));
@@ -77,7 +76,7 @@ public sealed class WinRTGeneratedBindableCustomPropertyWithBasesMemberAnalyzer 
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         WinRTGeneratedBindableCustomPropertyWithBaseRelayCommand,
-                        typeSymbol.Locations.FirstOrDefault(),
+                        typeSymbol.GetLocationFromAttributeDataOrDefault(generatedBindableCustomPropertyAttribute),
                         typeSymbol,
                         methodSymbol));
                 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer.cs
@@ -5,6 +5,7 @@
 #if ROSLYN_4_11_0_OR_GREATER
 
 using System.Collections.Immutable;
+using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -50,11 +51,11 @@ public sealed class WinRTObservablePropertyOnFieldsIsNotAotCompatibleAnalyzer : 
                 }
 
                 // Emit a diagnostic if the field is using the [ObservableProperty] attribute
-                if (fieldSymbol.TryGetAttributeWithType(observablePropertySymbol, out AttributeData? observablePropertyAttribute))
+                if (fieldSymbol.HasAttributeWithType(observablePropertySymbol))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         WinRTObservablePropertyOnFieldsIsNotAotCompatible,
-                        observablePropertyAttribute.GetLocation(),
+                        fieldSymbol.Locations.FirstOrDefault(),
                         ImmutableDictionary.Create<string, string?>()
                             .Add(FieldReferenceForObservablePropertyFieldAnalyzer.FieldNameKey, fieldSymbol.Name)
                             .Add(FieldReferenceForObservablePropertyFieldAnalyzer.PropertyNameKey, ObservablePropertyGenerator.Execute.GetGeneratedPropertyName(fieldSymbol)),

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -49,7 +50,7 @@ public sealed class WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompati
                 }
 
                 // If the method is not using [RelayCommand], we can skip it
-                if (!methodSymbol.TryGetAttributeWithType(relayCommandSymbol, out AttributeData? relayCommandAttribute))
+                if (!methodSymbol.HasAttributeWithType(relayCommandSymbol))
                 {
                     return;
                 }
@@ -59,7 +60,7 @@ public sealed class WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompati
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatible,
-                        relayCommandAttribute.GetLocation(),
+                        methodSymbol.Locations.FirstOrDefault(),
                         methodSymbol));
                 }
             }, SymbolKind.Method);

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -50,7 +49,7 @@ public sealed class WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompati
                 }
 
                 // If the method is not using [RelayCommand], we can skip it
-                if (!methodSymbol.HasAttributeWithType(relayCommandSymbol))
+                if (!methodSymbol.TryGetAttributeWithType(relayCommandSymbol, out AttributeData? relayCommandAttribute))
                 {
                     return;
                 }
@@ -60,7 +59,7 @@ public sealed class WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompati
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatible,
-                        methodSymbol.Locations.FirstOrDefault(),
+                        methodSymbol.GetLocationFromAttributeDataOrDefault(relayCommandAttribute),
                         methodSymbol));
                 }
             }, SymbolKind.Method);

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/ISymbolExtensions.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Extensions/ISymbolExtensions.cs
@@ -175,4 +175,31 @@ internal static class ISymbolExtensions
             accessibility == Accessibility.Public ||
             accessibility == Accessibility.Internal && symbol.ContainingAssembly.GivesAccessTo(assembly);
     }
+
+    /// <summary>
+    /// Gets the location of a given symbol that is in the same syntax tree of a specified attribute, or the first one.
+    /// </summary>
+    /// <param name="symbol">The input <see cref="ISymbol"/> instance to check.</param>
+    /// <param name="attributeData">The target <see cref="AttributeData"/> instance.</param>
+    /// <returns>The best <see cref="Location"/> match.</returns>
+    public static Location? GetLocationFromAttributeDataOrDefault(this ISymbol symbol, AttributeData attributeData)
+    {
+        Location? firstLocation = null;
+
+        // Get the syntax tree where the attribute application is located. We use
+        // it to try to find the symbol location that belongs to the same file.
+        SyntaxTree? attributeTree = attributeData.ApplicationSyntaxReference?.SyntaxTree;
+
+        foreach (Location location in symbol.Locations)
+        {
+            if (location.SourceTree == attributeTree)
+            {
+                return location;
+            }
+
+            firstLocation ??= location;
+        }
+
+        return firstLocation;
+    }
 }

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4001.UnitTests/Test_UnsupportedRoslynVersionForPartialPropertyAnalyzer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4001.UnitTests/Test_UnsupportedRoslynVersionForPartialPropertyAnalyzer.cs
@@ -21,8 +21,8 @@ public class Test_UnsupportedRoslynVersionForPartialPropertyAnalyzer
             {
                 public partial class SampleViewModel : ObservableObject
                 {            
-                    [{|MVVMTK0044:ObservableProperty|}]            
-                    public string Bar { get; set; }
+                    [ObservableProperty]            
+                    public string {|MVVMTK0044:Bar|} { get; set; }
                 }
             }
             """;

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -78,8 +78,8 @@ partial class Test_SourceGeneratorsDiagnostics
             {
                 public partial class SampleViewModel : ObservableObject
                 {            
-                    [{|MVVMTK0042:ObservableProperty|}]            
-                    private string name;
+                    [ObservableProperty]            
+                    private string {|MVVMTK0042:name|};
                 }
             }
             """;
@@ -371,8 +371,8 @@ partial class Test_SourceGeneratorsDiagnostics
             {
                 public partial class SampleViewModel : ObservableObject
                 {            
-                    [{|MVVMTK0045:ObservableProperty|}]            
-                    private string name;
+                    [ObservableProperty]            
+                    private string {|MVVMTK0045:name|};
                 }
             }
             """;
@@ -415,8 +415,8 @@ partial class Test_SourceGeneratorsDiagnostics
             {
                 public partial class SampleViewModel : ObservableObject
                 {            
-                    [{|MVVMTK0045:ObservableProperty|}]            
-                    private string name;
+                    [ObservableProperty]            
+                    private string {|MVVMTK0045:name|};
                 }
             }
             """;
@@ -437,8 +437,8 @@ partial class Test_SourceGeneratorsDiagnostics
             {
                 public partial class SampleViewModel : ObservableObject
                 {            
-                    [{|MVVMTK0045:ObservableProperty|}]            
-                    private string name;
+                    [ObservableProperty]            
+                    private string {|MVVMTK0045:name|};
                 }
             }
             """;
@@ -459,8 +459,8 @@ partial class Test_SourceGeneratorsDiagnostics
             {
                 public partial class SampleViewModel : ObservableObject
                 {            
-                    [{|MVVMTK0045:ObservableProperty|}]            
-                    private string name;
+                    [ObservableProperty]            
+                    private string {|MVVMTK0045:name|};
                 }
             }
 
@@ -486,8 +486,8 @@ partial class Test_SourceGeneratorsDiagnostics
             {
                 public partial class SampleViewModel : ObservableObject
                 {            
-                    [{|MVVMTK0045:ObservableProperty|}]            
-                    private string name;
+                    [ObservableProperty]            
+                    private string {|MVVMTK0045:name|};
                 }
             }
 
@@ -585,8 +585,8 @@ partial class Test_SourceGeneratorsDiagnostics
             
             namespace MyApp
             {
-                [{|MVVMTK0047:GeneratedBindableCustomProperty|}]
-                public partial class SampleViewModel : BaseViewModel
+                [GeneratedBindableCustomProperty]
+                public partial class {|MVVMTK0047:SampleViewModel|} : BaseViewModel
                 {                    
                 }
 
@@ -620,8 +620,8 @@ partial class Test_SourceGeneratorsDiagnostics
             
             namespace MyApp
             {
-                [{|MVVMTK0048:GeneratedBindableCustomProperty|}]
-                public partial class SampleViewModel : BaseViewModel
+                [GeneratedBindableCustomProperty]
+                public partial class {|MVVMTK0048:SampleViewModel|} : BaseViewModel
                 {                    
                 }
 

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_UsePartialPropertyForObservablePropertyCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4110.UnitTests/Test_UsePartialPropertyForObservablePropertyCodeFixer.cs
@@ -54,8 +54,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(6,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 17, 6, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -102,8 +102,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(7,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 17, 7, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -152,8 +152,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(8,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(8, 17, 8, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -204,8 +204,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(9,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(9, 17, 9, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -275,8 +275,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(7,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 6, 7, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(15,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(15, 17, 15, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -323,8 +323,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(7,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 17, 7, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -373,8 +373,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(7,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 6, 7, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(8,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(8, 17, 8, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -427,8 +427,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(9,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(9, 6, 9, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(10,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(10, 17, 10, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -487,8 +487,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(6,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 17, 6, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -533,8 +533,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(6,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 17, 6, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -584,8 +584,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.items using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "items"),
+            // /0/Test0.cs(7,33): info MVVMTK0042: The field C.items using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 33, 7, 38).WithArguments("C", "items"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -635,8 +635,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,6): info MVVMTK0042: The field C.items using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 6, 6, 24).WithArguments("C", "items"),
+            // /0/Test0.cs(7,33): info MVVMTK0042: The field C.items using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 33, 7, 38).WithArguments("C", "items"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -685,8 +685,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.foo using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "foo"),
+            // /0/Test0.cs(6,30): info MVVMTK0042: The field C.foo using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 30, 6, 33).WithArguments("C", "foo"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
@@ -755,8 +755,8 @@ public class Test_UsePartialPropertyForObservablePropertyCodeFixer
         test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
         test.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(5,6): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
-            CSharpCodeFixVerifier.Diagnostic().WithSpan(5, 6, 5, 24).WithArguments("C", "i"),
+            // /0/Test0.cs(6,17): info MVVMTK0042: The field C.i using [ObservableProperty] can be converted to a partial property instead, which is recommended (doing so improves the developer experience and allows other generators and analyzers to correctly see the generated property as well)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(6, 17, 6, 18).WithArguments("C", "i"),
         });
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -2063,8 +2063,8 @@ public partial class Test_SourceGeneratorsDiagnostics
                 [GeneratedBindableCustomProperty]
                 public partial class SampleViewModel : ObservableObject
                 {            
-                    [{|MVVMTK0046:RelayCommand|}]
-                    private void DoStuff()
+                    [RelayCommand]
+                    private void {|MVVMTK0046:DoStuff|}()
                     {
                     }
                 }


### PR DESCRIPTION
This PR improves the locations resolution logic for the new analyzers. In particular:
- Emits the new warnings directly over fields, rather than on the applied attributes
- Uses the closest location for target symbols based on the triggered attribute, by default

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions