### PR TITLE
Add code fixer for semi-auto property to '[ObservableProperty]' partial property

### DIFF
--- a/src/CommunityToolkit.Mvvm.CodeFixers/CommunityToolkit.Mvvm.CodeFixers.projitems
+++ b/src/CommunityToolkit.Mvvm.CodeFixers/CommunityToolkit.Mvvm.CodeFixers.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AsyncVoidReturningRelayCommandMethodCodeFixer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ClassUsingAttributeInsteadOfInheritanceCodeFixer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FieldReferenceForObservablePropertyFieldCodeFixer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UsePartialPropertyForSemiAutoPropertyCodeFixer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UsePartialPropertyForObservablePropertyCodeFixer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForObservablePropertyCodeFixer.cs
+++ b/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForObservablePropertyCodeFixer.cs
@@ -100,7 +100,7 @@ public sealed class UsePartialPropertyForObservablePropertyCodeFixer : CodeFixPr
         if (root!.FindNode(diagnosticSpan).FirstAncestorOrSelf<FieldDeclarationSyntax>() is { Declaration.Variables: [{ Identifier.Text: string identifierName }] } fieldDeclaration &&
             identifierName == fieldName)
         {
-            // Register the code fix to update the class declaration to inherit from ObservableObject instead
+            // Register the code fix to convert the field declaration to a partial property
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title: "Use a partial property",

--- a/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
+++ b/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
@@ -98,12 +98,11 @@ public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProv
         // Find the parent type for the property
         TypeDeclarationSyntax typeDeclaration = propertyDeclaration.FirstAncestorOrSelf<TypeDeclarationSyntax>()!;
 
-        // Make sure it's partial
+        // Make sure it's partial (we create the updated node in the function to preserve the updated property declaration).
+        // If we created it separately and replaced it, the whole tree would also be replaced, and we'd lose the new property.
         if (!typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
         {
-            TypeDeclarationSyntax updatedTypeDeclaration = typeDeclaration.AddModifiers(Token(SyntaxKind.PartialKeyword));
-
-            editor.ReplaceNode(typeDeclaration, updatedTypeDeclaration);
+            editor.ReplaceNode(typeDeclaration, static (node, generator) => generator.WithModifiers(node, generator.GetModifiers(node).WithPartial(true)));
         }
 
         return document.WithSyntaxRoot(editor.GetChangedRoot());

--- a/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
+++ b/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
@@ -116,8 +116,9 @@ public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProv
                 .WithBody(null)
                 .WithExpressionBody(null)
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+                .WithTrailingTrivia(propertyDeclaration.AccessorList.Accessors[1].GetTrailingTrivia())
                 .WithAdditionalAnnotations(Formatter.Annotation)
-            ])));
+            ])).WithTrailingTrivia(propertyDeclaration.AccessorList.GetTrailingTrivia()));
 
         // Create an editor to perform all mutations
         SyntaxEditor editor = new(root, document.Project.Solution.Workspace.Services);

--- a/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
+++ b/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if ROSLYN_4_12_0_OR_GREATER
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace CommunityToolkit.Mvvm.CodeFixers;
+
+/// <summary>
+/// A code fixer that converts semi-auto properties to partial properties using <c>[ObservableProperty]</c>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+[Shared]
+public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(UseObservablePropertyOnSemiAutoPropertyId);
+
+    /// <inheritdoc/>
+    public override FixAllProvider? GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        Diagnostic diagnostic = context.Diagnostics[0];
+        TextSpan diagnosticSpan = context.Span;
+
+        SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        // Get the property declaration from the target diagnostic
+        if (root!.FindNode(diagnosticSpan) is PropertyDeclarationSyntax propertyDeclaration)
+        {
+            // Register the code fix to update the semi-auto property to a partial property
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use a partial property",
+                    createChangedDocument: token => ConvertToPartialProperty(context.Document, root, propertyDeclaration),
+                    equivalenceKey: "Use a partial property"),
+                diagnostic);
+        }
+    }
+
+    /// <summary>
+    /// Applies the code fix to a target identifier and returns an updated document.
+    /// </summary>
+    /// <param name="document">The original document being fixed.</param>
+    /// <param name="root">The original tree root belonging to the current document.</param>
+    /// <param name="propertyDeclaration">The <see cref="PropertyDeclarationSyntax"/> for the property being updated.</param>
+    /// <returns>An updated document with the applied code fix, and <paramref name="propertyDeclaration"/> being replaced with a partial property.</returns>
+    private static async Task<Document> ConvertToPartialProperty(Document document, SyntaxNode root, PropertyDeclarationSyntax propertyDeclaration)
+    {
+        await Task.CompletedTask;
+
+        // Get a new property that is partial and with semicolon token accessors
+        PropertyDeclarationSyntax updatedPropertyDeclaration =
+            propertyDeclaration
+            .AddModifiers(Token(SyntaxKind.PartialKeyword))
+            .AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(IdentifierName("ObservableProperty")))))
+            .WithAdditionalAnnotations(Formatter.Annotation)
+            .WithAccessorList(AccessorList(List(
+            [
+                // Keep the accessors (so we can easily keep all trivia, modifiers, attributes, etc.) but make them semicolon only
+                propertyDeclaration.AccessorList!.Accessors[0]
+                .WithBody(null)
+                .WithExpressionBody(null)
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+                .WithAdditionalAnnotations(Formatter.Annotation),
+                propertyDeclaration.AccessorList!.Accessors[1]
+                .WithBody(null)
+                .WithExpressionBody(null)
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+                .WithAdditionalAnnotations(Formatter.Annotation)
+            ])));
+
+        // Create an editor to perform all mutations
+        SyntaxEditor editor = new(root, document.Project.Solution.Workspace.Services);
+
+        editor.ReplaceNode(propertyDeclaration, updatedPropertyDeclaration);
+
+        // Find the parent type for the property
+        TypeDeclarationSyntax typeDeclaration = propertyDeclaration.FirstAncestorOrSelf<TypeDeclarationSyntax>()!;
+
+        // Make sure it's partial
+        if (!typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            TypeDeclarationSyntax updatedTypeDeclaration = typeDeclaration.AddModifiers(Token(SyntaxKind.PartialKeyword));
+
+            editor.ReplaceNode(typeDeclaration, updatedTypeDeclaration);
+        }
+
+        return document.WithSyntaxRoot(editor.GetChangedRoot());
+    }
+}
+
+#endif

--- a/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
+++ b/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -32,9 +33,9 @@ public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProv
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(UseObservablePropertyOnSemiAutoPropertyId);
 
     /// <inheritdoc/>
-    public override FixAllProvider? GetFixAllProvider()
+    public override Microsoft.CodeAnalysis.CodeFixes.FixAllProvider? GetFixAllProvider()
     {
-        return WellKnownFixAllProviders.BatchFixer;
+        return new FixAllProvider();
     }
 
     /// <inheritdoc/>
@@ -43,16 +44,31 @@ public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProv
         Diagnostic diagnostic = context.Diagnostics[0];
         TextSpan diagnosticSpan = context.Span;
 
+        // This code fixer needs the semantic model, so check that first
+        if (!context.Document.SupportsSemanticModel)
+        {
+            return;
+        }
+
         SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
         // Get the property declaration from the target diagnostic
         if (root!.FindNode(diagnosticSpan) is PropertyDeclarationSyntax propertyDeclaration)
         {
+            // Get the semantic model, as we need to resolve symbols
+            SemanticModel semanticModel = (await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false))!;
+
+            // Make sure we can resolve the [ObservableProperty] attribute (as we want to add it in the fixed code)
+            if (semanticModel.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol)
+            {
+                return;
+            }
+
             // Register the code fix to update the semi-auto property to a partial property
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title: "Use a partial property",
-                    createChangedDocument: token => ConvertToPartialProperty(context.Document, root, propertyDeclaration),
+                    createChangedDocument: token => ConvertToPartialProperty(context.Document, root, propertyDeclaration, observablePropertySymbol),
                     equivalenceKey: "Use a partial property"),
                 diagnostic);
         }
@@ -64,14 +80,47 @@ public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProv
     /// <param name="document">The original document being fixed.</param>
     /// <param name="root">The original tree root belonging to the current document.</param>
     /// <param name="propertyDeclaration">The <see cref="PropertyDeclarationSyntax"/> for the property being updated.</param>
+    /// <param name="observablePropertySymbol">The <see cref="INamedTypeSymbol"/> for <c>[ObservableProperty]</c>.</param>
     /// <returns>An updated document with the applied code fix, and <paramref name="propertyDeclaration"/> being replaced with a partial property.</returns>
-    private static async Task<Document> ConvertToPartialProperty(Document document, SyntaxNode root, PropertyDeclarationSyntax propertyDeclaration)
+    private static async Task<Document> ConvertToPartialProperty(
+        Document document,
+        SyntaxNode root,
+        PropertyDeclarationSyntax propertyDeclaration,
+        INamedTypeSymbol observablePropertySymbol)
     {
         await Task.CompletedTask;
 
-        // Prepare the [ObservableProperty] attribute, which is always inserted first
-        AttributeListSyntax observablePropertyAttributeList = AttributeList(SingletonSeparatedList(Attribute(IdentifierName("ObservableProperty"))));
+        SyntaxGenerator syntaxGenerator = SyntaxGenerator.GetGenerator(document);
 
+        // Create the attribute syntax for the new [ObservableProperty] attribute. Also
+        // annotate it to automatically add using directives to the document, if needed.
+        SyntaxNode attributeTypeSyntax = syntaxGenerator.TypeExpression(observablePropertySymbol).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
+        AttributeListSyntax observablePropertyAttributeList = (AttributeListSyntax)syntaxGenerator.Attribute(attributeTypeSyntax);
+
+        // Create an editor to perform all mutations
+        SyntaxEditor syntaxEditor = new(root, document.Project.Solution.Workspace.Services);
+
+        ConvertToPartialProperty(
+            propertyDeclaration,
+            observablePropertyAttributeList,
+            syntaxEditor);
+
+        // Create the new document with the single change
+        return document.WithSyntaxRoot(syntaxEditor.GetChangedRoot());
+    }
+
+    /// <summary>
+    /// Applies the code fix to a target identifier and returns an updated document.
+    /// </summary>
+    /// <param name="propertyDeclaration">The <see cref="PropertyDeclarationSyntax"/> for the property being updated.</param>
+    /// <param name="observablePropertyAttributeList">The <see cref="AttributeListSyntax"/> with the attribute to add.</param>
+    /// <param name="syntaxEditor">The <see cref="SyntaxEditor"/> instance to use.</param>
+    /// <returns>An updated document with the applied code fix, and <paramref name="propertyDeclaration"/> being replaced with a partial property.</returns>
+    private static void ConvertToPartialProperty(
+        PropertyDeclarationSyntax propertyDeclaration,
+        AttributeListSyntax observablePropertyAttributeList,
+        SyntaxEditor syntaxEditor)
+    {
         // Start setting up the updated attribute lists
         SyntaxList<AttributeListSyntax> attributeLists = propertyDeclaration.AttributeLists;
 
@@ -120,10 +169,7 @@ public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProv
                 .WithAdditionalAnnotations(Formatter.Annotation)
             ])).WithTrailingTrivia(propertyDeclaration.AccessorList.GetTrailingTrivia()));
 
