### PR TITLE
Improve 'RequiresCSharpLanguageVersionPreviewAnalyzer'

### DIFF
--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
@@ -63,16 +63,6 @@ internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpA
 #endif
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(ObservableObject).Assembly.Location));
 
-        test.SolutionTransforms.Add((solution, projectId) =>
-            solution.AddAnalyzerConfigDocument(DocumentId.CreateNewId(projectId),
-                "UseMarshalType.editorconfig",
-                SourceText.From("""
-                    is_global = true
-                    build_property.LibraryImportGenerator_UseMarshalType = true
-                    """,
-                    Encoding.UTF8),
-                filePath: "/UseMarshalType.editorconfig"));
-
         test.ExpectedDiagnostics.AddRange(expected);
 
         return test.RunAsync(CancellationToken.None);


### PR DESCRIPTION
This PR improves `RequiresCSharpLanguageVersionPreviewAnalyzer` to skip warning on non-partial properties.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions