### PR TITLE
Eliminate this = default shortcut when height * width = 0

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
@@ -64,6 +64,6 @@ internal static class OverflowHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int ComputeInt32Area(int height, int width, int pitch)
     {
-        return checked(((width + pitch) * Max(unchecked(height - 1), 0)) + width);
+        return Max(checked(((width + pitch) * (height - 1)) + width), 0);
     }
 }

--- a/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -362,13 +362,6 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
         }
 
-        if (width == 0 || height == 0)
-        {
-            this = default;
-
-            return;
-        }
-
         int area = OverflowHelper.ComputeInt32Area(height, width, pitch);
         int remaining = length - offset;
 
@@ -435,16 +428,8 @@ public readonly struct Memory2D<T> : IEquatable<Memory2D<T>>
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
         }
 
-        if (width == 0 || height == 0)
-        {
-            this = default;
-
-            return;
-        }
-
-        int
-            area = OverflowHelper.ComputeInt32Area(height, width, pitch),
-            remaining = memory.Length - offset;
+        int area = OverflowHelper.ComputeInt32Area(height, width, pitch);
+        int remaining = memory.Length - offset;
 
         if (area > remaining)
         {

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -382,13 +382,6 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
         }
 
-        if (width == 0 || height == 0)
-        {
-            this = default;
-
-            return;
-        }
-
         int area = OverflowHelper.ComputeInt32Area(height, width, pitch);
         int remaining = length - offset;
 
@@ -453,13 +446,6 @@ public readonly struct ReadOnlyMemory2D<T> : IEquatable<ReadOnlyMemory2D<T>>
         if (pitch < 0)
         {
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
-        }
-
-        if (width == 0 || height == 0)
-        {
-            this = default;
-
-            return;
         }
 
         int area = OverflowHelper.ComputeInt32Area(height, width, pitch);

--- a/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -209,13 +209,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
         }
 
-        if (width == 0 || height == 0)
-        {
-            this = default;
-
-            return;
-        }
-
         int area = OverflowHelper.ComputeInt32Area(height, width, pitch);
         int remaining = array.Length - offset;
 
@@ -457,13 +450,6 @@ public readonly ref partial struct ReadOnlySpan2D<T>
         if (pitch < 0)
         {
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
-        }
-
-        if (width == 0 || height == 0)
-        {
-            this = default;
-
-            return;
         }
 
         int area = OverflowHelper.ComputeInt32Area(height, width, pitch);

--- a/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/src/CommunityToolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -531,13 +531,6 @@ public readonly ref partial struct Span2D<T>
             ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
         }
 
-        if (width == 0 || height == 0)
-        {
-            this = default;
-
-            return;
-        }
-
         int area = OverflowHelper.ComputeInt32Area(height, width, pitch);
         int remaining = span.Length - offset;
 

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_MemoryExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_MemoryExtensions.cs
@@ -566,6 +566,33 @@ public class Test_MemoryExtensions
         Assert.IsTrue(stream.CanWrite);
     }
 
+#if NET8_0_OR_GREATER
+    [TestMethod]
+    public void Test_MemoryExtensions_AsMemory2D_Empty()
+    {
+        Memory2D<int> empty1 = Array.Empty<int>().AsMemory().AsMemory2D(0, 0);
+
+        Assert.IsTrue(empty1.IsEmpty);
+        Assert.AreEqual(0, empty1.Length);
+        Assert.AreEqual(0, empty1.Width);
+        Assert.AreEqual(0, empty1.Height);
+
+        Memory2D<int> empty2 = Array.Empty<int>().AsMemory().AsMemory2D(4, 0);
+
+        Assert.IsTrue(empty2.IsEmpty);
+        Assert.AreEqual(0, empty2.Length);
+        Assert.AreEqual(0, empty2.Width);
+        Assert.AreEqual(4, empty2.Height);
+
+        Memory2D<int> empty3 = Array.Empty<int>().AsMemory().AsMemory2D(0, 7);
+
+        Assert.IsTrue(empty3.IsEmpty);
+        Assert.AreEqual(0, empty3.Length);
+        Assert.AreEqual(7, empty3.Width);
+        Assert.AreEqual(0, empty3.Height);
+    }
+#endif
+
     private sealed class ArrayMemoryManager<T> : MemoryManager<T>
         where T : unmanaged
     {

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlyMemoryExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlyMemoryExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -34,4 +35,31 @@ public class Test_ReadOnlyMemoryExtensions
         Assert.AreEqual(stream.Length, memory.Length);
         Assert.IsFalse(stream.CanWrite);
     }