-        // Create an editor to perform all mutations
-        SyntaxEditor editor = new(root, document.Project.Solution.Workspace.Services);
-
-        editor.ReplaceNode(propertyDeclaration, updatedPropertyDeclaration);
+        syntaxEditor.ReplaceNode(propertyDeclaration, updatedPropertyDeclaration);
 
         // Find the parent type for the property
         TypeDeclarationSyntax typeDeclaration = propertyDeclaration.FirstAncestorOrSelf<TypeDeclarationSyntax>()!;
@@ -132,10 +178,61 @@ public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProv
         // If we created it separately and replaced it, the whole tree would also be replaced, and we'd lose the new property.
         if (!typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
         {
-            editor.ReplaceNode(typeDeclaration, static (node, generator) => generator.WithModifiers(node, generator.GetModifiers(node).WithPartial(true)));
+            syntaxEditor.ReplaceNode(typeDeclaration, static (node, generator) => generator.WithModifiers(node, generator.GetModifiers(node).WithPartial(true)));
         }
+    }
 
-        return document.WithSyntaxRoot(editor.GetChangedRoot());
+    /// <summary>
+    /// A custom <see cref="FixAllProvider"/> with the logic from <see cref="UsePartialPropertyForSemiAutoPropertyCodeFixer"/>.
+    /// </summary>
+    private sealed class FixAllProvider : DocumentBasedFixAllProvider
+    {
+        /// <inheritdoc/>
+        protected override async Task<Document?> FixAllAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
+        {
+            // Get the semantic model, as we need to resolve symbols
+            if (await document.GetSemanticModelAsync(fixAllContext.CancellationToken).ConfigureAwait(false) is not SemanticModel semanticModel)
+            {
+                return document;
+            }
+
+            // Make sure we can resolve the [ObservableProperty] attribute here as well
+            if (semanticModel.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol)
+            {
+                return document;
+            }
+
+            // Get the document root (this should always succeed)
+            if (await document.GetSyntaxRootAsync(fixAllContext.CancellationToken).ConfigureAwait(false) is not SyntaxNode root)
+            {
+                return document;
+            }
+
+            SyntaxGenerator syntaxGenerator = SyntaxGenerator.GetGenerator(document);
+
+            // Create the attribute syntax for the new [ObservableProperty] attribute here too
+            SyntaxNode attributeTypeSyntax = syntaxGenerator.TypeExpression(observablePropertySymbol).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
+            AttributeListSyntax observablePropertyAttributeList = (AttributeListSyntax)syntaxGenerator.Attribute(attributeTypeSyntax);
+
+            // Create an editor to perform all mutations (across all edits in the file)
+            SyntaxEditor syntaxEditor = new(root, fixAllContext.Solution.Services);
+
+            foreach (Diagnostic diagnostic in diagnostics)
+            {
+                // Get the current property declaration for the diagnostic
+                if (root.FindNode(diagnostic.Location.SourceSpan) is not PropertyDeclarationSyntax propertyDeclaration)
+                {
+                    continue;
+                }
+
+                ConvertToPartialProperty(
+                    propertyDeclaration,
+                    observablePropertyAttributeList,
+                    syntaxEditor);
+            }
+
+            return document.WithSyntaxRoot(syntaxEditor.GetChangedRoot());
+        }
     }
 }
 

--- a/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
+++ b/src/CommunityToolkit.Mvvm.CodeFixers/UsePartialPropertyForSemiAutoPropertyCodeFixer.cs
@@ -101,7 +101,7 @@ public sealed class UsePartialPropertyForSemiAutoPropertyCodeFixer : CodeFixProv
         PropertyDeclarationSyntax updatedPropertyDeclaration =
             propertyDeclaration
             .AddModifiers(Token(SyntaxKind.PartialKeyword))
