### PR TITLE
Remove explicit backing field generated Relay Commands when possible

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
@@ -60,7 +60,7 @@ public sealed class WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompati
                     return;
                 }
 
-                (_, string propertyName) = RelayCommandGenerator.Execute.GetGeneratedFieldAndPropertyNames(methodSymbol, context.Compilation);
+                (_, string propertyName) = RelayCommandGenerator.Execute.GetGeneratedFieldAndPropertyNames(methodSymbol);
 
                 if (DoesGeneratedBindableCustomPropertyAttributeIncludePropertyName(generatedBindableCustomPropertyAttribute, propertyName))
                 {

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/Analyzers/WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompatibleAnalyzer.cs
@@ -60,7 +60,7 @@ public sealed class WinRTRelayCommandIsNotGeneratedBindableCustomPropertyCompati
                     return;
                 }
 
-                (_, string propertyName) = RelayCommandGenerator.Execute.GetGeneratedFieldAndPropertyNames(methodSymbol);
+                (_, string propertyName) = RelayCommandGenerator.Execute.GetGeneratedFieldAndPropertyNames(methodSymbol, context.Compilation);
 
                 if (DoesGeneratedBindableCustomPropertyAttributeIncludePropertyName(generatedBindableCustomPropertyAttribute, propertyName))
                 {

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Input/Models/CommandInfo.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Input/Models/CommandInfo.cs
@@ -11,7 +11,7 @@ namespace CommunityToolkit.Mvvm.SourceGenerators.Input.Models;
 /// A model with gathered info on a given command method.
 /// </summary>
 /// <param name="MethodName">The name of the target method.</param>
-/// <param name="FieldName">The resulting field name for the generated command.</param>
+/// <param name="FieldName">The resulting field name for the generated command, or null if the <see langword="field"/> is available.</param>
 /// <param name="PropertyName">The resulting property name for the generated command.</param>
 /// <param name="CommandInterfaceType">The command interface type name.</param>
 /// <param name="CommandClassType">The command class type name.</param>
@@ -26,7 +26,7 @@ namespace CommunityToolkit.Mvvm.SourceGenerators.Input.Models;
 /// <param name="ForwardedAttributes">The sequence of forwarded attributes for the generated members.</param>
 internal sealed record CommandInfo(
     string MethodName,
-    string FieldName,
+    string? FieldName,
     string PropertyName,
     string CommandInterfaceType,
     string CommandClassType,

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
@@ -59,7 +59,7 @@ partial class RelayCommandGenerator
             token.ThrowIfCancellationRequested();
 
             // Get the command field and property names
-            (string fieldName, string propertyName) = GetGeneratedFieldAndPropertyNames(methodSymbol);
+            (string? fieldName, string propertyName) = GetGeneratedFieldAndPropertyNames(methodSymbol, semanticModel.Compilation);
 
             token.ThrowIfCancellationRequested();
 
@@ -207,25 +207,30 @@ partial class RelayCommandGenerator
                 .Select(static a => AttributeList(SingletonSeparatedList(a.GetSyntax())))
                 .ToArray();
 
-            // Construct the generated field as follows:
-            //
-            // /// <summary>The backing field for <see cref="<COMMAND_PROPERTY_NAME>"/></summary>
-            // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
-            // <FORWARDED_ATTRIBUTES>
-            // private <COMMAND_TYPE>? <COMMAND_FIELD_NAME>;
-            FieldDeclarationSyntax fieldDeclaration =
-                FieldDeclaration(
-                VariableDeclaration(NullableType(IdentifierName(commandClassTypeName)))
-                .AddVariables(VariableDeclarator(Identifier(commandInfo.FieldName))))
-                .AddModifiers(Token(SyntaxKind.PrivateKeyword))
-                .AddAttributeLists(
-                    AttributeList(SingletonSeparatedList(
-                        Attribute(IdentifierName("global::System.CodeDom.Compiler.GeneratedCode"))
-                        .AddArgumentListArguments(
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).FullName))),
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).Assembly.GetName().Version.ToString()))))))
-                    .WithOpenBracketToken(Token(TriviaList(Comment($"/// <summary>The backing field for <see cref=\"{commandInfo.PropertyName}\"/>.</summary>")), SyntaxKind.OpenBracketToken, TriviaList())))
-                .AddAttributeLists(forwardedFieldAttributes);
+            // Declare a backing field if needed
+            FieldDeclarationSyntax? fieldDeclaration = null;
+            if (commandInfo.FieldName is not null)
+            {
+                // Construct the generated field as follows:
+                //
+                // /// <summary>The backing field for <see cref="<COMMAND_PROPERTY_NAME>"/></summary>
+                // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
+                // <FORWARDED_ATTRIBUTES>
+                // private <COMMAND_TYPE>? <COMMAND_FIELD_NAME>;
+                fieldDeclaration =
+                    FieldDeclaration(
+                    VariableDeclaration(NullableType(IdentifierName(commandClassTypeName)))
+                    .AddVariables(VariableDeclarator(Identifier(commandInfo.FieldName))))
+                    .AddModifiers(Token(SyntaxKind.PrivateKeyword))
+                    .AddAttributeLists(
+                        AttributeList(SingletonSeparatedList(
+                            Attribute(IdentifierName("global::System.CodeDom.Compiler.GeneratedCode"))
+                            .AddArgumentListArguments(
+                                AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).FullName))),
+                                AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).Assembly.GetName().Version.ToString()))))))
+                        .WithOpenBracketToken(Token(TriviaList(Comment($"/// <summary>The backing field for <see cref=\"{commandInfo.PropertyName}\"/>.</summary>")), SyntaxKind.OpenBracketToken, TriviaList())))
+                    .AddAttributeLists(forwardedFieldAttributes);
+            }
 
             // Prepares the argument to pass the underlying method to invoke
             using ImmutableArrayBuilder<ArgumentSyntax> commandCreationArguments = ImmutableArrayBuilder<ArgumentSyntax>.Rent();
@@ -337,7 +342,7 @@ partial class RelayCommandGenerator
                     ArrowExpressionClause(
                         AssignmentExpression(
                             SyntaxKind.CoalesceAssignmentExpression,
-                            IdentifierName(commandInfo.FieldName),
+                            commandInfo.FieldName is not null ? IdentifierName(commandInfo.FieldName) : IdentifierName(Token(SyntaxKind.FieldKeyword)),
                             ObjectCreationExpression(IdentifierName(commandClassTypeName))
                             .AddArgumentListArguments(commandCreationArguments.ToArray()))))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
@@ -346,26 +351,31 @@ partial class RelayCommandGenerator
             if (commandInfo.IncludeCancelCommand)
             {
                 // Prepare all necessary member and type names
-                string cancelCommandFieldName = $"{commandInfo.FieldName.Substring(0, commandInfo.FieldName.Length - "Command".Length)}CancelCommand";
+                string? cancelCommandFieldName = commandInfo.FieldName is not null ? $"{commandInfo.FieldName.Substring(0, commandInfo.FieldName.Length - "Command".Length)}CancelCommand" : null;
                 string cancelCommandPropertyName = $"{commandInfo.PropertyName.Substring(0, commandInfo.PropertyName.Length - "Command".Length)}CancelCommand";
 
-                // Construct the generated field for the cancel command as follows:
-                //
-                // /// <summary>The backing field for <see cref="<COMMAND_PROPERTY_NAME>"/></summary>
-                // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
-                // private global::System.Windows.Input.ICommand? <CANCEL_COMMAND_FIELD_NAME>;
-                FieldDeclarationSyntax cancelCommandFieldDeclaration =
-                    FieldDeclaration(
-                    VariableDeclaration(NullableType(IdentifierName("global::System.Windows.Input.ICommand")))
-                    .AddVariables(VariableDeclarator(Identifier(cancelCommandFieldName))))
-                    .AddModifiers(Token(SyntaxKind.PrivateKeyword))
-                    .AddAttributeLists(
-                        AttributeList(SingletonSeparatedList(
-                            Attribute(IdentifierName("global::System.CodeDom.Compiler.GeneratedCode"))
-                            .AddArgumentListArguments(
-                                AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).FullName))),
-                                AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).Assembly.GetName().Version.ToString()))))))
-                        .WithOpenBracketToken(Token(TriviaList(Comment($"/// <summary>The backing field for <see cref=\"{cancelCommandPropertyName}\"/>.</summary>")), SyntaxKind.OpenBracketToken, TriviaList())));
+                FieldDeclarationSyntax? cancelCommandFieldDeclaration = null;
+                if (cancelCommandFieldName is not null)
+                {
+                    // Construct the generated field for the cancel command as follows:
+                    //
+                    // /// <summary>The backing field for <see cref="<COMMAND_PROPERTY_NAME>"/></summary>
+                    // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
+                    // private global::System.Windows.Input.ICommand? <CANCEL_COMMAND_FIELD_NAME>;
+                    cancelCommandFieldDeclaration =
+                        FieldDeclaration(
+                        VariableDeclaration(NullableType(IdentifierName("global::System.Windows.Input.ICommand")))
+                        .AddVariables(VariableDeclarator(Identifier(cancelCommandFieldName))))
+                        .AddModifiers(Token(SyntaxKind.PrivateKeyword))
+                        .AddAttributeLists(
+                            AttributeList(SingletonSeparatedList(
+                                Attribute(IdentifierName("global::System.CodeDom.Compiler.GeneratedCode"))
+                                .AddArgumentListArguments(
+                                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).FullName))),
+                                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).Assembly.GetName().Version.ToString()))))))
+                            .WithOpenBracketToken(Token(TriviaList(Comment($"/// <summary>The backing field for <see cref=\"{cancelCommandPropertyName}\"/>.</summary>")), SyntaxKind.OpenBracketToken, TriviaList())));
+
+                }
 
                 // Construct the generated property as follows (the explicit delegate cast is needed to avoid overload resolution conflicts):
                 //
@@ -393,7 +403,7 @@ partial class RelayCommandGenerator
                         ArrowExpressionClause(
                             AssignmentExpression(
                                 SyntaxKind.CoalesceAssignmentExpression,
-                                IdentifierName(cancelCommandFieldName),
+                                cancelCommandFieldName is not null ? IdentifierName(cancelCommandFieldName) : IdentifierName(Token(SyntaxKind.FieldKeyword)),
                                 InvocationExpression(
                                     MemberAccessExpression(
                                         SyntaxKind.SimpleMemberAccessExpression,
@@ -402,10 +412,20 @@ partial class RelayCommandGenerator
                                 .AddArgumentListArguments(Argument(IdentifierName(commandInfo.PropertyName))))))
                     .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
-                return ImmutableArray.Create<MemberDeclarationSyntax>(fieldDeclaration, propertyDeclaration, cancelCommandFieldDeclaration, cancelCommandPropertyDeclaration);
+                if (fieldDeclaration is not null && cancelCommandFieldDeclaration is not null)
+                {
+                    return ImmutableArray.Create<MemberDeclarationSyntax>(fieldDeclaration, propertyDeclaration, cancelCommandFieldDeclaration, cancelCommandPropertyDeclaration);
+                }
+
+                return ImmutableArray.Create<MemberDeclarationSyntax>(propertyDeclaration, cancelCommandPropertyDeclaration);
             }
 
-            return ImmutableArray.Create<MemberDeclarationSyntax>(fieldDeclaration, propertyDeclaration);
+            if (fieldDeclaration is not null)
+            {
+                return ImmutableArray.Create<MemberDeclarationSyntax>(fieldDeclaration, propertyDeclaration);
+            }
+
+            return ImmutableArray.Create<MemberDeclarationSyntax>(propertyDeclaration);
         }
 
         /// <summary>
@@ -474,8 +494,9 @@ partial class RelayCommandGenerator
         /// Get the generated field and property names for the input method.
         /// </summary>
         /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