+
+#if NET8_0_OR_GREATER
+    [TestMethod]
+    public void Test_ReadOnlyMemoryExtensions_AsMemory2D_Empty()
+    {
+        ReadOnlyMemory2D<int> empty1 = ((ReadOnlyMemory<int>)Array.Empty<int>().AsMemory()).AsMemory2D(0, 0);
+
+        Assert.IsTrue(empty1.IsEmpty);
+        Assert.AreEqual(0, empty1.Length);
+        Assert.AreEqual(0, empty1.Width);
+        Assert.AreEqual(0, empty1.Height);
+
+        ReadOnlyMemory2D<int> empty2 = ((ReadOnlyMemory<int>)Array.Empty<int>().AsMemory()).AsMemory2D(4, 0);
+
+        Assert.IsTrue(empty2.IsEmpty);
+        Assert.AreEqual(0, empty2.Length);
+        Assert.AreEqual(0, empty2.Width);
+        Assert.AreEqual(4, empty2.Height);
+
+        ReadOnlyMemory2D<int> empty3 = ((ReadOnlyMemory<int>)Array.Empty<int>().AsMemory()).AsMemory2D(0, 7);
+
+        Assert.IsTrue(empty3.IsEmpty);
+        Assert.AreEqual(0, empty3.Length);
+        Assert.AreEqual(7, empty3.Width);
+        Assert.AreEqual(0, empty3.Height);
+    }
+#endif
 }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_ReadOnlySpanExtensions.cs
@@ -294,4 +294,31 @@ public partial class Test_ReadOnlySpanExtensions
 
         CollectionAssert.AreEqual(array, result);
     }
+
+#if NET8_0_OR_GREATER
+    [TestMethod]
+    public void Test_ReadOnlySpanExtensions_AsSpan2D_Empty()
+    {
+        ReadOnlySpan2D<int> empty1 = ReadOnlySpan<int>.Empty.AsSpan2D(0, 0);
+
+        Assert.IsTrue(empty1.IsEmpty);
+        Assert.AreEqual(0, empty1.Length);
+        Assert.AreEqual(0, empty1.Width);
+        Assert.AreEqual(0, empty1.Height);
+
+        ReadOnlySpan2D<int> empty2 = ReadOnlySpan<int>.Empty.AsSpan2D(4, 0);
+
+        Assert.IsTrue(empty2.IsEmpty);
+        Assert.AreEqual(0, empty2.Length);
+        Assert.AreEqual(0, empty2.Width);
+        Assert.AreEqual(4, empty2.Height);
+
+        ReadOnlySpan2D<int> empty3 = ReadOnlySpan<int>.Empty.AsSpan2D(0, 7);
+
+        Assert.IsTrue(empty3.IsEmpty);
+        Assert.AreEqual(0, empty3.Length);
+        Assert.AreEqual(7, empty3.Width);
+        Assert.AreEqual(0, empty3.Height);
+    }
+#endif
 }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_SpanExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_SpanExtensions.cs
@@ -199,4 +199,31 @@ public class Test_SpanExtensions
 
         CollectionAssert.AreEqual(array, result);
     }
+
+#if NET8_0_OR_GREATER
+    [TestMethod]
+    public void Test_SpanExtensions_AsSpan2D_Empty()
+    {
+        Span2D<int> empty1 = Span<int>.Empty.AsSpan2D(0, 0);
+
+        Assert.IsTrue(empty1.IsEmpty);
+        Assert.AreEqual(0, empty1.Length);
+        Assert.AreEqual(0, empty1.Width);
+        Assert.AreEqual(0, empty1.Height);
+
+        Span2D<int> empty2 = Span<int>.Empty.AsSpan2D(4, 0);
+
+        Assert.IsTrue(empty2.IsEmpty);
+        Assert.AreEqual(0, empty2.Length);
+        Assert.AreEqual(0, empty2.Width);
+        Assert.AreEqual(4, empty2.Height);
+
+        Span2D<int> empty3 = Span<int>.Empty.AsSpan2D(0, 7);
+
+        Assert.IsTrue(empty3.IsEmpty);
+        Assert.AreEqual(0, empty3.Length);
+        Assert.AreEqual(7, empty3.Width);
+        Assert.AreEqual(0, empty3.Height);
+    }
+#endif
 }

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_Memory2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_Memory2D{T}.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Runtime.CompilerServices;
+using CommunityToolkit.HighPerformance.UnitTests.Buffers.Internals;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.HighPerformance.UnitTests;
@@ -43,6 +45,30 @@ public class Test_Memory2DT
         Assert.AreEqual(0, empty4.Length);
         Assert.AreEqual(7, empty4.Width);
         Assert.AreEqual(0, empty4.Height);