-            .WithoutTrivia()
+            .WithoutLeadingTrivia()
             .WithAttributeLists(attributeLists)
             .WithAdditionalAnnotations(Formatter.Annotation)
             .WithAccessorList(AccessorList(List(

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -97,3 +97,11 @@ MVVMTK0052 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator 
 MVVMTK0053 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0053
 MVVMTK0054 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0054
 MVVMTK0055 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0055
+
+## Release 8.4.1
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MVVMTK0056 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Info | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0056

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -97,11 +97,4 @@ MVVMTK0052 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator 
 MVVMTK0053 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0053
 MVVMTK0054 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0054
 MVVMTK0055 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0055
-
-## Release 8.4.1
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
 MVVMTK0056 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Info | See https://aka.ms/mvvmtoolkit/errors/mvvmtk0056

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\ObservableValidatorValidateAllPropertiesGenerator.Execute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\TransitiveMembersGenerator.Execute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\UseObservablePropertyOnSemiAutoPropertyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\AsyncVoidReturningRelayCommandMethodAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidGeneratedPropertyObservablePropertyAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\InvalidPointerTypeObservablePropertyAttributeAnalyzer.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -89,6 +89,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\EquatableArray{T}.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\HashCode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ImmutableArrayBuilder{T}.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\ObjectPool{T}.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Input\Models\CanExecuteExpressionType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Input\Models\CommandInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Input\RelayCommandGenerator.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnSemiAutoPropertyAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnSemiAutoPropertyAnalyzer.cs
@@ -212,7 +212,8 @@ public sealed class UseObservablePropertyOnSemiAutoPropertyAnalyzer : Diagnostic
                             context.ReportDiagnostic(Diagnostic.Create(
                                 UseObservablePropertyOnSemiAutoProperty,
                                 pair.Key.Locations.FirstOrDefault(),
-                                pair.Key));
+                                pair.Key.ContainingType,
+                                pair.Key.Name));
                         }
                     }
                 });

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnSemiAutoPropertyAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/UseObservablePropertyOnSemiAutoPropertyAnalyzer.cs
@@ -1,0 +1,256 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if ROSLYN_4_12_0_OR_GREATER
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using CommunityToolkit.Mvvm.SourceGenerators.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using static CommunityToolkit.Mvvm.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates a suggestion whenever <c>[ObservableProperty]</c> is used on a semi-auto property when a partial property could be used instead.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseObservablePropertyOnSemiAutoPropertyAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(UseObservablePropertyOnSemiAutoProperty);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Using [ObservableProperty] on partial properties is only supported when using C# preview.
+            // As such, if that is not the case, return immediately, as no diagnostic should be produced.
+            if (!context.Compilation.IsLanguageVersionPreview())
+            {
+                return;
+            }
+
+            // Get the symbol for [ObservableProperty] and ObservableObject
+            if (context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") is not INamedTypeSymbol observablePropertySymbol ||
+                context.Compilation.GetTypeByMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservableObject") is not INamedTypeSymbol observableObjectSymbol)
+            {
+                return;
+            }
+
+            // Get the symbol for the SetProperty<T> method as well
+            if (!TryGetSetPropertyMethodSymbol(observableObjectSymbol, out IMethodSymbol? setPropertySymbol))
+            {
+                return;
+            }
+
+            context.RegisterSymbolStartAction(context =>
+            {
+                // We only care about types that could derive from ObservableObject
+                if (context.Symbol is not INamedTypeSymbol { IsStatic: false, IsReferenceType: true, BaseType.SpecialType: not SpecialType.System_Object } typeSymbol)
+                {
+                    return;
+                }
+
+                // If the type does not derive from ObservableObject, ignore it
+                if (!typeSymbol.InheritsFromType(observableObjectSymbol))
+                {
+                    return;
+                }
+
+                Dictionary<IPropertySymbol, bool[]> propertyMap = new(SymbolEqualityComparer.Default);
+
+                // Crawl all members to discover properties that might be of interest
+                foreach (ISymbol memberSymbol in typeSymbol.GetMembers())
+                {
+                    // We're only looking for properties that might be valid candidates for conversion
+                    if (memberSymbol is not IPropertySymbol
+                        {
+                            IsStatic: false,
+                            IsPartialDefinition: false,
+                            PartialDefinitionPart: null,
+                            PartialImplementationPart: null,
+                            ReturnsByRef: false,
+                            ReturnsByRefReadonly: false,
+                            Type.IsRefLikeType: false,
+                            GetMethod: not null,
+                            SetMethod.IsInitOnly: false
+                        } propertySymbol)
+                    {
+                        continue;
+                    }
+
+                    // We can safely ignore properties that already have [ObservableProperty]
+                    if (typeSymbol.HasAttributeWithType(observablePropertySymbol))
+                    {
+                        continue;
+                    }
+
+                    // Track the property for later
+                    propertyMap.Add(propertySymbol, new bool[2]);
+                }
+
+                // We want to process both accessors, where we specifically need both the syntax
+                // and their semantic model to verify what they're doing. We can use a code callback.
+                context.RegisterOperationBlockAction(context =>
+                {
+                    // Make sure the current symbol is a property accessor
+                    if (context.OwningSymbol is not IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet, AssociatedSymbol: IPropertySymbol propertySymbol })
+                    {
+                        return;
+                    }
+
+                    // If so, check that we are actually processing one of the properties we care about
+                    if (!propertyMap.TryGetValue(propertySymbol, out bool[]? validFlags))
+                    {
+                        return;
+                    }
+
+                    // Handle the 'get' logic
+                    if (SymbolEqualityComparer.Default.Equals(propertySymbol.GetMethod, context.OwningSymbol))
+                    {
+                        // We expect a top-level block operation, that immediately returns an expression
+                        if (context.OperationBlocks is not [IBlockOperation { Operations: [IReturnOperation returnOperation] }])
+                        {
+                            return;
+                        }
+
+                        // Next, we expect the return to produce a field reference
+                        if (returnOperation is not { ReturnedValue: IFieldReferenceOperation fieldReferenceOperation })
+                        {
+                            return;
+                        }
+
+                        // The field has to be implicitly declared and not constant (and not static)
+                        if (fieldReferenceOperation.Field is not { IsImplicitlyDeclared: true, IsStatic: false } fieldSymbol)
+                        {
+                            return;
+                        }
+
+                        // Validate tha the field is indeed 'field' (it will be associated with the property)
+                        if (!SymbolEqualityComparer.Default.Equals(fieldSymbol.AssociatedSymbol, propertySymbol))
+                        {
+                            return;
+                        }
+
+                        // The 'get' accessor is valid
+                        validFlags[0] = true;
+                    }
+                    else if (SymbolEqualityComparer.Default.Equals(propertySymbol.SetMethod, context.OwningSymbol))
+                    {
+                        // We expect a top-level block operation, that immediately performs an invocation
+                        if (context.OperationBlocks is not [IBlockOperation { Operations: [IExpressionStatementOperation { Operation: IInvocationOperation invocationOperation }] }])
+                        {
+                            return;
+                        }
+
+                        // Brief filtering of the target method, also get the original definition
+                        if (invocationOperation.TargetMethod is not { Name: "SetProperty", IsGenericMethod: true, IsStatic: false } methodSymbol)
+                        {
+                            return;
+                        }
+
+                        // First, check that we're calling 'ObservableObject.SetProperty'
+                        if (!SymbolEqualityComparer.Default.Equals(methodSymbol.ConstructedFrom, setPropertySymbol))
+                        {
+                            return;
+                        }
+
+                        // We matched the method, now let's validate the arguments
+                        if (invocationOperation.Arguments is not [{ } locationArgument, { } valueArgument, { } propertyNameArgument])
+                        {
+                            return;
+                        }
+
+                        // The field has to be implicitly declared and not constant (and not static)
+                        if (locationArgument.Value is not IFieldReferenceOperation { Field: { IsImplicitlyDeclared: true, IsStatic: false } fieldSymbol })
+                        {
+                            return;
+                        }
+
+                        // Validate tha the field is indeed 'field' (it will be associated with the property)
+                        if (!SymbolEqualityComparer.Default.Equals(fieldSymbol.AssociatedSymbol, propertySymbol))
+                        {
+                            return;
+                        }
+
+                        // The value is just the 'value' keyword
+                        if (valueArgument.Value is not IParameterReferenceOperation { Syntax: IdentifierNameSyntax { Identifier.Text: "value" } })
+                        {
+                            return;
+                        }
+
+                        // The property name should be the default value
+                        if (propertyNameArgument is not { IsImplicit: true, ArgumentKind: ArgumentKind.DefaultValue })
+                        {
+                            return;
+                        }
+
+                        // The 'set' accessor is valid
+                        validFlags[1] = true;
+                    }
+                });
+
+                // Finally, we can consume this information when we finish processing the symbol
+                context.RegisterSymbolEndAction(context =>
+                {
+                    // Emit a diagnostic for each property that was a valid match
+                    foreach (KeyValuePair<IPropertySymbol, bool[]> pair in propertyMap)
+                    {
+                        if (pair.Value is [true, true])
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                UseObservablePropertyOnSemiAutoProperty,
+                                pair.Key.Locations.FirstOrDefault(),
+                                pair.Key));
+                        }
+                    }
+                });
+            }, SymbolKind.NamedType);
+        });
+    }
+
+    /// <summary>
+    /// Tries to get the symbol for the target <c>SetProperty</c> method this analyzer looks for.
+    /// </summary>
+    /// <param name="observableObjectSymbol">The symbol for <c>ObservableObject</c>.</param>
+    /// <param name="setPropertySymbol">The resulting method symbol, if found (this should always be the case).</param>
+    /// <returns>Whether <paramref name="setPropertySymbol"/> could be resolved correctly.</returns>
+    private static bool TryGetSetPropertyMethodSymbol(INamedTypeSymbol observableObjectSymbol, [NotNullWhen(true)] out IMethodSymbol? setPropertySymbol)
+    {
+        foreach (ISymbol symbol in observableObjectSymbol.GetMembers("SetProperty"))
+        {
+            // We're guaranteed to only match methods here
+            IMethodSymbol methodSymbol = (IMethodSymbol)symbol;
+
+            // Match the exact signature we need (there's several overloads)
+            if (methodSymbol.Parameters is not
+                [
+                    { Kind: SymbolKind.TypeParameter, RefKind: RefKind.Ref },
+                    { Kind: SymbolKind.TypeParameter, RefKind: RefKind.None },
+                    { Type.SpecialType: SpecialType.System_String }
+                ])
+            {
+                setPropertySymbol = methodSymbol;
+
+                return true;
+            }
+        }
+
+        setPropertySymbol = null;
+
+        return false;
+    }
+}
+
+#endif

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -45,6 +45,11 @@ internal static class DiagnosticDescriptors
     public const string WinRTObservablePropertyOnFieldsIsNotAotCompatibleId = "MVVMTK0045";
 
     /// <summary>
+    /// The diagnostic id for <see cref="UseObservablePropertyOnSemiAutoProperty"/>.
+    /// </summary>
+    public const string UseObservablePropertyOnSemiAutoPropertyId = "MVVMTK0056";
+
+    /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a duplicate declaration of <see cref="INotifyPropertyChanged"/> would happen.
     /// <para>
     /// Format: <c>"Cannot apply [INotifyPropertyChangedAttribute] to type {0}, as it already declares the INotifyPropertyChanged interface"</c>.
@@ -923,4 +928,20 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A property using [ObservableProperty] returns a pointer-like value ([ObservableProperty] must be used on properties of a non pointer-like type).",
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0055");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when a semi-auto property can be converted to use <c>[ObservableProperty]</c> instead.
+    /// <para>
+    /// Format: <c>"The semi-auto property {0}.{1} can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor UseObservablePropertyOnSemiAutoProperty = new DiagnosticDescriptor(
+        id: UseObservablePropertyOnSemiAutoPropertyId,
+        title: "Prefer using [ObservableProperty] over semi-auto properties",
+        messageFormat: """The semi-auto property {0}.{1} can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)""",
+        category: typeof(ObservablePropertyGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Semi-auto properties should be converted to partial properties using [ObservableProperty] when possible, which is recommended (doing so makes the code less verbose and results in more optimized code).",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0056");
 }

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Helpers/ObjectPool{T}.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Helpers/ObjectPool{T}.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Ported and adapted from https://github.com/dotnet/roslyn
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+#pragma warning disable RS1035, IDE0290
+
+namespace Microsoft.CodeAnalysis.PooledObjects;
+
+/// <summary>
+/// Generic implementation of object pooling pattern with predefined pool size limit. The main
+/// purpose is that limited number of frequently used objects can be kept in the pool for
+/// further recycling.
+/// 
+/// Notes: 
+/// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
+///    is no space in the pool, extra returned objects will be dropped.
+/// 
+/// 2) it is implied that if object was obtained from a pool, the caller will return it back in
+///    a relatively short time. Keeping checked out objects for long durations is ok, but 
+///    reduces usefulness of pooling. Just new up your own.
+/// 
+/// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice. 
+/// Rationale: 
+///    If there is no intent for reusing the object, do not use pool - just use "new". 
+/// </summary>
+internal sealed class ObjectPool<T>
+    where T : class
+{
+    // Storage for the pool objects. The first item is stored in a dedicated field because we
+    // expect to be able to satisfy most requests from it.
+    private T? firstItem;
+    private readonly Element[] items;
+
+    // The factory is stored for the lifetime of the pool. We will call this only when pool needs to
+    // expand. compared to "new T()", Func gives more flexibility to implementers and faster
+    // than "new T()".
+    private readonly Func<T> factory; 
+
+    /// <summary>
+    /// Creates a new <see cref="ObjectPool{T}"/> instance with a given factory.
+    /// </summary>
+    /// <param name="factory">The factory to use to produce new objects.</param>
+    public ObjectPool(Func<T> factory)
+        : this(factory, Environment.ProcessorCount * 2)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ObjectPool{T}"/> instance with a given factory.
+    /// </summary>
+    /// <param name="factory">The factory to use to produce new objects.</param>
+    /// <param name="size">The size of the pool.</param>
+    public ObjectPool(Func<T> factory, int size)
+    {
+        this.factory = factory;
+        this.items = new Element[size - 1];
+    }
+
+    /// <summary>
+    /// Produces an instance.
+    /// </summary>
+    /// <returns>The instance to return to the pool later.</returns>
+    /// <remarks>
+    /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+    /// Note that Free will try to store recycled objects close to the start thus statistically 
+    /// reducing how far we will typically search.
+    /// </remarks>
+    public T Allocate()
+    {
+        // PERF: Examine the first element. If that fails, AllocateSlow will look at the remaining elements.
+        // Note that the initial read is optimistically not synchronized. That is intentional. 
+        // We will interlock only when we have a candidate. in a worst case we may miss some
+        // recently returned objects. Not a big deal.
+        T? instance = this.firstItem;
+        if (instance == null || instance != Interlocked.CompareExchange(ref this.firstItem, null, instance))
+        {
+            instance = AllocateSlow();
+        }
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Slow path to produce a new instance.
+    /// </summary>
+    /// <returns>The instance to return to the pool later.</returns>
+    private T AllocateSlow()
+    {
+        Element[] items = this.items;
+
+        for (int i = 0; i < items.Length; i++)
+        {
+            T? instance = items[i].Value;
+
+            if (instance is not null)
+            {
+                if (instance == Interlocked.CompareExchange(ref items[i].Value, null, instance))
+                {
+                    return instance;
+                }
+            }
+        }
+
+        return this.factory();
+    }
+
+    /// <summary>
+    /// Returns objects to the pool.
+    /// </summary>
+    /// <param name="obj">The object to return to the pool.</param>
+    /// <remarks>
+    /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+    /// Note that Free will try to store recycled objects close to the start thus statistically 
+    /// reducing how far we will typically search in Allocate.
+    /// </remarks>
+    public void Free(T obj)
+    {
+        if (this.firstItem is null)
+        {
+            this.firstItem = obj;
+        }
+        else
+        {
+            FreeSlow(obj);
+        }
+    }
+
+    /// <summary>
+    /// Slow path to return an object to the pool.
+    /// </summary>
+    /// <param name="obj">The object to return to the pool.</param>
+    private void FreeSlow(T obj)
+    {
+        Element[] items = this.items;
+
+        for (int i = 0; i < items.Length; i++)
+        {
+            if (items[i].Value == null)
+            {
+                items[i].Value = obj;
+
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Wrapper to avoid array covariance.
+    /// </summary>
+    [DebuggerDisplay("{Value,nq}")]
+    private struct Element
+    {
+        /// <summary>
+        /// The value for the current element.
+        /// </summary>
+        public T? Value;
+    }
+}

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests/Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests/Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CSharpCodeFixTest = CommunityToolkit.Mvvm.SourceGenerators.UnitTests.Helpers.CSharpCodeFixWithLanguageVersionTest<
+    CommunityToolkit.Mvvm.SourceGenerators.UseObservablePropertyOnSemiAutoPropertyAnalyzer,
+    CommunityToolkit.Mvvm.CodeFixers.UsePartialPropertyForSemiAutoPropertyCodeFixer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using CSharpCodeFixVerifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
+    CommunityToolkit.Mvvm.SourceGenerators.UseObservablePropertyOnSemiAutoPropertyAnalyzer,
+    CommunityToolkit.Mvvm.CodeFixers.UsePartialPropertyForSemiAutoPropertyCodeFixer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators.UnitTests;
+
+[TestClass]
+public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
+{
+    [TestMethod]
+    public async Task SimpleProperty()
+    {
+        string original = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public class SampleViewModel : ObservableObject
+            {
+                public string Name
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+            }
+            """;
+
+        string @fixed = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                public partial string Name { get; set; }
+            }
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(7,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Name can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 19, 7, 23).WithArguments("MyApp.SampleViewModel", "Name"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(6,24): error CS9248: Partial property 'C.I' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(6, 24, 6, 25).WithArguments("C.I"),
+        });
+
+        await test.RunAsync();
+    }
+}

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests/Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests/Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer.cs
@@ -67,8 +67,446 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(6,24): error CS9248: Partial property 'C.I' must have an implementation part.
-            DiagnosticResult.CompilerError("CS9248").WithSpan(6, 24, 6, 25).WithArguments("C.I"),
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+        });
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task SimpleProperty_WithLeadingTrivia()
+    {
+        string original = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public class SampleViewModel : ObservableObject
+            {
+                /// <summary>
+                /// This is a property.
+                /// </summary>
+                public string Name
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+            }
+            """;
+
+        string @fixed = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                /// <summary>
+                /// This is a property.
+                /// </summary>
+                [ObservableProperty]
+                public partial string Name { get; set; }
+            }
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(10,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Name can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(10, 19, 10, 23).WithArguments("MyApp.SampleViewModel", "Name"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+        });
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task SimpleProperty_WithLeadingTrivia_AndAttributes()
+    {
+        string original = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public class SampleViewModel : ObservableObject
+            {
+                /// <summary>
+                /// This is a property.
+                /// </summary>
+                [Test("Targeting property")]
+                [field: Test("Targeting field")]
+                public string Name
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+            }
+
+            public class TestAttribute(string text) : Attribute;
+            """;
+
+        string @fixed = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                /// <summary>
+                /// This is a property.
+                /// </summary>
+                [ObservableProperty]
+                [Test("Targeting property")]
+                [field: Test("Targeting field")]
+                public partial string Name { get; set; }
+            }
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(13,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Name can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(13, 19, 13, 23).WithArguments("MyApp.SampleViewModel", "Name"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+        });
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task SimpleProperty_Multiple()
+    {
+        string original = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public class SampleViewModel : ObservableObject
+            {
+                public string FirstName
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+
+                public string LastName
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+            }
+            """;
+
+        string @fixed = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                public partial string FirstName { get; set; }
+
+                [ObservableProperty]
+                public partial string LastName { get; set; }
+            }
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(7,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.FirstName can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 19, 7, 28).WithArguments("MyApp.SampleViewModel", "FirstName"),
+
+            // /0/Test0.cs(13,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.LastName can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(13, 19, 13, 27).WithArguments("MyApp.SampleViewModel", "LastName"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+        });
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task SimpleProperty_WithinPartialType()
+    {
+        string original = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                public string Name
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+            }
+            """;
+
+        string @fixed = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                public partial string Name { get; set; }
+            }
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(7,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Name can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 19, 7, 23).WithArguments("MyApp.SampleViewModel", "Name"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+        });
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task SimpleProperty_WithinPartialType_Multiple()
+    {
+        string original = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                public string FirstName
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+
+                public string LastName
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+            }
+            """;
+
+        string @fixed = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                public partial string FirstName { get; set; }
+
+                [ObservableProperty]
+                public partial string LastName { get; set; }
+            }
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(7,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.FirstName can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 19, 7, 28).WithArguments("MyApp.SampleViewModel", "FirstName"),
+
+            // /0/Test0.cs(13,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.LastName can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(13, 19, 13, 27).WithArguments("MyApp.SampleViewModel", "LastName"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+        });
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task SimpleProperty_WithinPartialType_Multiple_MixedScenario()
+    {
+        string original = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                [Test("This is an attribute")]
+                public string Prop1
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+
+                // Single comment
+                public string Prop2
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+
+                /// <summary>
+                /// This is a property.
+                /// </summary>
+                public string Prop3
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+
+                /// <summary>
+                /// This is another property.
+                /// </summary>
+                [Test("Another attribute")]
+                public string Prop4
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+
+                // Some other single comment
+                [Test("Yet another attribute")]
+                public string Prop5
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+            }
+
+            public class TestAttribute(string text) : Attribute;
+            """;
+
+        string @fixed = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                [ObservableAttribute]
+                [Test("This is an attribute")]
+                public partial string Prop1 { get; set; }
+
+                // Single comment
+                [ObservableAttribute]
+                public partial string Prop2 { get; set; }
+
+                /// <summary>
+                /// This is a property.
+                /// </summary>
+                [ObservableAttribute]
+                public partial string Prop3 { get; set; }
+
+                /// <summary>
+                /// This is another property.
+                /// </summary>
+                [ObservableAttribute]
+                [Test("Another attribute")]
+                public partial string Prop4 { get; set; }
+
+                // Some other single comment
+                [ObservableAttribute]
+                [Test("Yet another attribute")]
+                public partial string Prop5 { get; set; }
+            }
+
+            public class TestAttribute(string text) : Attribute;
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(9,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Prop1 can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(9, 19, 9, 24).WithArguments("MyApp.SampleViewModel", "Prop1"),
+
+            // /0/Test0.cs(16,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Prop2 can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(16, 19, 16, 24).WithArguments("MyApp.SampleViewModel", "Prop2"),
+
+            // /0/Test0.cs(25,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Prop3 can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(25, 19, 25, 24).WithArguments("MyApp.SampleViewModel", "Prop3"),
+
+            // /0/Test0.cs(35,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Prop4 can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(35, 19, 35, 24).WithArguments("MyApp.SampleViewModel", "Prop4"),
+
+            // /0/Test0.cs(43,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.Prop5 can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(43, 19, 43, 24).WithArguments("MyApp.SampleViewModel", "Prop5"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
         });
 
         await test.RunAsync();

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests/Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests/Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer.cs
@@ -126,8 +126,8 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
-            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+            // /0/Test0.cs(11,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(11, 27, 11, 31).WithArguments("MyApp.SampleViewModel.Name"),
         });
 
         await test.RunAsync();
@@ -175,6 +175,8 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
                 [field: Test("Targeting field")]
                 public partial string Name { get; set; }
             }
+
+            public class TestAttribute(string text) : Attribute;
             """;
 
         CSharpCodeFixTest test = new(LanguageVersion.Preview)
@@ -193,8 +195,8 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
-            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+            // /0/Test0.cs(14,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(14, 27, 14, 31).WithArguments("MyApp.SampleViewModel.Name"),
         });
 
         await test.RunAsync();
@@ -447,29 +449,29 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
 
             public partial class SampleViewModel : ObservableObject
             {
-                [ObservableAttribute]
+                [ObservableProperty]
                 [Test("This is an attribute")]
                 public partial string Prop1 { get; set; }
 
                 // Single comment
-                [ObservableAttribute]
+                [ObservableProperty]
                 public partial string Prop2 { get; set; }
 
                 /// <summary>
                 /// This is a property.
                 /// </summary>
-                [ObservableAttribute]
+                [ObservableProperty]
                 public partial string Prop3 { get; set; }
 
                 /// <summary>
                 /// This is another property.
                 /// </summary>
-                [ObservableAttribute]
+                [ObservableProperty]
                 [Test("Another attribute")]
                 public partial string Prop4 { get; set; }
 
                 // Some other single comment
-                [ObservableAttribute]
+                [ObservableProperty]
                 [Test("Yet another attribute")]
                 public partial string Prop5 { get; set; }
             }
@@ -505,8 +507,20 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
-            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+            // /0/Test0.cs(10,27): error CS9248: Partial property 'SampleViewModel.Prop1' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(10, 27, 10, 32).WithArguments("MyApp.SampleViewModel.Prop1"),
+
+            // /0/Test0.cs(14,27): error CS9248: Partial property 'SampleViewModel.Prop2' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(14, 27, 14, 32).WithArguments("MyApp.SampleViewModel.Prop2"),
+
+            // /0/Test0.cs(20,27): error CS9248: Partial property 'SampleViewModel.Prop3' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(20, 27, 20, 32).WithArguments("MyApp.SampleViewModel.Prop3"),
+
+            // /0/Test0.cs(27,27): error CS9248: Partial property 'SampleViewModel.Prop4' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(27, 27, 27, 32).WithArguments("MyApp.SampleViewModel.Prop4"),
+
+            // /0/Test0.cs(32,27): error CS9248: Partial property 'SampleViewModel.Prop5' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(32, 27, 32, 32).WithArguments("MyApp.SampleViewModel.Prop5"),
         });
 
         await test.RunAsync();

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests/Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests/Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer.cs
@@ -260,8 +260,80 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
-            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.FirstName' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 36).WithArguments("MyApp.SampleViewModel.FirstName"),
+
+            // /0/Test0.cs(11,27): error CS9248: Partial property 'SampleViewModel.LastName' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(11, 27, 11, 35).WithArguments("MyApp.SampleViewModel.LastName"),
+        });
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task SimpleProperty_Multiple_OnlyTriggersOnFirstOne()
+    {
+        string original = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public class SampleViewModel : ObservableObject
+            {
+                public string FirstName
+                {
+                    get => field;
+                    set => SetProperty(ref field, value);
+                }
+
+                private string _lastName;
+
+                public string LastName
+                {
+                    get => _lastName;
+                    set => SetProperty(ref _lastName, value);
+                }
+            }
+            """;
+
+        string @fixed = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            public partial class SampleViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                public partial string FirstName { get; set; }
+
+                private string _lastName;
+
+                public string LastName
+                {
+                    get => _lastName;
+                    set => SetProperty(ref _lastName, value);
+                }
+            }
+            """;
+
+        CSharpCodeFixTest test = new(LanguageVersion.Preview)
+        {
+            TestCode = original,
+            FixedCode = @fixed,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        test.TestState.AdditionalReferences.Add(typeof(ObservableObject).Assembly);
+        test.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(7,19): info MVVMTK0056: The semi-auto property MyApp.SampleViewModel.FirstName can be converted to a partial property using [ObservableProperty], which is recommended (doing so makes the code less verbose and results in more optimized code)
+            CSharpCodeFixVerifier.Diagnostic().WithSpan(7, 19, 7, 28).WithArguments("MyApp.SampleViewModel", "FirstName"),
+        });
+
+        test.FixedState.ExpectedDiagnostics.AddRange(new[]
+        {
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.FirstName' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 36).WithArguments("MyApp.SampleViewModel.FirstName"),
         });
 
         await test.RunAsync();