+        /// <param name="compilation">The compilation info, used to determine language version.</param>
         /// <returns>The generated field and property names for <paramref name="methodSymbol"/>.</returns>
-        public static (string FieldName, string PropertyName) GetGeneratedFieldAndPropertyNames(IMethodSymbol methodSymbol)
+        public static (string? FieldName, string PropertyName) GetGeneratedFieldAndPropertyNames(IMethodSymbol methodSymbol, Compilation? compilation = null)
         {
             string propertyName = methodSymbol.Name;
 
@@ -497,6 +518,24 @@ partial class RelayCommandGenerator
             }
 
             propertyName += "Command";
+
+            if (compilation is not null)
+            {
+                // We can use the field keyword as the generated field name if the language version is C# 14 or greater, or if it's C# 13 and the preview features are enabled.
+                // In this case, there is no need to generate a backing field, as the property itself will be auto-generated with an underlying field.
+                bool useFieldKeyword = false;
+
+#if ROSLYN_5_0_0_OR_GREATER
+                useFieldKeyword = compilation.HasLanguageVersionAtLeastEqualTo(LanguageVersion.CSharp14);
+#elif ROSLYN_4_12_0_OR_GREATER
+                useFieldKeyword = compilation.IsLanguageVersionPreview();
+#endif
+
+                if (useFieldKeyword)
+                {
+                    return (null, propertyName);
+                }
+            }
 
             char firstCharacter = propertyName[0];
             char loweredFirstCharacter = char.ToLower(firstCharacter, CultureInfo.InvariantCulture);

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
@@ -345,7 +345,7 @@ partial class RelayCommandGenerator
                     ArrowExpressionClause(
                         AssignmentExpression(
                             SyntaxKind.CoalesceAssignmentExpression,
-                            commandInfo.FieldName is not null ? IdentifierName(commandInfo.FieldName) : IdentifierName(Token(SyntaxKind.FieldKeyword)),
+                            commandInfo.FieldName is not null ? IdentifierName(commandInfo.FieldName) : IdentifierName("field"),
                             ObjectCreationExpression(IdentifierName(commandClassTypeName))
                             .AddArgumentListArguments(commandCreationArguments.ToArray()))))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
@@ -410,7 +410,7 @@ partial class RelayCommandGenerator
                         ArrowExpressionClause(
                             AssignmentExpression(
                                 SyntaxKind.CoalesceAssignmentExpression,
-                                cancelCommandFieldName is not null ? IdentifierName(cancelCommandFieldName) : IdentifierName(Token(SyntaxKind.FieldKeyword)),
+                                cancelCommandFieldName is not null ? IdentifierName(cancelCommandFieldName) : IdentifierName("field"),
                                 InvocationExpression(
                                     MemberAccessExpression(
                                         SyntaxKind.SimpleMemberAccessExpression,

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
@@ -207,7 +207,7 @@ partial class RelayCommandGenerator
                 .Select(static a => AttributeList(SingletonSeparatedList(a.GetSyntax())))
                 .ToArray();
 
-            ImmutableArrayBuilder<MemberDeclarationSyntax> declarations = ImmutableArrayBuilder<MemberDeclarationSyntax>.Rent();
+            using ImmutableArrayBuilder<MemberDeclarationSyntax> declarations = ImmutableArrayBuilder<MemberDeclarationSyntax>.Rent();
 
             // Declare a backing field if needed
             if (commandInfo.FieldName is not null)

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
@@ -59,7 +59,7 @@ partial class RelayCommandGenerator
             token.ThrowIfCancellationRequested();
 
             // Get the command field and property names
-            (string? fieldName, string propertyName) = GetGeneratedFieldAndPropertyNames(methodSymbol, semanticModel.Compilation);
+            (string fieldName, string propertyName) = GetGeneratedFieldAndPropertyNames(methodSymbol);
 
             token.ThrowIfCancellationRequested();
 
@@ -135,6 +135,17 @@ partial class RelayCommandGenerator
 
             token.ThrowIfCancellationRequested();
 
+            // Get the option to force a backing field, if any
+            if (!TryGetUseBackingField(
+                attributeData,
+                semanticModel,
+                out bool useBackingField))
+            {
+                goto Failure;
+            }
+
+            token.ThrowIfCancellationRequested();
+
             // Get all forwarded attributes (don't stop in case of errors, just ignore faulting attributes)
             GatherForwardedAttributes(
                 methodSymbol,
@@ -147,7 +158,7 @@ partial class RelayCommandGenerator
 
             commandInfo = new CommandInfo(
                 methodSymbol.Name,
-                fieldName,
+                useBackingField ? fieldName : null,
                 propertyName,
                 commandInterfaceType,
                 commandClassType,
@@ -356,8 +367,8 @@ partial class RelayCommandGenerator
             if (commandInfo.IncludeCancelCommand)
             {
                 // Prepare all necessary member and type names
-                string? cancelCommandFieldName = commandInfo.FieldName is not null ? $"{commandInfo.FieldName.Substring(0, commandInfo.FieldName.Length - "Command".Length)}CancelCommand" : null;
-                string cancelCommandPropertyName = $"{commandInfo.PropertyName.Substring(0, commandInfo.PropertyName.Length - "Command".Length)}CancelCommand";
+                string? cancelCommandFieldName = commandInfo.FieldName is not null ? $"{commandInfo.FieldName[..^"Command".Length]}CancelCommand" : null;
+                string cancelCommandPropertyName = $"{commandInfo.PropertyName[..^"Command".Length]}CancelCommand";
 
                 // Declare a backing field for the cancel command if needed.
                 // This is only needed if we can't use the field keyword for the main command, as otherwise the cancel command can just use its own field keyword.
@@ -492,9 +503,8 @@ partial class RelayCommandGenerator
         /// Get the generated field and property names for the input method.
         /// </summary>
         /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
-        /// <param name="compilation">The compilation info, used to determine language version.</param>
         /// <returns>The generated field and property names for <paramref name="methodSymbol"/>.</returns>
-        public static (string? FieldName, string PropertyName) GetGeneratedFieldAndPropertyNames(IMethodSymbol methodSymbol, Compilation? compilation = null)
+        public static (string FieldName, string PropertyName) GetGeneratedFieldAndPropertyNames(IMethodSymbol methodSymbol)
         {
             string propertyName = methodSymbol.Name;
 
@@ -516,24 +526,6 @@ partial class RelayCommandGenerator
             }
 
             propertyName += "Command";
-
-            if (compilation is not null)
-            {
-                // We can use the field keyword as the generated field name if the language version is C# 14 or greater, or if it's C# 13 and the preview features are enabled.
-                // In this case, there is no need to generate a backing field, as the property itself will be auto-generated with an underlying field.
-                bool useFieldKeyword = false;
-
-#if ROSLYN_5_0_0_OR_GREATER
-                useFieldKeyword = compilation.HasLanguageVersionAtLeastEqualTo(LanguageVersion.CSharp14);
-#elif ROSLYN_4_12_0_OR_GREATER
-                useFieldKeyword = compilation.IsLanguageVersionPreview();
-#endif
-
-                if (useFieldKeyword)
-                {
-                    return (null, propertyName);
-                }
-            }
 
             char firstCharacter = propertyName[0];
             char loweredFirstCharacter = char.ToLower(firstCharacter, CultureInfo.InvariantCulture);
@@ -795,6 +787,43 @@ partial class RelayCommandGenerator
 
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Checks whether or not the user has requested to force using a backing field.
+        /// </summary>
+        /// <param name="attributeData">The <see cref="AttributeData"/> instance the method was annotated with.</param>
+        /// <param name="semanticModel">The <see cref="SemanticModel"/> instance for the current run.</param>
+        /// <param name="useBackingField">Whether or not to use a backing field.</param>
+        /// <returns>Whether or not a value for <paramref name="useBackingField"/> could be retrieved successfully.</returns>
+        private static bool TryGetUseBackingField(
+            AttributeData attributeData,
+            SemanticModel semanticModel,
+            out bool useBackingField)
+        {
+            // Try to get the custom switch for cancel command generation (the default is false)
+            if (!attributeData.TryGetNamedArgument("ForceBackingField", out useBackingField))
+            {
+                useBackingField = false;
+            }
+            
+            // We can only use the field keyword as the generated field name if the language version is C# 14 or greater, or if it's C# 13 and the preview features are enabled.
+            // Otherwise, we must use a backing field.
+#if ROSLYN_5_0_0_OR_GREATER
+            if (!semanticModel.Compilation.HasLanguageVersionAtLeastEqualTo(LanguageVersion.CSharp14))
+            {
+                useBackingField = true;
+            }
+#elif ROSLYN_4_12_0_OR_GREATER
+            if (!semanticModel.Compilation.IsLanguageVersionPreview())
+            {
+                useBackingField = true;
+            }
+#else
+                useBackingField = true;
+#endif
+
+            return true;
         }
 
         /// <summary>

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Input/RelayCommandGenerator.Execute.cs
@@ -207,8 +207,9 @@ partial class RelayCommandGenerator
                 .Select(static a => AttributeList(SingletonSeparatedList(a.GetSyntax())))
                 .ToArray();
 
+            ImmutableArrayBuilder<MemberDeclarationSyntax> declarations = ImmutableArrayBuilder<MemberDeclarationSyntax>.Rent();
+
             // Declare a backing field if needed
-            FieldDeclarationSyntax? fieldDeclaration = null;
             if (commandInfo.FieldName is not null)
             {
                 // Construct the generated field as follows:
@@ -217,7 +218,7 @@ partial class RelayCommandGenerator
                 // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
                 // <FORWARDED_ATTRIBUTES>
                 // private <COMMAND_TYPE>? <COMMAND_FIELD_NAME>;
-                fieldDeclaration =
+                FieldDeclarationSyntax fieldDeclaration =
                     FieldDeclaration(
                     VariableDeclaration(NullableType(IdentifierName(commandClassTypeName)))
                     .AddVariables(VariableDeclarator(Identifier(commandInfo.FieldName))))
@@ -230,6 +231,8 @@ partial class RelayCommandGenerator
                                 AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).Assembly.GetName().Version.ToString()))))))
                         .WithOpenBracketToken(Token(TriviaList(Comment($"/// <summary>The backing field for <see cref=\"{commandInfo.PropertyName}\"/>.</summary>")), SyntaxKind.OpenBracketToken, TriviaList())))
                     .AddAttributeLists(forwardedFieldAttributes);
+
+                declarations.Add(fieldDeclaration);
             }
 
             // Prepares the argument to pass the underlying method to invoke
@@ -347,6 +350,8 @@ partial class RelayCommandGenerator
                             .AddArgumentListArguments(commandCreationArguments.ToArray()))))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
+            declarations.Add(propertyDeclaration);
+
             // Conditionally declare the additional members for the cancel commands
             if (commandInfo.IncludeCancelCommand)
             {
@@ -354,7 +359,8 @@ partial class RelayCommandGenerator
                 string? cancelCommandFieldName = commandInfo.FieldName is not null ? $"{commandInfo.FieldName.Substring(0, commandInfo.FieldName.Length - "Command".Length)}CancelCommand" : null;
                 string cancelCommandPropertyName = $"{commandInfo.PropertyName.Substring(0, commandInfo.PropertyName.Length - "Command".Length)}CancelCommand";
 
-                FieldDeclarationSyntax? cancelCommandFieldDeclaration = null;
+                // Declare a backing field for the cancel command if needed.
+                // This is only needed if we can't use the field keyword for the main command, as otherwise the cancel command can just use its own field keyword.
                 if (cancelCommandFieldName is not null)
                 {
                     // Construct the generated field for the cancel command as follows:
@@ -362,7 +368,7 @@ partial class RelayCommandGenerator
                     // /// <summary>The backing field for <see cref="<COMMAND_PROPERTY_NAME>"/></summary>
                     // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
                     // private global::System.Windows.Input.ICommand? <CANCEL_COMMAND_FIELD_NAME>;
-                    cancelCommandFieldDeclaration =
+                    FieldDeclarationSyntax cancelCommandFieldDeclaration =
                         FieldDeclaration(
                         VariableDeclaration(NullableType(IdentifierName("global::System.Windows.Input.ICommand")))
                         .AddVariables(VariableDeclarator(Identifier(cancelCommandFieldName))))
@@ -375,6 +381,7 @@ partial class RelayCommandGenerator
                                     AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(RelayCommandGenerator).Assembly.GetName().Version.ToString()))))))
                             .WithOpenBracketToken(Token(TriviaList(Comment($"/// <summary>The backing field for <see cref=\"{cancelCommandPropertyName}\"/>.</summary>")), SyntaxKind.OpenBracketToken, TriviaList())));
 
+                    declarations.Add(cancelCommandFieldDeclaration);
                 }
 
                 // Construct the generated property as follows (the explicit delegate cast is needed to avoid overload resolution conflicts):
@@ -412,20 +419,11 @@ partial class RelayCommandGenerator
                                 .AddArgumentListArguments(Argument(IdentifierName(commandInfo.PropertyName))))))
                     .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
-                if (fieldDeclaration is not null && cancelCommandFieldDeclaration is not null)
-                {
-                    return ImmutableArray.Create<MemberDeclarationSyntax>(fieldDeclaration, propertyDeclaration, cancelCommandFieldDeclaration, cancelCommandPropertyDeclaration);
-                }
+                declarations.Add(cancelCommandPropertyDeclaration);
 
-                return ImmutableArray.Create<MemberDeclarationSyntax>(propertyDeclaration, cancelCommandPropertyDeclaration);
             }
 
-            if (fieldDeclaration is not null)
-            {
-                return ImmutableArray.Create<MemberDeclarationSyntax>(fieldDeclaration, propertyDeclaration);
-            }
-
-            return ImmutableArray.Create<MemberDeclarationSyntax>(propertyDeclaration);
+            return declarations.ToImmutable();
         }
 
         /// <summary>

--- a/src/CommunityToolkit.Mvvm/Input/Attributes/RelayCommandAttribute.cs
+++ b/src/CommunityToolkit.Mvvm/Input/Attributes/RelayCommandAttribute.cs
@@ -116,4 +116,9 @@ public sealed class RelayCommandAttribute : Attribute
     /// </summary>
     /// <remarks>Using this property is not valid if the target command doesn't map to a cancellable asynchronous command.</remarks>
     public bool IncludeCancelCommand { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not a backing field should generated regardless of the availablity of the <see langword="field"/> keyword.
+    /// </summary>
+    public bool ForceBackingField { get; init; }
 }

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -1003,6 +1003,7 @@ public partial class Test_ObservablePropertyAttribute
         Assert.AreEqual((Animal)67, testAttribute2.Animal);
     }
 
+#if !ROSLYN_4_12_0_OR_GREATER
     // See https://github.com/CommunityToolkit/dotnet/issues/446
     [TestMethod]
     public void Test_ObservableProperty_CommandNamesThatCantBeLowered()
@@ -1021,6 +1022,7 @@ public partial class Test_ObservablePropertyAttribute
 
         Assert.AreSame(model.c中文Command, fieldInfo?.GetValue(model));
     }
+#endif
 
     // See https://github.com/CommunityToolkit/dotnet/issues/375
     [TestMethod]

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommandAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_RelayCommandAttribute.cs
@@ -571,6 +571,7 @@ public partial class Test_RelayCommandAttribute
     [TestMethod]
     public void Test_RelayCommandAttribute_WithExplicitAttributesForFieldAndProperty()
     {
+#if !ROSLYN_4_12_0_OR_GREATER
         FieldInfo fooField = typeof(MyViewModelWithExplicitFieldAndPropertyAttributes).GetField("fooCommand", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         Assert.IsNotNull(fooField.GetCustomAttribute<RequiredAttribute>());
@@ -579,6 +580,7 @@ public partial class Test_RelayCommandAttribute
         Assert.IsNotNull(fooField.GetCustomAttribute<MaxLengthAttribute>());
         Assert.AreEqual(100, fooField.GetCustomAttribute<MaxLengthAttribute>()!.Length);
 
+#endif
         PropertyInfo fooProperty = typeof(MyViewModelWithExplicitFieldAndPropertyAttributes).GetProperty("FooCommand")!;
 
         Assert.IsNotNull(fooProperty.GetCustomAttribute<RequiredAttribute>());
@@ -618,17 +620,21 @@ public partial class Test_RelayCommandAttribute
             Assert.AreEqual(Test_ObservablePropertyAttribute.Animal.Llama, testAttribute.Animal);
         }
 
+#if !ROSLYN_4_12_0_OR_GREATER
         FieldInfo fooBarField = typeof(MyViewModelWithExplicitFieldAndPropertyAttributes).GetField("fooBarCommand", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         ValidateTestAttribute(fooBarField.GetCustomAttribute<TestValidationAttribute>()!);
+#endif
 
         PropertyInfo fooBarProperty = typeof(MyViewModelWithExplicitFieldAndPropertyAttributes).GetProperty("FooBarCommand")!;
 
         ValidateTestAttribute(fooBarProperty.GetCustomAttribute<TestValidationAttribute>()!);
 
+#if !ROSLYN_4_12_0_OR_GREATER
         FieldInfo barBazField = typeof(MyViewModelWithExplicitFieldAndPropertyAttributes).GetField("barBazCommand", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         Assert.IsNotNull(barBazField.GetCustomAttribute<Test_ObservablePropertyAttribute.TestAttribute>());
+#endif
 
         PropertyInfo barBazCommand = typeof(MyViewModelWithExplicitFieldAndPropertyAttributes).GetProperty("BarBazCommand")!;
 
@@ -670,11 +676,13 @@ public partial class Test_RelayCommandAttribute
         _ = Assert.IsInstanceOfType<RelayCommand>(model.BazCommand);
         _ = Assert.IsInstanceOfType<AsyncRelayCommand>(model.FooBarCommand);
 
+#if !ROSLYN_4_12_0_OR_GREATER
         FieldInfo bazField = typeof(ModelWithPartialCommandMethods).GetField("bazCommand", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         Assert.IsNotNull(bazField.GetCustomAttribute<RequiredAttribute>());
         Assert.IsNotNull(bazField.GetCustomAttribute<MinLengthAttribute>());
         Assert.AreEqual(1, bazField.GetCustomAttribute<MinLengthAttribute>()!.Length);
+#endif
 
         PropertyInfo bazProperty = typeof(ModelWithPartialCommandMethods).GetProperty("BazCommand")!;
 
@@ -682,11 +690,13 @@ public partial class Test_RelayCommandAttribute
         Assert.AreEqual(2, bazProperty.GetCustomAttribute<MinLengthAttribute>()!.Length);
         Assert.IsNotNull(bazProperty.GetCustomAttribute<XmlIgnoreAttribute>());
 
+#if !ROSLYN_4_12_0_OR_GREATER
         FieldInfo fooBarField = typeof(ModelWithPartialCommandMethods).GetField("fooBarCommand", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         Assert.IsNotNull(fooBarField.GetCustomAttribute<RequiredAttribute>());
         Assert.IsNotNull(fooBarField.GetCustomAttribute<MinLengthAttribute>());
-        Assert.AreEqual(1, fooBarField.GetCustomAttribute<MinLengthAttribute>()!.Length);
+        Assert.AreEqual(1, fooBarField.GetCustomAttribute<MinLengthAttribute>()!.Length); 
+#endif
 
         PropertyInfo fooBarProperty = typeof(ModelWithPartialCommandMethods).GetProperty("FooBarCommand")!;
 


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #1073**

<!-- Add an overview of the changes here -->

When the C# language version supports it, this change replaces the backing field for generated `RelayCommand`s with an implicit field using the new `field` keyword.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

Technically, this is a breaking change since someone may have been using the backing fields for whatever reason 