+
+#if NET6_0_OR_GREATER
+        MemoryManager<int> memoryManager = new UnmanagedSpanOwner<int>(1);
+        Memory2D<int> empty5 = new(memoryManager, 0, 0);
+
+        Assert.IsTrue(empty5.IsEmpty);
+        Assert.AreEqual(0, empty5.Length);
+        Assert.AreEqual(0, empty5.Width);
+        Assert.AreEqual(0, empty5.Height);
+
+        Memory2D<int> empty6 = new(memoryManager, 4, 0);
+
+        Assert.IsTrue(empty6.IsEmpty);
+        Assert.AreEqual(0, empty6.Length);
+        Assert.AreEqual(0, empty6.Width);
+        Assert.AreEqual(4, empty6.Height);
+
+        Memory2D<int> empty7 = new(memoryManager, 0, 7);
+
+        Assert.IsTrue(empty7.IsEmpty);
+        Assert.AreEqual(0, empty7.Length);
+        Assert.AreEqual(7, empty7.Width);
+        Assert.AreEqual(0, empty7.Height);
+#endif
     }
 
     [TestMethod]

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlyMemory2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlyMemory2D{T}.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Runtime.CompilerServices;
+using CommunityToolkit.HighPerformance.UnitTests.Buffers.Internals;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.HighPerformance.UnitTests;
@@ -34,6 +36,30 @@ public class Test_ReadOnlyMemory2DT
         Assert.AreEqual(0, empty2.Length);
         Assert.AreEqual(0, empty2.Width);
         Assert.AreEqual(0, empty2.Height);
+
+#if NET6_0_OR_GREATER
+        MemoryManager<int> memoryManager = new UnmanagedSpanOwner<int>(1);
+        ReadOnlyMemory2D<int> empty5 = new(memoryManager, 0, 0);
+
+        Assert.IsTrue(empty5.IsEmpty);
+        Assert.AreEqual(0, empty5.Length);
+        Assert.AreEqual(0, empty5.Width);
+        Assert.AreEqual(0, empty5.Height);
+
+        ReadOnlyMemory2D<int> empty6 = new(memoryManager, 4, 0);
+
+        Assert.IsTrue(empty6.IsEmpty);
+        Assert.AreEqual(0, empty6.Length);
+        Assert.AreEqual(0, empty6.Width);
+        Assert.AreEqual(4, empty6.Height);
+
+        ReadOnlyMemory2D<int> empty7 = new(memoryManager, 0, 7);
+
+        Assert.IsTrue(empty7.IsEmpty);
+        Assert.AreEqual(0, empty7.Length);
+        Assert.AreEqual(7, empty7.Width);
+        Assert.AreEqual(0, empty7.Height);
+#endif
     }
 
     [TestMethod]

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlySpan2D{T}.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Memory/Test_ReadOnlySpan2D{T}.cs
@@ -36,6 +36,27 @@ public class Test_ReadOnlySpan2DT
         Assert.AreEqual(0, empty2.Length);
         Assert.AreEqual(0, empty2.Width);
         Assert.AreEqual(0, empty2.Height);
+
+        ReadOnlySpan2D<string> empty3 = new([], 0, 0);
+
+        Assert.IsTrue(empty3.IsEmpty);
+        Assert.AreEqual(0, empty3.Length);
+        Assert.AreEqual(0, empty3.Width);
+        Assert.AreEqual(0, empty3.Height);
+        
+        ReadOnlySpan2D<string> empty4 = new([], 4, 0);
+
+        Assert.IsTrue(empty4.IsEmpty);
+        Assert.AreEqual(0, empty4.Length);
+        Assert.AreEqual(0, empty4.Width);
+        Assert.AreEqual(4, empty4.Height);
+
+        ReadOnlySpan2D<string> empty5 = new([], 0, 7);
+
+        Assert.IsTrue(empty5.IsEmpty);
+        Assert.AreEqual(0, empty5.Length);
+        Assert.AreEqual(7, empty5.Width);
+        Assert.AreEqual(0, empty5.Height);
     }
 
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #1101**

<!-- Add an overview of the changes here -->

Previously, when creating 2D memory structures (`Memory2D<T>`, `ReadOnlyMemory2D<T>`, `Span2D<T>`, `ReadOnlySpan2D<T>`) with zero height or width, some constructors would take a shortcut by setting `this = default`. This approach had issues because it didn't properly preserve non-zero dimensions (e.g., a 4×0 or 0×7 structure would become 0×0). Additionally, the `OverflowHelper.ComputeInt32Area` method could return non-zero values when `height=0` due to an invalid formula.

Solution

- Removed the this = default shortcuts from all 2D memory structure constructors

- Fixed calculation in `OverflowHelper.ComputeInt32Area`:

- Added comprehensive tests to verify empty structures maintain correct dimensions
<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->