@@ -447,8 +519,11 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
 
         test.FixedState.ExpectedDiagnostics.AddRange(new[]
         {
-            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.Name' must have an implementation part.
-            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 31).WithArguments("MyApp.SampleViewModel.Name"),
+            // /0/Test0.cs(8,27): error CS9248: Partial property 'SampleViewModel.FirstName' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(8, 27, 8, 36).WithArguments("MyApp.SampleViewModel.FirstName"),
+
+            // /0/Test0.cs(11,27): error CS9248: Partial property 'SampleViewModel.LastName' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(11, 27, 11, 35).WithArguments("MyApp.SampleViewModel.LastName"),
         });
 
         await test.RunAsync();
@@ -616,6 +691,12 @@ public class Test_UseObservablePropertyOnSemiAutoPropertyCodeFixer
 
             // /0/Test0.cs(32,27): error CS9248: Partial property 'SampleViewModel.Prop5' must have an implementation part.
             DiagnosticResult.CompilerError("CS9248").WithSpan(32, 27, 32, 32).WithArguments("MyApp.SampleViewModel.Prop5"),
+
+            // /0/Test0.cs(36,27): error CS9248: Partial property 'SampleViewModel.Prop6' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(36, 27, 36, 32).WithArguments("MyApp.SampleViewModel.Prop6"),
+
+            // /0/Test0.cs(39,27): error CS9248: Partial property 'SampleViewModel.Prop7' must have an implementation part.
+            DiagnosticResult.CompilerError("CS9248").WithSpan(39, 27, 39, 32).WithArguments("MyApp.SampleViewModel.Prop7"),
         });
 
         await test.RunAsync();


### PR DESCRIPTION
This PR adds a new diagnostic and code fixer to easily convert semi-auto properties into partial properties.

## PR Checklist

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Tested code with current [supported SDKs](../#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions