### PR TITLE
Add net10.0 and net10.0-windows10.0.17763.0 target frameworks to CommunityToolkit.Mvvm

### DIFF
--- a/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
+++ b/src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net8.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net8.0-windows10.0.17763.0;net10.0;net10.0-windows10.0.17763.0</TargetFrameworks>
   </PropertyGroup>
 
   <!--

--- a/tests/CommunityToolkit.Mvvm.Roslyn5000.UnitTests/CommunityToolkit.Mvvm.Roslyn5000.UnitTests.csproj
+++ b/tests/CommunityToolkit.Mvvm.Roslyn5000.UnitTests/CommunityToolkit.Mvvm.Roslyn5000.UnitTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>14.0</LangVersion>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <DefineConstants>$(DefineConstants);ROSLYN_4_12_0_OR_GREATER;ROSLYN_5_0_0_OR_GREATER</DefineConstants>


### PR DESCRIPTION
## Summary

Adds 
et10.0 and 
et10.0-windows10.0.17763.0 to CommunityToolkit.Mvvm's TargetFrameworks, following the existing LTS-only shipping pattern (net8.0 LTS → net10.0 LTS, skipping net9.0 STS).

## Changes

- src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj: add 
et10.0;net10.0-windows10.0.17763.0 to TargetFrameworks
- 	ests/CommunityToolkit.Mvvm.Roslyn5000.UnitTests/: add 
et10.0 (was the only MVVM runtime test project missing it; all 408 tests pass)

## Why no other changes are needed

All Windows-conditional property groups use IsTargetFrameworkCompatible(..., 'net8.0-windows10.0.17763.0') which returns 	rue for 
et10.0-windows10.0.17763.0 automatically. All NET8_0_OR_GREATER symbols are true for net10.0, so no source code changes are required. The global.json already pins SDK 10.0.101, and CI uses global.json, so no CI changes are needed.

## Verification

Built locally with dotnet build src/CommunityToolkit.Mvvm/CommunityToolkit.Mvvm.csproj -warnaserror: **0 warnings, 0 errors**, with confirmed output for 
et10.0\CommunityToolkit.Mvvm.dll and 
et10.0-windows10.0.17763.0\CommunityToolkit.Mvvm.dll.