### PR TITLE
Use 'ref readonly' in 'IndexOf<T>' APIs

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Enumerables/SpanTokenizer{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Enumerables/SpanTokenizer{T}.cs
@@ -73,7 +73,10 @@ public ref struct SpanTokenizer<T>
         {
             this.start = newEnd;
 
-            int index = this.span.Slice(newEnd).IndexOf(this.separator);
+            // Here we're inside the 'CommunityToolkit.HighPerformance.Enumerables' namespace, so the
+            // 'MemoryExtensions' type from the .NET Community Toolkit would be bound instead. Because
+            // want the one from the BCL (to search by value), we can use its fully qualified name.
+            int index = System.MemoryExtensions.IndexOf(this.span.Slice(newEnd), this.separator);
 
             // Extract the current subsequence
             if (index >= 0)

--- a/src/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
@@ -210,7 +210,7 @@ public static class ReadOnlySpanExtensions
     /// <param name="value">The reference to the target item to get the index for.</param>
     /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>, or <c>-1</c>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe int IndexOf<T>(this ReadOnlySpan<T> span, in T value)
+    public static unsafe int IndexOf<T>(this ReadOnlySpan<T> span, ref readonly T value)
     {
         ref T r0 = ref MemoryMarshal.GetReference(span);
         ref T r1 = ref Unsafe.AsRef(in value);

--- a/src/CommunityToolkit.HighPerformance/Extensions/SpanExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/SpanExtensions.cs
@@ -148,10 +148,15 @@ public static class SpanExtensions
     /// <param name="value">The reference to the target item to get the index for.</param>
     /// <returns>The index of <paramref name="value"/> within <paramref name="span"/>, or <c>-1</c>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe int IndexOf<T>(this Span<T> span, ref T value)
+    public static unsafe int IndexOf<T>(this Span<T> span, ref readonly T value)
     {
         ref T r0 = ref MemoryMarshal.GetReference(span);
-        IntPtr byteOffset = Unsafe.ByteOffset(ref r0, ref value);
+        IntPtr byteOffset =
+#if NET8_0_OR_GREATER
+            Unsafe.ByteOffset(ref r0, in value);
+#else
+            Unsafe.ByteOffset(ref r0, ref Unsafe.AsRef(in value));
+#endif
 
         nint elementOffset = byteOffset / (nint)(uint)sizeof(T);
 


### PR DESCRIPTION
### Fixes

This:

![image](https://github.com/user-attachments/assets/658bb5fe-c94c-434d-ad73-dcbf12835c83)

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ X Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions