### PR TITLE
Added VIRTUAL access modifers to observables

### DIFF
--- a/src/CommunityToolkit.Mvvm/ComponentModel/ObservableObject.cs
+++ b/src/CommunityToolkit.Mvvm/ComponentModel/ObservableObject.cs
@@ -30,11 +30,13 @@ namespace CommunityToolkit.Mvvm.ComponentModel;
 /// </summary>
 public abstract class ObservableObject : INotifyPropertyChanged, INotifyPropertyChanging
 {
+
+#pragma warning disable CA1070 // Virtual required for things like NHibernate proxies
     /// <inheritdoc cref="INotifyPropertyChanged.PropertyChanged"/>
-    public event PropertyChangedEventHandler? PropertyChanged;
+    public virtual event PropertyChangedEventHandler? PropertyChanged;
 
     /// <inheritdoc cref="INotifyPropertyChanging.PropertyChanging"/>
-    public event PropertyChangingEventHandler? PropertyChanging;
+    public virtual event PropertyChangingEventHandler? PropertyChanging;
 
     /// <summary>
     /// Raises the <see cref="PropertyChanged"/> event.
@@ -70,7 +72,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// Raises the <see cref="PropertyChanged"/> event.
     /// </summary>
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
-    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
     }
@@ -79,7 +81,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// Raises the <see cref="PropertyChanging"/> event.
     /// </summary>
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
-    protected void OnPropertyChanging([CallerMemberName] string? propertyName = null)
+    protected virtual void OnPropertyChanging([CallerMemberName] string? propertyName = null)
     {
         // When support is disabled, avoid instantiating the event args entirely
         if (!FeatureSwitches.EnableINotifyPropertyChangingSupport)
@@ -104,7 +106,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// The <see cref="PropertyChanging"/> and <see cref="PropertyChanged"/> events are not raised
     /// if the current and new value for the target property are the same.
     /// </remarks>
-    protected bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, [CallerMemberName] string? propertyName = null)
     {
         // We duplicate the code here instead of calling the overload because we can't
         // guarantee that the invoked SetProperty<T> will be inlined, and we need the JIT
@@ -141,7 +143,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/> is <see langword="null"/>.</exception>
-    protected bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, IEqualityComparer<T> comparer, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, IEqualityComparer<T> comparer, [CallerMemberName] string? propertyName = null)
     {
         ArgumentNullException.ThrowIfNull(comparer);
 
@@ -183,7 +185,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// if the current and new value for the target property are the same.
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="callback"/> is <see langword="null"/>.</exception>
-    protected bool SetProperty<T>(T oldValue, T newValue, Action<T> callback, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<T>(T oldValue, T newValue, Action<T> callback, [CallerMemberName] string? propertyName = null)
     {
         ArgumentNullException.ThrowIfNull(callback);
 
@@ -216,7 +218,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/> or <paramref name="callback"/> are <see langword="null"/>.</exception>
-    protected bool SetProperty<T>(T oldValue, T newValue, IEqualityComparer<T> comparer, Action<T> callback, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<T>(T oldValue, T newValue, IEqualityComparer<T> comparer, Action<T> callback, [CallerMemberName] string? propertyName = null)
     {
         ArgumentNullException.ThrowIfNull(comparer);
         ArgumentNullException.ThrowIfNull(callback);
@@ -288,7 +290,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// raised if the current and new value for the target property are the same.
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="model"/> or <paramref name="callback"/> are <see langword="null"/>.</exception>
-    protected bool SetProperty<TModel, T>(T oldValue, T newValue, TModel model, Action<TModel, T> callback, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<TModel, T>(T oldValue, T newValue, TModel model, Action<TModel, T> callback, [CallerMemberName] string? propertyName = null)
         where TModel : class
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -325,7 +327,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/>, <paramref name="model"/> or <paramref name="callback"/> are <see langword="null"/>.</exception>
-    protected bool SetProperty<TModel, T>(T oldValue, T newValue, IEqualityComparer<T> comparer, TModel model, Action<TModel, T> callback, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<TModel, T>(T oldValue, T newValue, IEqualityComparer<T> comparer, TModel model, Action<TModel, T> callback, [CallerMemberName] string? propertyName = null)
         where TModel : class
     {
         ArgumentNullException.ThrowIfNull(comparer);
@@ -379,7 +381,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// indicates that the new value being assigned to <paramref name="taskNotifier"/> is different than the previous one,
     /// and it does not mean the new <see cref="Task"/> instance passed as argument is in any particular state.
     /// </remarks>
-    protected bool SetPropertyAndNotifyOnCompletion([NotNull] ref TaskNotifier? taskNotifier, Task? newValue, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetPropertyAndNotifyOnCompletion([NotNull] ref TaskNotifier? taskNotifier, Task? newValue, [CallerMemberName] string? propertyName = null)
     {
         // We invoke the overload with a callback here to avoid code duplication, and simply pass an empty callback.
         // The lambda expression here is transformed by the C# compiler into an empty closure class with a
@@ -408,7 +410,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// if the current and new value for the target property are the same.
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="callback"/> is <see langword="null"/>.</exception>
-    protected bool SetPropertyAndNotifyOnCompletion([NotNull] ref TaskNotifier? taskNotifier, Task? newValue, Action<Task?> callback, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetPropertyAndNotifyOnCompletion([NotNull] ref TaskNotifier? taskNotifier, Task? newValue, Action<Task?> callback, [CallerMemberName] string? propertyName = null)
     {
         ArgumentNullException.ThrowIfNull(callback);
 
@@ -449,7 +451,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// indicates that the new value being assigned to <paramref name="taskNotifier"/> is different than the previous one,
     /// and it does not mean the new <see cref="Task{TResult}"/> instance passed as argument is in any particular state.
     /// </remarks>
-    protected bool SetPropertyAndNotifyOnCompletion<T>([NotNull] ref TaskNotifier<T>? taskNotifier, Task<T>? newValue, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetPropertyAndNotifyOnCompletion<T>([NotNull] ref TaskNotifier<T>? taskNotifier, Task<T>? newValue, [CallerMemberName] string? propertyName = null)
     {
         return SetPropertyAndNotifyOnCompletion(taskNotifier ??= new TaskNotifier<T>(), newValue, null, propertyName);
     }
@@ -473,7 +475,7 @@ public abstract class ObservableObject : INotifyPropertyChanged, INotifyProperty
     /// if the current and new value for the target property are the same.
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="callback"/> is <see langword="null"/>.</exception>
-    protected bool SetPropertyAndNotifyOnCompletion<T>([NotNull] ref TaskNotifier<T>? taskNotifier, Task<T>? newValue, Action<Task<T>?> callback, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetPropertyAndNotifyOnCompletion<T>([NotNull] ref TaskNotifier<T>? taskNotifier, Task<T>? newValue, Action<Task<T>?> callback, [CallerMemberName] string? propertyName = null)
     {
         ArgumentNullException.ThrowIfNull(callback);
 

--- a/src/CommunityToolkit.Mvvm/ComponentModel/ObservableRecipient.cs
+++ b/src/CommunityToolkit.Mvvm/ComponentModel/ObservableRecipient.cs
@@ -54,7 +54,7 @@ public abstract class ObservableRecipient : ObservableObject
     /// <summary>
     /// Gets or sets a value indicating whether the current view model is currently active.
     /// </summary>
-    public bool IsActive
+    public virtual bool IsActive
     {
         get => this.isActive;
 
@@ -163,7 +163,7 @@ public abstract class ObservableRecipient : ObservableObject
     /// the <see cref="ObservableObject.PropertyChanging"/> and <see cref="ObservableObject.PropertyChanged"/> events
     /// are not raised if the current and new value for the target property are the same.
     /// </remarks>
-    protected bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, bool broadcast, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, bool broadcast, [CallerMemberName] string? propertyName = null)
     {
         T oldValue = field;
 
@@ -193,7 +193,7 @@ public abstract class ObservableRecipient : ObservableObject
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/> is <see langword="null"/>.</exception>
-    protected bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, IEqualityComparer<T> comparer, bool broadcast, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, IEqualityComparer<T> comparer, bool broadcast, [CallerMemberName] string? propertyName = null)
     {
         ArgumentNullException.ThrowIfNull(comparer);
 
@@ -230,7 +230,7 @@ public abstract class ObservableRecipient : ObservableObject
     /// are not raised if the current and new value for the target property are the same.
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="callback"/> is <see langword="null"/>.</exception>
-    protected bool SetProperty<T>(T oldValue, T newValue, Action<T> callback, bool broadcast, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<T>(T oldValue, T newValue, Action<T> callback, bool broadcast, [CallerMemberName] string? propertyName = null)
     {
         ArgumentNullException.ThrowIfNull(callback);
 
@@ -259,7 +259,7 @@ public abstract class ObservableRecipient : ObservableObject
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/> or <paramref name="callback"/> are <see langword="null"/>.</exception>
-    protected bool SetProperty<T>(T oldValue, T newValue, IEqualityComparer<T> comparer, Action<T> callback, bool broadcast, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<T>(T oldValue, T newValue, IEqualityComparer<T> comparer, Action<T> callback, bool broadcast, [CallerMemberName] string? propertyName = null)
     {
         ArgumentNullException.ThrowIfNull(comparer);
         ArgumentNullException.ThrowIfNull(callback);
@@ -292,7 +292,7 @@ public abstract class ObservableRecipient : ObservableObject
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="model"/> or <paramref name="callback"/> are <see langword="null"/>.</exception>
-    protected bool SetProperty<TModel, T>(T oldValue, T newValue, TModel model, Action<TModel, T> callback, bool broadcast, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<TModel, T>(T oldValue, T newValue, TModel model, Action<TModel, T> callback, bool broadcast, [CallerMemberName] string? propertyName = null)
         where TModel : class
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -328,7 +328,7 @@ public abstract class ObservableRecipient : ObservableObject
     /// <param name="propertyName">(optional) The name of the property that changed.</param>
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/>, <paramref name="model"/> or <paramref name="callback"/> are <see langword="null"/>.</exception>
-    protected bool SetProperty<TModel, T>(T oldValue, T newValue, IEqualityComparer<T> comparer, TModel model, Action<TModel, T> callback, bool broadcast, [CallerMemberName] string? propertyName = null)
+    protected virtual bool SetProperty<TModel, T>(T oldValue, T newValue, IEqualityComparer<T> comparer, TModel model, Action<TModel, T> callback, bool broadcast, [CallerMemberName] string? propertyName = null)
         where TModel : class
     {
         ArgumentNullException.ThrowIfNull(comparer);

--- a/src/CommunityToolkit.Mvvm/ComponentModel/ObservableValidator.cs
+++ b/src/CommunityToolkit.Mvvm/ComponentModel/ObservableValidator.cs
@@ -60,8 +60,9 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// </summary>
     private int totalErrors;
 
+#pragma warning disable CA1070 // Virtual required for things like NHibernate proxies
     /// <inheritdoc/>
-    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+    public virtual event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ObservableValidator"/> class.
@@ -124,7 +125,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
 
     /// <inheritdoc/>
     [Display(AutoGenerateField = false)]
-    public bool HasErrors => this.totalErrors > 0;
+    public virtual bool HasErrors => this.totalErrors > 0;
 
     /// <summary>
     /// Compares the current and new values for a given property. If the value has changed,
@@ -146,7 +147,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="propertyName"/> is <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, bool validate, [CallerMemberName] string propertyName = null!)
+    protected virtual bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, bool validate, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(propertyName);
 
@@ -175,7 +176,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, IEqualityComparer<T> comparer, bool validate, [CallerMemberName] string propertyName = null!)
+    protected virtual bool SetProperty<T>([NotNullIfNotNull(nameof(newValue))] ref T field, T newValue, IEqualityComparer<T> comparer, bool validate, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(comparer);
         ArgumentNullException.ThrowIfNull(propertyName);
@@ -212,7 +213,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="callback"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool SetProperty<T>(T oldValue, T newValue, Action<T> callback, bool validate, [CallerMemberName] string propertyName = null!)
+    protected virtual bool SetProperty<T>(T oldValue, T newValue, Action<T> callback, bool validate, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(callback);
         ArgumentNullException.ThrowIfNull(propertyName);
@@ -243,7 +244,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/>, <paramref name="callback"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool SetProperty<T>(T oldValue, T newValue, IEqualityComparer<T> comparer, Action<T> callback, bool validate, [CallerMemberName] string propertyName = null!)
+    protected virtual bool SetProperty<T>(T oldValue, T newValue, IEqualityComparer<T> comparer, Action<T> callback, bool validate, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(comparer);
         ArgumentNullException.ThrowIfNull(callback);
@@ -278,7 +279,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="model"/>, <paramref name="callback"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool SetProperty<TModel, T>(T oldValue, T newValue, TModel model, Action<TModel, T> callback, bool validate, [CallerMemberName] string propertyName = null!)
+    protected virtual bool SetProperty<TModel, T>(T oldValue, T newValue, TModel model, Action<TModel, T> callback, bool validate, [CallerMemberName] string propertyName = null!)
         where TModel : class
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -316,7 +317,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns><see langword="true"/> if the property was changed, <see langword="false"/> otherwise.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/>, <paramref name="model"/>, <paramref name="callback"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool SetProperty<TModel, T>(T oldValue, T newValue, IEqualityComparer<T> comparer, TModel model, Action<TModel, T> callback, bool validate, [CallerMemberName] string propertyName = null!)
+    protected virtual bool SetProperty<TModel, T>(T oldValue, T newValue, IEqualityComparer<T> comparer, TModel model, Action<TModel, T> callback, bool validate, [CallerMemberName] string propertyName = null!)
         where TModel : class
     {
         ArgumentNullException.ThrowIfNull(comparer);
@@ -346,7 +347,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns>Whether the validation was successful and the property value changed as well.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="propertyName"/> is <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool TrySetProperty<T>(ref T field, T newValue, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
+    protected virtual bool TrySetProperty<T>(ref T field, T newValue, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(propertyName);
 
@@ -367,7 +368,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns>Whether the validation was successful and the property value changed as well.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool TrySetProperty<T>(ref T field, T newValue, IEqualityComparer<T> comparer, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
+    protected virtual bool TrySetProperty<T>(ref T field, T newValue, IEqualityComparer<T> comparer, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(comparer);
         ArgumentNullException.ThrowIfNull(propertyName);
@@ -389,7 +390,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns>Whether the validation was successful and the property value changed as well.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="callback"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool TrySetProperty<T>(T oldValue, T newValue, Action<T> callback, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
+    protected virtual bool TrySetProperty<T>(T oldValue, T newValue, Action<T> callback, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(callback);
         ArgumentNullException.ThrowIfNull(propertyName);
@@ -412,7 +413,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns>Whether the validation was successful and the property value changed as well.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/>, <paramref name="callback"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool TrySetProperty<T>(T oldValue, T newValue, IEqualityComparer<T> comparer, Action<T> callback, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
+    protected virtual bool TrySetProperty<T>(T oldValue, T newValue, IEqualityComparer<T> comparer, Action<T> callback, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(comparer);
         ArgumentNullException.ThrowIfNull(callback);
@@ -437,7 +438,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns>Whether the validation was successful and the property value changed as well.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="model"/>, <paramref name="callback"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool TrySetProperty<TModel, T>(T oldValue, T newValue, TModel model, Action<TModel, T> callback, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
+    protected virtual bool TrySetProperty<TModel, T>(T oldValue, T newValue, TModel model, Action<TModel, T> callback, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
         where TModel : class
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -464,7 +465,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <returns>Whether the validation was successful and the property value changed as well.</returns>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="comparer"/>, <paramref name="model"/>, <paramref name="callback"/> or <paramref name="propertyName"/> are <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected bool TrySetProperty<TModel, T>(T oldValue, T newValue, IEqualityComparer<T> comparer, TModel model, Action<TModel, T> callback, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
+    protected virtual bool TrySetProperty<TModel, T>(T oldValue, T newValue, IEqualityComparer<T> comparer, TModel model, Action<TModel, T> callback, out IReadOnlyCollection<ValidationResult> errors, [CallerMemberName] string propertyName = null!)
         where TModel : class
     {
         ArgumentNullException.ThrowIfNull(comparer);
@@ -483,7 +484,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// The name of the property to clear validation errors for.
     /// If a <see langword="null"/> or empty name is used, all entity-level errors will be cleared.
     /// </param>
-    protected void ClearErrors(string? propertyName = null)
+    protected virtual void ClearErrors(string? propertyName = null)
     {
         // Clear entity-level errors when the target property is null or empty
         if (string.IsNullOrEmpty(propertyName))
@@ -497,7 +498,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     }
 
     /// <inheritdoc cref="INotifyDataErrorInfo.GetErrors(string)"/>
-    public IEnumerable<ValidationResult> GetErrors(string? propertyName = null)
+    public virtual IEnumerable<ValidationResult> GetErrors(string? propertyName = null)
     {
         // Get entity-level errors when the target property is null or empty
         if (string.IsNullOrEmpty(propertyName))
@@ -544,7 +545,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
         "If this type is removed by the linker, or if the target recipient was created dynamically and was missed by the source generator, a slower fallback " +
         "path using a compiled LINQ expression will be used. This will have more overhead in the first invocation of this method for any given recipient type. " +
         "Additionally, due to the usage of validation APIs, the type of the current instance cannot be statically discovered.")]
-    protected void ValidateAllProperties()
+    protected virtual void ValidateAllProperties()
     {
         // Fast path that tries to create a delegate from a generated type-specific method. This
         // is used to make this method more AOT-friendly and faster, as there is no dynamic code.
@@ -628,7 +629,7 @@ public abstract class ObservableValidator : ObservableObject, INotifyDataErrorIn
     /// <param name="propertyName">The name of the property to validate.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="propertyName"/> is <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The type of the current instance cannot be statically discovered.")]
-    protected internal void ValidateProperty(object? value, [CallerMemberName] string propertyName = null!)
+    protected internal virtual void ValidateProperty(object? value, [CallerMemberName] string propertyName = null!)
     {
         ArgumentNullException.ThrowIfNull(propertyName);
 


### PR DESCRIPTION
Added to all `public`, `protected`, `internal` facing methods, properties, and events (yes, those are required as well for this purpose).
For improved interoperability with NHIBERNATE proxy features.
Added PRAGMA for purposes of disabling the VIRTUAL EVENT warning.

**Closes #1095**

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] No changes to any of the tests, there is nothing to test really unless there is a desire to verify somehow virtual aspects are virtual
- [x] Contains **NO** breaking changes
- [x] Code follows all style conventions

## Other information

`virtual` required for all `public`, `protected`, `protected internal` members, yes, even including `event` members. I did have to put a `#pragma warning` in there for `event`.