### PR TITLE
Add MVVM dependency graph notifications

### DIFF
--- a/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,9 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MVVMTK0057 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | Invalid source name for [DependsOn]
+MVVMTK0058 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | Dependency cycle for [DependsOn]
+MVVMTK0059 | CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator | Error | Invalid sub-property source for [DependsOn]

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/CommunityToolkit.Mvvm.SourceGenerators.projitems
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\INotifyPropertyChangedGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\Models\AttributeInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\Models\ChildPropertyChangedSubscriptionInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\Models\INotifyPropertyChangedInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\Models\ObservableRecipientInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComponentModel\Models\PropertyInfo.cs" />

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/Models/ChildPropertyChangedSubscriptionInfo.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/Models/ChildPropertyChangedSubscriptionInfo.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Mvvm.SourceGenerators.Helpers;
+
+namespace CommunityToolkit.Mvvm.SourceGenerators.ComponentModel.Models;
+
+/// <summary>
+/// A model representing generated child <c>PropertyChanged</c> forwarding for an observable property.
+/// </summary>
+/// <param name="PropertyChangedNames">The dependent property names to notify when the child instance changes.</param>
+/// <param name="NotifiedCommandNames">The dependent command names to notify when the child instance changes.</param>
+internal sealed record ChildPropertyChangedSubscriptionInfo(
+    EquatableArray<string> PropertyChangedNames,
+    EquatableArray<string> NotifiedCommandNames);

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/Models/PropertyInfo.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/Models/PropertyInfo.cs
@@ -22,6 +22,7 @@ namespace CommunityToolkit.Mvvm.SourceGenerators.ComponentModel.Models;
 /// <param name="PropertyChangingNames">The sequence of property changing properties to notify.</param>
 /// <param name="PropertyChangedNames">The sequence of property changed properties to notify.</param>
 /// <param name="NotifiedCommandNames">The sequence of commands to notify.</param>
+/// <param name="ChildPropertyChangedSubscriptions">The child property changed subscriptions to generate.</param>
 /// <param name="NotifyPropertyChangedRecipients">Whether or not the generated property also broadcasts changes.</param>
 /// <param name="NotifyDataErrorInfo">Whether or not the generated property also validates its value.</param>
 /// <param name="IsOldPropertyValueDirectlyReferenced">Whether the old property value is being directly referenced.</param>
@@ -41,6 +42,7 @@ internal sealed record PropertyInfo(
     EquatableArray<string> PropertyChangingNames,
     EquatableArray<string> PropertyChangedNames,
     EquatableArray<string> NotifiedCommandNames,
+    EquatableArray<ChildPropertyChangedSubscriptionInfo> ChildPropertyChangedSubscriptions,
     bool NotifyPropertyChangedRecipients,
     bool NotifyDataErrorInfo,
     bool IsOldPropertyValueDirectlyReferenced,

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.Execute.cs
@@ -234,6 +234,7 @@ partial class ObservablePropertyGenerator
 
             using ImmutableArrayBuilder<string> propertyChangedNames = ImmutableArrayBuilder<string>.Rent();
             using ImmutableArrayBuilder<string> notifiedCommandNames = ImmutableArrayBuilder<string>.Rent();
+            using ImmutableArrayBuilder<ChildPropertyChangedSubscriptionInfo> childPropertyChangedSubscriptions = ImmutableArrayBuilder<ChildPropertyChangedSubscriptionInfo>.Rent();
             using ImmutableArrayBuilder<AttributeInfo> forwardedAttributes = ImmutableArrayBuilder<AttributeInfo>.Rent();
 
             bool notifyRecipients = false;
@@ -359,6 +360,15 @@ partial class ObservablePropertyGenerator
 
             token.ThrowIfCancellationRequested();
 
+            GatherDependencyGraphInfo(
+                memberSymbol,
+                propertyName,
+                in propertyChangedNames,
+                in notifiedCommandNames,
+                in childPropertyChangedSubscriptions);
+
+            token.ThrowIfCancellationRequested();
+
             // We should generate [RequiresUnreferencedCode] on the setter if [NotifyDataErrorInfo] was used and the attribute is available
             bool includeRequiresUnreferencedCodeOnSetAccessor =
                 notifyDataErrorInfo &&
@@ -409,6 +419,7 @@ partial class ObservablePropertyGenerator
                 effectivePropertyChangingNames,
                 effectivePropertyChangedNames,
                 notifiedCommandNames.ToImmutable(),
+                childPropertyChangedSubscriptions.ToImmutable(),
                 notifyRecipients,
                 notifyDataErrorInfo,
                 isOldPropertyValueDirectlyReferenced,
@@ -621,6 +632,534 @@ partial class ObservablePropertyGenerator
 
             return false;
         }
+
+        /// <summary>
+        /// Gets diagnostics for <c>[DependsOn]</c> usages on a target property.
+        /// </summary>
+        /// <param name="targetPropertySymbol">The target property annotated with <c>[DependsOn]</c>.</param>
+        /// <param name="attributeData">The attributes that were matched for the target property.</param>
+        /// <param name="token">The cancellation token for the current operation.</param>
+        /// <returns>The diagnostics produced for <paramref name="targetPropertySymbol"/>.</returns>
+        public static EquatableArray<DiagnosticInfo> GetDependsOnDiagnostics(
+            IPropertySymbol targetPropertySymbol,
+            ImmutableArray<AttributeData> attributeData,
+            CancellationToken token)
+        {
+            using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = ImmutableArrayBuilder<DiagnosticInfo>.Rent();
+
+            foreach (AttributeData attribute in attributeData)
+            {
+                token.ThrowIfCancellationRequested();
+
+                if (attribute.AttributeClass?.HasFullyQualifiedMetadataName("CommunityToolkit.Mvvm.ComponentModel.DependsOnAttribute") != true)
+                {
+                    continue;
+                }
+
+                bool notifyOnSubPropertyChanges = attribute.GetNamedArgument("NotifyOnSubPropertyChanges", false);
+
+                foreach (string? sourcePropertyName in attribute.GetConstructorArguments<string>())
+                {
+                    if (!TryGetPropertyDependencySource(targetPropertySymbol.ContainingType, sourcePropertyName, out ITypeSymbol? sourceType, out bool isGeneratedSource))
+                    {
+                        diagnostics.Add(DependsOnInvalidSourceError, targetPropertySymbol, sourcePropertyName ?? "", targetPropertySymbol.ContainingType);
+
+                        continue;
+                    }
+
+                    if (sourcePropertyName == targetPropertySymbol.Name)
+                    {
+                        diagnostics.Add(DependsOnInvalidSourceError, targetPropertySymbol, sourcePropertyName, targetPropertySymbol.ContainingType);
+
+                        continue;
+                    }
+
+                    if (notifyOnSubPropertyChanges &&
+                        (!isGeneratedSource ||
+                         sourceType is null ||
+                         !IsINotifyPropertyChangedType(sourceType)))
+                    {
+                        diagnostics.Add(DependsOnInvalidSubPropertySourceError, targetPropertySymbol, sourcePropertyName ?? "", targetPropertySymbol.ContainingType);
+                    }
+                }
+            }
+
+            Dictionary<string, List<DependsOnEdge>> sourceToTargets = GetDependsOnSourceToTargetsMap(targetPropertySymbol.ContainingType, includeOnlyValidEdges: true);
+
+            if (IsInDependsOnCycle(targetPropertySymbol.Name, sourceToTargets) &&
+                IsCanonicalCycleDiagnosticTarget(targetPropertySymbol.Name, sourceToTargets))
+            {
+                diagnostics.Add(DependsOnCycleError, targetPropertySymbol, targetPropertySymbol.Name, targetPropertySymbol.ContainingType);
+            }
+
+            return diagnostics.ToImmutable().AsEquatableArray();
+        }
+
+        /// <summary>
+        /// Gathers property and command notifications declared through the generated dependency graph.
+        /// </summary>
+        /// <param name="memberSymbol">The source member being generated.</param>
+        /// <param name="propertyName">The generated property name.</param>
+        /// <param name="propertyChangedNames">The collection of property changed names to update.</param>
+        /// <param name="notifiedCommandNames">The collection of command names to update.</param>
+        /// <param name="childPropertyChangedSubscriptions">The collection of child subscriptions to update.</param>
+        private static void GatherDependencyGraphInfo(
+            ISymbol memberSymbol,
+            string propertyName,
+            in ImmutableArrayBuilder<string> propertyChangedNames,
+            in ImmutableArrayBuilder<string> notifiedCommandNames,
+            in ImmutableArrayBuilder<ChildPropertyChangedSubscriptionInfo> childPropertyChangedSubscriptions)
+        {
+            INamedTypeSymbol containingType = memberSymbol.ContainingType;
+            Dictionary<string, List<DependsOnEdge>> sourceToTargets = GetDependsOnSourceToTargetsMap(containingType, includeOnlyValidEdges: true);
+            Dictionary<string, List<string>> canExecutePropertyToCommandNames = GetCanExecutePropertyToCommandNamesMap(containingType);
+
+            ImmutableArray<string> graphPropertyChangedNames = GetTransitiveDependsOnTargets(propertyName, sourceToTargets);
+
+            foreach (string dependentPropertyName in graphPropertyChangedNames)
+            {
+                AddIfMissing(in propertyChangedNames, dependentPropertyName);
+            }
+
+            AddInferredCommandNames(propertyName, graphPropertyChangedNames, canExecutePropertyToCommandNames, in notifiedCommandNames);
+
+            ImmutableArray<string> childGraphPropertyChangedNames = GetTransitiveChildDependsOnTargets(propertyName, sourceToTargets);
+
+            if (childGraphPropertyChangedNames.Length > 0)
+            {
+                using ImmutableArrayBuilder<string> childPropertyNames = ImmutableArrayBuilder<string>.Rent();
+                using ImmutableArrayBuilder<string> childCommandNames = ImmutableArrayBuilder<string>.Rent();
+
+                foreach (string dependentPropertyName in childGraphPropertyChangedNames)
+                {
+                    AddIfMissing(in childPropertyNames, dependentPropertyName);
+                    AddInferredCommandNamesForProperty(dependentPropertyName, canExecutePropertyToCommandNames, in childCommandNames);
+                }
+
+                childPropertyChangedSubscriptions.Add(new ChildPropertyChangedSubscriptionInfo(
+                    childPropertyNames.ToImmutable(),
+                    childCommandNames.ToImmutable()));
+            }
+        }
+
+        /// <summary>
+        /// Gets all valid transitive property targets for a given source property.
+        /// </summary>
+        /// <param name="sourcePropertyName">The source property name.</param>
+        /// <param name="sourceToTargets">The source to target graph.</param>
+        /// <returns>The transitive targets for <paramref name="sourcePropertyName"/>.</returns>
+        private static ImmutableArray<string> GetTransitiveDependsOnTargets(string sourcePropertyName, Dictionary<string, List<DependsOnEdge>> sourceToTargets)
+        {
+            using ImmutableArrayBuilder<string> propertyNames = ImmutableArrayBuilder<string>.Rent();
+            HashSet<string> visitedNames = new(StringComparer.Ordinal);
+            Queue<string> pendingNames = new();
+
+            visitedNames.Add(sourcePropertyName);
+            pendingNames.Enqueue(sourcePropertyName);
+
+            while (pendingNames.Count > 0)
+            {
+                string currentPropertyName = pendingNames.Dequeue();
+
+                if (!sourceToTargets.TryGetValue(currentPropertyName, out List<DependsOnEdge>? targetEdges))
+                {
+                    continue;
+                }
+
+                foreach (DependsOnEdge targetEdge in targetEdges)
+                {
+                    if (visitedNames.Add(targetEdge.TargetName))
+                    {
+                        propertyNames.Add(targetEdge.TargetName);
+                        pendingNames.Enqueue(targetEdge.TargetName);
+                    }
+                }
+            }
+
+            return propertyNames.ToImmutable();
+        }
+
+        /// <summary>
+        /// Gets all transitive child property targets from direct edges that opted into child forwarding.
+        /// </summary>
+        /// <param name="sourcePropertyName">The source property name.</param>
+        /// <param name="sourceToTargets">The source to target graph.</param>
+        /// <returns>The transitive child property targets for <paramref name="sourcePropertyName"/>.</returns>
+        private static ImmutableArray<string> GetTransitiveChildDependsOnTargets(string sourcePropertyName, Dictionary<string, List<DependsOnEdge>> sourceToTargets)
+        {
+            using ImmutableArrayBuilder<string> propertyNames = ImmutableArrayBuilder<string>.Rent();
+            HashSet<string> visitedNames = new(StringComparer.Ordinal) { sourcePropertyName };
+            Queue<string> pendingNames = new();
+
+            if (!sourceToTargets.TryGetValue(sourcePropertyName, out List<DependsOnEdge>? rootTargetEdges))
+            {
+                return ImmutableArray<string>.Empty;
+            }
+
+            foreach (DependsOnEdge targetEdge in rootTargetEdges)
+            {
+                if (targetEdge.NotifyOnSubPropertyChanges &&
+                    visitedNames.Add(targetEdge.TargetName))
+                {
+                    propertyNames.Add(targetEdge.TargetName);
+                    pendingNames.Enqueue(targetEdge.TargetName);
+                }
+            }
+
+            while (pendingNames.Count > 0)
+            {
+                string currentPropertyName = pendingNames.Dequeue();
+
+                if (!sourceToTargets.TryGetValue(currentPropertyName, out List<DependsOnEdge>? targetEdges))
+                {
+                    continue;
+                }
+
+                foreach (DependsOnEdge targetEdge in targetEdges)
+                {
+                    if (visitedNames.Add(targetEdge.TargetName))
+                    {
+                        propertyNames.Add(targetEdge.TargetName);
+                        pendingNames.Enqueue(targetEdge.TargetName);
+                    }
+                }
+            }
+
+            return propertyNames.ToImmutable();
+        }
+
+        /// <summary>
+        /// Adds inferred command names for all property names produced by the dependency graph.
+        /// </summary>
+        /// <param name="sourcePropertyName">The source property name.</param>
+        /// <param name="graphPropertyChangedNames">The transitive graph property names.</param>
+        /// <param name="canExecutePropertyToCommandNames">The map of can execute properties to command names.</param>
+        /// <param name="notifiedCommandNames">The command notification collection to update.</param>
+        private static void AddInferredCommandNames(
+            string sourcePropertyName,
+            ImmutableArray<string> graphPropertyChangedNames,
+            Dictionary<string, List<string>> canExecutePropertyToCommandNames,
+            in ImmutableArrayBuilder<string> notifiedCommandNames)
+        {
+            AddInferredCommandNamesForProperty(sourcePropertyName, canExecutePropertyToCommandNames, in notifiedCommandNames);
+
+            foreach (string propertyName in graphPropertyChangedNames)
+            {
+                AddInferredCommandNamesForProperty(propertyName, canExecutePropertyToCommandNames, in notifiedCommandNames);
+            }
+        }
+
+        /// <summary>
+        /// Adds inferred command names for a single property.
+        /// </summary>
+        /// <param name="propertyName">The property name to inspect.</param>
+        /// <param name="canExecutePropertyToCommandNames">The map of can execute properties to command names.</param>
+        /// <param name="notifiedCommandNames">The command notification collection to update.</param>
+        private static void AddInferredCommandNamesForProperty(
+            string propertyName,
+            Dictionary<string, List<string>> canExecutePropertyToCommandNames,
+            in ImmutableArrayBuilder<string> notifiedCommandNames)
+        {
+            if (canExecutePropertyToCommandNames.TryGetValue(propertyName, out List<string>? commandNames))
+            {
+                foreach (string commandName in commandNames)
+                {
+                    AddIfMissing(in notifiedCommandNames, commandName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds the source to target map for all <c>[DependsOn]</c> declarations in a type.
+        /// </summary>
+        /// <param name="containingType">The containing type to inspect.</param>
+        /// <param name="includeOnlyValidEdges">Whether invalid edges should be skipped.</param>
+        /// <returns>The source to target map for <paramref name="containingType"/>.</returns>
+        private static Dictionary<string, List<DependsOnEdge>> GetDependsOnSourceToTargetsMap(INamedTypeSymbol containingType, bool includeOnlyValidEdges)
+        {
+            Dictionary<string, List<DependsOnEdge>> sourceToTargets = new(StringComparer.Ordinal);
+
+            foreach (IPropertySymbol propertySymbol in containingType.GetAllMembers().OfType<IPropertySymbol>())
+            {
+                foreach (AttributeData attributeData in propertySymbol.GetAttributes())
+                {
+                    if (attributeData.AttributeClass?.HasFullyQualifiedMetadataName("CommunityToolkit.Mvvm.ComponentModel.DependsOnAttribute") != true)
+                    {
+                        continue;
+                    }
+
+                    bool notifyOnSubPropertyChanges = attributeData.GetNamedArgument("NotifyOnSubPropertyChanges", false);
+
+                    foreach (string? sourcePropertyName in attributeData.GetConstructorArguments<string>())
+                    {
+                        if (!TryGetPropertyDependencySource(containingType, sourcePropertyName, out _, out _) ||
+                            sourcePropertyName == propertySymbol.Name)
+                        {
+                            if (includeOnlyValidEdges)
+                            {
+                                continue;
+                            }
+                        }
+
+                        if (sourcePropertyName is null or "")
+                        {
+                            continue;
+                        }
+
+                        if (!sourceToTargets.TryGetValue(sourcePropertyName, out List<DependsOnEdge>? targetEdges))
+                        {
+                            sourceToTargets.Add(sourcePropertyName, targetEdges = new List<DependsOnEdge>());
+                        }
+
+                        targetEdges.Add(new DependsOnEdge(sourcePropertyName, propertySymbol.Name, notifyOnSubPropertyChanges));
+                    }
+                }
+            }
+
+            return sourceToTargets;
+        }
+
+        /// <summary>
+        /// Builds the map of <c>CanExecute</c> properties to generated command property names.
+        /// </summary>
+        /// <param name="containingType">The containing type to inspect.</param>
+        /// <returns>The map of <c>CanExecute</c> properties to command property names.</returns>
+        private static Dictionary<string, List<string>> GetCanExecutePropertyToCommandNamesMap(INamedTypeSymbol containingType)
+        {
+            Dictionary<string, List<string>> canExecutePropertyToCommandNames = new(StringComparer.Ordinal);
+
+            foreach (IMethodSymbol methodSymbol in containingType.GetAllMembers().OfType<IMethodSymbol>())
+            {
+                AttributeData? relayCommandAttribute = null;
+
+                foreach (AttributeData attributeData in methodSymbol.GetAttributes())
+                {
+                    if (attributeData.AttributeClass?.HasFullyQualifiedMetadataName("CommunityToolkit.Mvvm.Input.RelayCommandAttribute") == true)
+                    {
+                        relayCommandAttribute = attributeData;
+
+                        break;
+                    }
+                }
+
+                if (relayCommandAttribute is null ||
+                    !relayCommandAttribute.TryGetNamedArgument("CanExecute", out string? canExecuteMemberName) ||
+                    canExecuteMemberName is null or "" ||
+                    !IsBooleanProperty(containingType, canExecuteMemberName))
+                {
+                    continue;
+                }
+
+                string commandPropertyName = RelayCommandGenerator.Execute.GetGeneratedFieldAndPropertyNames(methodSymbol).PropertyName;
+
+                if (!canExecutePropertyToCommandNames.TryGetValue(canExecuteMemberName, out List<string>? commandNames))
+                {
+                    canExecutePropertyToCommandNames.Add(canExecuteMemberName, commandNames = new List<string>());
+                }
+
+                commandNames.Add(commandPropertyName);
+            }
+
+            return canExecutePropertyToCommandNames;
+        }
+
+        /// <summary>
+        /// Checks whether a property dependency source exists.
+        /// </summary>
+        /// <param name="containingType">The containing type to inspect.</param>
+        /// <param name="propertyName">The property name to resolve.</param>
+        /// <param name="propertyType">The resolved source property type, if any.</param>
+        /// <param name="isGeneratedSource">Whether the source property is generated from <c>[ObservableProperty]</c>.</param>
+        /// <returns>Whether <paramref name="propertyName"/> resolves to a valid source property.</returns>
+        private static bool TryGetPropertyDependencySource(
+            INamedTypeSymbol containingType,
+            string? propertyName,
+            [NotNullWhen(true)] out ITypeSymbol? propertyType,
+            out bool isGeneratedSource)
+        {
+            if (propertyName is null or "")
+            {
+                propertyType = null;
+                isGeneratedSource = false;
+
+                return false;
+            }
+
+            foreach (IPropertySymbol propertySymbol in containingType.GetAllMembers(propertyName).OfType<IPropertySymbol>())
+            {
+                propertyType = propertySymbol.Type;
+                isGeneratedSource = propertySymbol.HasAttributeWithFullyQualifiedMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute");
+
+                return true;
+            }
+
+            foreach (ISymbol memberSymbol in containingType.GetAllMembers())
+            {
+                if (memberSymbol is IFieldSymbol fieldSymbol &&
+                    fieldSymbol.HasAttributeWithFullyQualifiedMetadataName("CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute") &&
+                    propertyName == GetGeneratedPropertyName(fieldSymbol))
+                {
+                    propertyType = fieldSymbol.Type;
+                    isGeneratedSource = true;
+
+                    return true;
+                }
+            }
+
+            propertyType = null;
+            isGeneratedSource = false;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether a property name resolves to a bool property.
+        /// </summary>
+        /// <param name="containingType">The containing type to inspect.</param>
+        /// <param name="propertyName">The property name to resolve.</param>
+        /// <returns>Whether <paramref name="propertyName"/> resolves to a bool property.</returns>
+        private static bool IsBooleanProperty(INamedTypeSymbol containingType, string propertyName)
+        {
+            return
+                TryGetPropertyDependencySource(containingType, propertyName, out ITypeSymbol? propertyType, out _) &&
+                propertyType.SpecialType == SpecialType.System_Boolean;
+        }
+
+        /// <summary>
+        /// Checks whether a type is or implements <see cref="INotifyPropertyChanged"/>.
+        /// </summary>
+        /// <param name="typeSymbol">The type symbol to inspect.</param>
+        /// <returns>Whether <paramref name="typeSymbol"/> is or implements <see cref="INotifyPropertyChanged"/>.</returns>
+        private static bool IsINotifyPropertyChangedType(ITypeSymbol typeSymbol)
+        {
+            return
+                typeSymbol.HasFullyQualifiedMetadataName("System.ComponentModel.INotifyPropertyChanged") ||
+                typeSymbol.HasInterfaceWithFullyQualifiedMetadataName("System.ComponentModel.INotifyPropertyChanged");
+        }
+
+        /// <summary>
+        /// Checks whether a target property participates in a cycle.
+        /// </summary>
+        /// <param name="propertyName">The target property name.</param>
+        /// <param name="sourceToTargets">The source to target graph.</param>
+        /// <returns>Whether <paramref name="propertyName"/> participates in a cycle.</returns>
+        private static bool IsInDependsOnCycle(string propertyName, Dictionary<string, List<DependsOnEdge>> sourceToTargets)
+        {
+            HashSet<string> visitedNames = new(StringComparer.Ordinal);
+
+            bool Visit(string currentPropertyName)
+            {
+                if (!sourceToTargets.TryGetValue(currentPropertyName, out List<DependsOnEdge>? targetEdges))
+                {
+                    return false;
+                }
+
+                foreach (DependsOnEdge targetEdge in targetEdges)
+                {
+                    if (targetEdge.TargetName == propertyName)
+                    {
+                        return true;
+                    }
+
+                    if (visitedNames.Add(targetEdge.TargetName) && Visit(targetEdge.TargetName))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            return Visit(propertyName);
+        }
+
+        /// <summary>
+        /// Checks whether a property is the canonical diagnostic location for a cycle.
+        /// </summary>
+        /// <param name="propertyName">The target property name.</param>
+        /// <param name="sourceToTargets">The source to target graph.</param>
+        /// <returns>Whether <paramref name="propertyName"/> is the canonical diagnostic target.</returns>
+        private static bool IsCanonicalCycleDiagnosticTarget(string propertyName, Dictionary<string, List<DependsOnEdge>> sourceToTargets)
+        {
+            List<string> cycleNames = new() { propertyName };
+
+            foreach (string candidateName in sourceToTargets.Keys)
+            {
+                if (candidateName != propertyName &&
+                    IsReachable(propertyName, candidateName, sourceToTargets) &&
+                    IsReachable(candidateName, propertyName, sourceToTargets))
+                {
+                    cycleNames.Add(candidateName);
+                }
+            }
+
+            cycleNames.Sort(StringComparer.Ordinal);
+
+            return cycleNames[0] == propertyName;
+        }
+
+        /// <summary>
+        /// Checks whether one property is reachable from another.
+        /// </summary>
+        /// <param name="sourcePropertyName">The source property name.</param>
+        /// <param name="targetPropertyName">The target property name.</param>
+        /// <param name="sourceToTargets">The source to target graph.</param>
+        /// <returns>Whether <paramref name="targetPropertyName"/> is reachable from <paramref name="sourcePropertyName"/>.</returns>
+        private static bool IsReachable(string sourcePropertyName, string targetPropertyName, Dictionary<string, List<DependsOnEdge>> sourceToTargets)
+        {
+            HashSet<string> visitedNames = new(StringComparer.Ordinal);
+
+            bool Visit(string currentPropertyName)
+            {
+                if (!sourceToTargets.TryGetValue(currentPropertyName, out List<DependsOnEdge>? targetEdges))
+                {
+                    return false;
+                }
+
+                foreach (DependsOnEdge targetEdge in targetEdges)
+                {
+                    if (targetEdge.TargetName == targetPropertyName)
+                    {
+                        return true;
+                    }
+
+                    if (visitedNames.Add(targetEdge.TargetName) && Visit(targetEdge.TargetName))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            return Visit(sourcePropertyName);
+        }
+
+        /// <summary>
+        /// Adds a value to a builder if it is not already present.
+        /// </summary>
+        /// <param name="builder">The builder to update.</param>
+        /// <param name="value">The value to add.</param>
+        private static void AddIfMissing(in ImmutableArrayBuilder<string> builder, string value)
+        {
+            foreach (string existingValue in builder.WrittenSpan)
+            {
+                if (existingValue == value)
+                {
+                    return;
+                }
+            }
+
+            builder.Add(value);
+        }
+
+        /// <summary>
+        /// A dependency edge from a source property to a target calculated property.
+        /// </summary>
+        /// <param name="SourceName">The source property name.</param>
+        /// <param name="TargetName">The target property name.</param>
+        /// <param name="NotifyOnSubPropertyChanges">Whether child <see cref="INotifyPropertyChanged.PropertyChanged"/> events should be forwarded.</param>
+        private sealed record DependsOnEdge(string SourceName, string TargetName, bool NotifyOnSubPropertyChanges);
 
         /// <summary>
         /// Checks whether a given generated property should also notify recipients.
@@ -1235,6 +1774,17 @@ partial class ObservablePropertyGenerator
                         setterFieldExpression,
                         IdentifierName("value"))));
 
+            // Add the child PropertyChanged subscription update, if requested:
+            //
+            // __SubscribeTo<PROPERTY_NAME>PropertyChanged(value);
+            if (!propertyInfo.ChildPropertyChangedSubscriptions.IsEmpty)
+            {
+                setterStatements.Add(
+                    ExpressionStatement(
+                        InvocationExpression(IdentifierName($"__SubscribeTo{propertyInfo.PropertyName}PropertyChanged"))
+                        .AddArgumentListArguments(Argument(IdentifierName("value")))));
+            }
+
             // If validation is requested, add a call to ValidateProperty:
             //
             // ValidateProperty(value, <PROPERTY_NAME>);
@@ -1392,6 +1942,26 @@ partial class ObservablePropertyGenerator
             // Also add any forwarded attributes
             setAccessor = setAccessor.AddAttributeLists(forwardedSetAccessorAttributes);
 
+            AccessorDeclarationSyntax getAccessor = AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                .WithModifiers(propertyInfo.GetterAccessibility.ToSyntaxTokenList());
+
+            if (propertyInfo.ChildPropertyChangedSubscriptions.IsEmpty)
+            {
+                getAccessor = getAccessor
+                    .WithExpressionBody(ArrowExpressionClause(getterFieldExpression))
+                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
+            }
+            else
+            {
+                getAccessor = getAccessor.WithBody(Block(
+                    ExpressionStatement(
+                        InvocationExpression(IdentifierName($"__SubscribeTo{propertyInfo.PropertyName}PropertyChanged"))
+                        .AddArgumentListArguments(Argument(getterFieldExpression))),
+                    ReturnStatement(getterFieldExpression)));
+            }
+
+            getAccessor = getAccessor.AddAttributeLists(forwardedGetAccessorAttributes);
+
             // Construct the generated property as follows:
             //
             // <XML_SUMMARY>
@@ -1417,11 +1987,7 @@ partial class ObservablePropertyGenerator
                 .AddAttributeLists(forwardedPropertyAttributes)
                 .WithModifiers(GetPropertyModifiers(propertyInfo))
                 .AddAccessorListAccessors(
-                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                    .WithModifiers(propertyInfo.GetterAccessibility.ToSyntaxTokenList())
-                    .WithExpressionBody(ArrowExpressionClause(getterFieldExpression))
-                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
-                    .AddAttributeLists(forwardedGetAccessorAttributes),
+                    getAccessor,
                     setAccessor);
         }
 
@@ -1447,6 +2013,85 @@ partial class ObservablePropertyGenerator
             }
 
             return propertyModifiers;
+        }
+
+        /// <summary>
+        /// Gets generated members used to forward child <see cref="INotifyPropertyChanged.PropertyChanged"/> events.
+        /// </summary>
+        /// <param name="propertyInfo">The input <see cref="PropertyInfo"/> instance to process.</param>
+        /// <returns>The generated members for child property changed forwarding.</returns>
+        public static ImmutableArray<MemberDeclarationSyntax> GetChildPropertyChangedSubscriptionMembersSyntax(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo.ChildPropertyChangedSubscriptions.IsEmpty)
+            {
+                return ImmutableArray<MemberDeclarationSyntax>.Empty;
+            }
+
+            using ImmutableArrayBuilder<MemberDeclarationSyntax> memberDeclarations = ImmutableArrayBuilder<MemberDeclarationSyntax>.Rent();
+
+            ChildPropertyChangedSubscriptionInfo childSubscription = propertyInfo.ChildPropertyChangedSubscriptions[0];
+            string sourceFieldName = $"__{char.ToLower(propertyInfo.PropertyName[0], CultureInfo.InvariantCulture)}{propertyInfo.PropertyName.Substring(1)}PropertyChangedSource";
+            string handlerName = $"__On{propertyInfo.PropertyName}PropertyChanged";
+            string subscribeMethodName = $"__SubscribeTo{propertyInfo.PropertyName}PropertyChanged";
+
+            memberDeclarations.Add(ParseMemberDeclaration($$"""
+                private global::System.ComponentModel.INotifyPropertyChanged? {{sourceFieldName}};
+                """)!);
+
+            memberDeclarations.Add(ParseMemberDeclaration($$"""
+                private void {{subscribeMethodName}}({{propertyInfo.TypeNameWithNullabilityAnnotations}} value)
+                {
+                    if (global::System.Object.ReferenceEquals({{sourceFieldName}}, value))
+                    {
+                        return;
+                    }
+
+                    if ({{sourceFieldName}} is object)
+                    {
+                        {{sourceFieldName}}.PropertyChanged -= {{handlerName}};
+                    }
+
+                    {{sourceFieldName}} = value;
+
+                    if (value is object)
+                    {
+                        value.PropertyChanged += {{handlerName}};
+                    }
+                }
+                """)!);
+
+            using ImmutableArrayBuilder<StatementSyntax> handlerStatements = ImmutableArrayBuilder<StatementSyntax>.Rent();
+
+            foreach (string propertyName in childSubscription.PropertyChangedNames)
+            {
+                handlerStatements.Add(
+                    ExpressionStatement(
+                        InvocationExpression(IdentifierName("OnPropertyChanged"))
+                        .AddArgumentListArguments(Argument(MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("global::CommunityToolkit.Mvvm.ComponentModel.__Internals.__KnownINotifyPropertyChangedArgs"),
+                            IdentifierName(propertyName))))));
+            }
+
+            foreach (string commandName in childSubscription.NotifiedCommandNames)
+            {
+                handlerStatements.Add(
+                    ExpressionStatement(
+                        InvocationExpression(MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName(commandName),
+                            IdentifierName("NotifyCanExecuteChanged")))));
+            }
+
+            memberDeclarations.Add(
+                MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), Identifier(handlerName))
+                .AddModifiers(Token(SyntaxKind.PrivateKeyword))
+                .AddParameterListParameters(
+                    Parameter(Identifier("sender")).WithType(NullableType(PredefinedType(Token(SyntaxKind.ObjectKeyword)))),
+                    Parameter(Identifier("e")).WithType(IdentifierName("global::System.ComponentModel.PropertyChangedEventArgs")))
+                .WithBody(Block(handlerStatements.AsEnumerable())));
+
+            return memberDeclarations.ToImmutable();
         }
 
         /// <summary>

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
@@ -22,6 +22,16 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        // Gather diagnostics for [DependsOn] declarations, including cases where no observable property is generated in the target type.
+        IncrementalValuesProvider<EquatableArray<DiagnosticInfo>> dependsOnDiagnostics =
+            context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                "CommunityToolkit.Mvvm.ComponentModel.DependsOnAttribute",
+                static (node, _) => node is PropertyDeclarationSyntax propertyDeclaration && propertyDeclaration.AttributeLists.Count > 0,
+                static (context, token) => Execute.GetDependsOnDiagnostics((IPropertySymbol)context.TargetSymbol, context.Attributes, token));
+
+        context.ReportDiagnostics(dependsOnDiagnostics);
+
         // Gather info for all annotated fields
         IncrementalValuesProvider<(HierarchyInfo Hierarchy, Result<PropertyInfo?> Info)> propertyInfoWithErrors =
             context.ForAttributeWithMetadataNameAndOptions(
@@ -86,6 +96,7 @@ public sealed partial class ObservablePropertyGenerator : IIncrementalGenerator
                 item.Properties
                 .Select(Execute.GetPropertySyntax)
                 .Concat(item.Properties.Select(Execute.GetOnPropertyChangeMethodsSyntax).SelectMany(static l => l))
+                .Concat(item.Properties.Select(Execute.GetChildPropertyChangedSubscriptionMembersSyntax).SelectMany(static l => l))
                 .ToImmutableArray();
 
             // Insert all members into the same partial type declaration

--- a/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/CommunityToolkit.Mvvm.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -944,4 +944,52 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Semi-auto properties should be converted to partial properties using [ObservableProperty] when possible, which is recommended (doing so makes the code less verbose and results in more optimized code).",
         helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0056");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when a <c>[DependsOn]</c> source property is invalid.
+    /// <para>
+    /// Format: <c>"The source property "{0}" for [DependsOn] has no valid match in type {1}"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor DependsOnInvalidSourceError = new DiagnosticDescriptor(
+        id: "MVVMTK0057",
+        title: "Invalid source name for [DependsOn]",
+        messageFormat: "The source property \"{0}\" for [DependsOn] has no valid match in type {1}",
+        category: typeof(ObservablePropertyGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The source properties for [DependsOn] must be different accessible properties in the parent type.",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0057");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when <c>[DependsOn]</c> declarations create a cycle.
+    /// <para>
+    /// Format: <c>"The [DependsOn] declaration for property "{0}" creates a dependency cycle in type {1}"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor DependsOnCycleError = new DiagnosticDescriptor(
+        id: "MVVMTK0058",
+        title: "Dependency cycle for [DependsOn]",
+        messageFormat: "The [DependsOn] declaration for property \"{0}\" creates a dependency cycle in type {1}",
+        category: typeof(ObservablePropertyGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The dependency graph declared with [DependsOn] must not contain cycles.",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0058");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when <c>[DependsOn(NotifyOnSubPropertyChanges = true)]</c> is used with an invalid source.
+    /// <para>
+    /// Format: <c>"The source property "{0}" for [DependsOn(NotifyOnSubPropertyChanges = true)] must be a generated observable property implementing INotifyPropertyChanged in type {1}"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor DependsOnInvalidSubPropertySourceError = new DiagnosticDescriptor(
+        id: "MVVMTK0059",
+        title: "Invalid sub-property source for [DependsOn]",
+        messageFormat: "The source property \"{0}\" for [DependsOn(NotifyOnSubPropertyChanges = true)] must be a generated observable property implementing INotifyPropertyChanged in type {1}",
+        category: typeof(ObservablePropertyGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Sources for [DependsOn(NotifyOnSubPropertyChanges = true)] must be generated observable properties with a type implementing INotifyPropertyChanged.",
+        helpLinkUri: "https://aka.ms/mvvmtoolkit/errors/mvvmtk0059");
 }

--- a/src/CommunityToolkit.Mvvm/ComponentModel/Attributes/DependsOnAttribute.cs
+++ b/src/CommunityToolkit.Mvvm/ComponentModel/Attributes/DependsOnAttribute.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace CommunityToolkit.Mvvm.ComponentModel;
+
+/// <summary>
+/// An attribute that can be used to declare dependencies for calculated properties.
+/// When this attribute is used on a property, generated observable properties listed
+/// in <see cref="PropertyNames"/> will also notify the annotated property when changed.
+/// </summary>
+/// <remarks>
+/// This attribute is processed by the MVVM Toolkit source generators.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+public sealed class DependsOnAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DependsOnAttribute"/> class.
+    /// </summary>
+    /// <param name="propertyName">The name of the property this calculated property depends on.</param>
+    public DependsOnAttribute(string propertyName)
+    {
+        PropertyNames = new[] { propertyName };
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DependsOnAttribute"/> class.
+    /// </summary>
+    /// <param name="propertyName">The name of the property this calculated property depends on.</param>
+    /// <param name="otherPropertyNames">The other property names this calculated property depends on.</param>
+    public DependsOnAttribute(string propertyName, params string[] otherPropertyNames)
+    {
+        PropertyNames = new[] { propertyName }.Concat(otherPropertyNames).ToArray();
+    }
+
+    /// <summary>
+    /// Gets the property names this calculated property depends on.
+    /// </summary>
+    public string[] PropertyNames { get; }
+
+    /// <summary>
+    /// Gets or sets whether changes from child <see cref="System.ComponentModel.INotifyPropertyChanged"/> instances should also notify dependents.
+    /// </summary>
+    public bool NotifyOnSubPropertyChanges { get; set; }
+}

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsCodegen.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsCodegen.cs
@@ -231,6 +231,80 @@ public partial class Test_SourceGeneratorsCodegen
     }
 
     [TestMethod]
+    public void DependsOnGeneratedDependencyGraph_IncludesTransitiveNotificationsAndCommandInvalidation()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using CommunityToolkit.Mvvm.Input;
+
+            namespace MyApp;
+
+            partial class MyViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                private string? name;
+
+                [DependsOn(nameof(Name))]
+                public bool CanSave => !string.IsNullOrWhiteSpace(Name);
+
+                [DependsOn(nameof(CanSave))]
+                public string State => CanSave ? "Ready" : "Blocked";
+
+                [RelayCommand(CanExecute = nameof(CanSave))]
+                private void Save()
+                {
+                }
+            }
+            """;
+
+        VerifyGeneratedSourceContains(
+            source,
+            new IIncrementalGenerator[] { new ObservablePropertyGenerator(), new RelayCommandGenerator() },
+            "MyApp.MyViewModel.g.cs",
+            [
+                "OnPropertyChanged(global::CommunityToolkit.Mvvm.ComponentModel.__Internals.__KnownINotifyPropertyChangedArgs.Name);",
+                "OnPropertyChanged(global::CommunityToolkit.Mvvm.ComponentModel.__Internals.__KnownINotifyPropertyChangedArgs.CanSave);",
+                "OnPropertyChanged(global::CommunityToolkit.Mvvm.ComponentModel.__Internals.__KnownINotifyPropertyChangedArgs.State);",
+                "SaveCommand.NotifyCanExecuteChanged();"
+            ]);
+    }
+
+    [TestMethod]
+    public void DependsOnGeneratedDependencyGraph_IncludesChildSubscriptionHelpers()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp;
+
+            partial class ChildViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                private string? name;
+            }
+
+            partial class MyViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                private ChildViewModel? selectedItem;
+
+                [DependsOn(nameof(SelectedItem), NotifyOnSubPropertyChanges = true)]
+                public string? SelectedItemName => SelectedItem?.Name;
+            }
+            """;
+
+        VerifyGeneratedSourceContains(
+            source,
+            new[] { new ObservablePropertyGenerator() },
+            "MyApp.MyViewModel.g.cs",
+            [
+                "PropertyChanged +=",
+                "PropertyChanged -=",
+                "OnPropertyChanged(global::CommunityToolkit.Mvvm.ComponentModel.__Internals.__KnownINotifyPropertyChangedArgs.SelectedItemName);"
+            ]);
+    }
+
+    [TestMethod]
     public void ObservablePropertyWithNonNullableUnconstrainedGenericType_EmitsMemberNotNullAttribute()
     {
         string source = """
@@ -3520,6 +3594,51 @@ public partial class Test_SourceGeneratorsCodegen
                 // If the text is null, verify that the file was not generated at all
                 Assert.IsFalse(outputCompilation.SyntaxTrees.Any(tree => Path.GetFileName(tree.FilePath) == filename));
             }
+        }
+
+        GC.KeepAlive(observableObjectType);
+        GC.KeepAlive(validationAttributeType);
+    }
+
+    /// <summary>
+    /// Generates sources and verifies that a generated file contains a set of snippets.
+    /// </summary>
+    /// <param name="source">The input source to process.</param>
+    /// <param name="generators">The generators to apply to the input syntax tree.</param>
+    /// <param name="filename">The generated filename to inspect.</param>
+    /// <param name="snippets">The snippets expected in the generated source.</param>
+    private static void VerifyGeneratedSourceContains(string source, IIncrementalGenerator[] generators, string filename, string[] snippets)
+    {
+        // Ensure CommunityToolkit.Mvvm and System.ComponentModel.DataAnnotations are loaded
+        Type observableObjectType = typeof(ObservableObject);
+        Type validationAttributeType = typeof(ValidationAttribute);
+
+        IEnumerable<MetadataReference> references =
+            from assembly in AppDomain.CurrentDomain.GetAssemblies()
+            where !assembly.IsDynamic
+            let reference = MetadataReference.CreateFromFile(assembly.Location)
+            select reference;
+
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp10));
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "original",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generators).WithUpdatedParseOptions((CSharpParseOptions)syntaxTree.Options);
+
+        _ = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out ImmutableArray<Diagnostic> diagnostics);
+
+        CollectionAssert.AreEquivalent(Array.Empty<Diagnostic>(), diagnostics);
+
+        SyntaxTree generatedTree = outputCompilation.SyntaxTrees.Single(tree => Path.GetFileName(tree.FilePath) == filename);
+        string generatedText = generatedTree.ToString();
+
+        foreach (string snippet in snippets)
+        {
+            StringAssert.Contains(generatedText, snippet);
         }
 
         GC.KeepAlive(observableObjectType);

--- a/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
+++ b/tests/CommunityToolkit.Mvvm.SourceGenerators.UnitTests/Test_SourceGeneratorsDiagnostics.cs
@@ -915,6 +915,113 @@ public partial class Test_SourceGeneratorsDiagnostics
     }
 
     [TestMethod]
+    public void DependsOnInvalidSourceError_Missing()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    private string name;
+
+                    [DependsOn("FooBar")]
+                    public string DisplayName => Name;
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0057");
+    }
+
+    [TestMethod]
+    public void DependsOnInvalidSourceError_Self()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {
+                    [DependsOn(nameof(DisplayName))]
+                    public string DisplayName => "";
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0057");
+    }
+
+    [TestMethod]
+    public void DependsOnCycleError()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {
+                    [DependsOn(nameof(Second))]
+                    public string First => "";
+
+                    [DependsOn(nameof(First))]
+                    public string Second => "";
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0058");
+    }
+
+    [TestMethod]
+    public void DependsOnInvalidSubPropertySourceError_NonGeneratedSource()
+    {
+        string source = """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {
+                    public object Child { get; } = new();
+
+                    [DependsOn(nameof(Child), NotifyOnSubPropertyChanges = true)]
+                    public string DisplayName => "";
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source, "MVVMTK0059");
+    }
+
+    [TestMethod]
+    public void DependsOnSubPropertySourceExactINotifyPropertyChangedTypeIsValid()
+    {
+        string source = """
+            using System.ComponentModel;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace MyApp
+            {
+                public partial class SampleViewModel : ObservableObject
+                {
+                    [ObservableProperty]
+                    private INotifyPropertyChanged? child;
+
+                    [DependsOn(nameof(Child), NotifyOnSubPropertyChanges = true)]
+                    public string DisplayName => "";
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ObservablePropertyGenerator>(source);
+    }
+
+    [TestMethod]
     public void InvalidAttributeCombinationForINotifyPropertyChangedAttributeError_InheritingINotifyPropertyChangedAttribute()
     {
         string source = """

--- a/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
+++ b/tests/CommunityToolkit.Mvvm.UnitTests/Test_ObservablePropertyAttribute.cs
@@ -1069,6 +1069,154 @@ public partial class Test_ObservablePropertyAttribute
         CollectionAssert.AreEqual(new[] { nameof(ModelWithDependentPropertyAndNoPropertyChanging.Name), nameof(ModelWithDependentPropertyAndNoPropertyChanging.FullName) }, changedArgs);
     }
 
+    [TestMethod]
+    public void Test_DependsOn_TransitiveCalculatedProperties()
+    {
+        ModelWithDependsOnTransitiveProperties model = new();
+
+        List<string?> propertyNames = new();
+
+        model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        model.FirstName = "Bob";
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                nameof(ModelWithDependsOnTransitiveProperties.FirstName),
+                nameof(ModelWithDependsOnTransitiveProperties.FullName),
+                nameof(ModelWithDependsOnTransitiveProperties.DisplayName)
+            },
+            propertyNames);
+    }
+
+    [TestMethod]
+    public void Test_DependsOn_CommandCanExecuteIsInvalidated()
+    {
+        ModelWithDependsOnCommand model = new();
+
+        int canExecuteChangedRequests = 0;
+
+        model.SaveCommand.CanExecuteChanged += (s, e) => canExecuteChangedRequests++;
+
+        model.Name = "Bob";
+
+        Assert.AreEqual(1, canExecuteChangedRequests);
+    }
+
+    [TestMethod]
+    public void Test_DependsOn_NotifyPropertyChangedForRemainsDirectOnly()
+    {
+        ModelWithNotifyPropertyChangedForDirectOnly model = new();
+
+        List<string?> propertyNames = new();
+
+        model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        model.Name = "Bob";
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                nameof(ModelWithNotifyPropertyChangedForDirectOnly.Name),
+                nameof(ModelWithNotifyPropertyChangedForDirectOnly.Intermediate)
+            },
+            propertyNames);
+    }
+
+    [TestMethod]
+    public void Test_DependsOn_SubPropertyChangesNotifyDependents()
+    {
+        ChildModelForDependsOn child = new();
+        ModelWithDependsOnChildProperty model = new() { SelectedItem = child };
+
+        List<string?> propertyNames = new();
+
+        model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        child.Name = "Bob";
+
+        CollectionAssert.AreEqual(new[] { nameof(ModelWithDependsOnChildProperty.SelectedItemName) }, propertyNames);
+    }
+
+    [TestMethod]
+    public void Test_DependsOn_SubPropertyChangesOnlyNotifyOptedInDependents()
+    {
+        ChildModelForDependsOn child = new();
+        ModelWithDependsOnMixedChildProperty model = new() { SelectedItem = child };
+
+        List<string?> propertyNames = new();
+        int canExecuteChangedRequests = 0;
+
+        model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+        model.SaveCommand.CanExecuteChanged += (s, e) => canExecuteChangedRequests++;
+
+        child.Name = "Bob";
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                nameof(ModelWithDependsOnMixedChildProperty.SelectedItemName),
+                nameof(ModelWithDependsOnMixedChildProperty.SelectedItemDisplayName)
+            },
+            propertyNames);
+
+        Assert.AreEqual(0, canExecuteChangedRequests);
+    }
+
+    [TestMethod]
+    public void Test_DependsOn_SubPropertyReplacingChildDetachesOldInstance()
+    {
+        ChildModelForDependsOn oldChild = new();
+        ChildModelForDependsOn newChild = new();
+        ModelWithDependsOnChildProperty model = new() { SelectedItem = oldChild };
+
+        List<string?> propertyNames = new();
+
+        model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        model.SelectedItem = newChild;
+        propertyNames.Clear();
+
+        oldChild.Name = "Bob";
+        newChild.Name = "Alice";
+
+        CollectionAssert.AreEqual(new[] { nameof(ModelWithDependsOnChildProperty.SelectedItemName) }, propertyNames);
+    }
+
+    [TestMethod]
+    public void Test_DependsOn_SubPropertyNullAssignmentIsSafe()
+    {
+        ChildModelForDependsOn child = new();
+        ModelWithDependsOnChildProperty model = new() { SelectedItem = child };
+
+        List<string?> propertyNames = new();
+
+        model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        model.SelectedItem = null;
+        propertyNames.Clear();
+
+        child.Name = "Bob";
+
+        Assert.IsEmpty(propertyNames);
+    }
+
+    [TestMethod]
+    public void Test_DependsOn_SubPropertyInitializedBackingFieldSubscribesAfterGetterAccess()
+    {
+        ModelWithInitializedDependsOnChildProperty model = new();
+        ChildModelForDependsOn child = model.SelectedItem!;
+
+        List<string?> propertyNames = new();
+
+        model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        child.Name = "Bob";
+
+        CollectionAssert.AreEqual(new[] { nameof(ModelWithInitializedDependsOnChildProperty.SelectedItemName) }, propertyNames);
+    }
+
 #if NET6_0_OR_GREATER
     [TestMethod]
     public void Test_ObservableProperty_MemberNotNullAttributeIsPresent()
@@ -1792,6 +1940,89 @@ public partial class Test_ObservablePropertyAttribute
         private string? name;
 
         public string? FullName => "";
+    }
+
+    private sealed partial class ModelWithDependsOnTransitiveProperties : ObservableObject
+    {
+        [ObservableProperty]
+        private string? firstName;
+
+        [DependsOn(nameof(FirstName))]
+        public string FullName => FirstName ?? "";
+
+        [DependsOn(nameof(FullName))]
+        public string DisplayName => FullName.ToUpperInvariant();
+    }
+
+    private sealed partial class ModelWithDependsOnCommand : ObservableObject
+    {
+        [ObservableProperty]
+        private string? name;
+
+        [DependsOn(nameof(Name))]
+        public bool CanSave => !string.IsNullOrWhiteSpace(Name);
+
+        [RelayCommand(CanExecute = nameof(CanSave))]
+        private void Save()
+        {
+        }
+    }
+
+    private sealed partial class ModelWithNotifyPropertyChangedForDirectOnly : ObservableObject
+    {
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(Intermediate))]
+        private string? name;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(Final))]
+        private string? intermediate;
+
+        public string Final => Intermediate ?? "";
+    }
+
+    private sealed partial class ChildModelForDependsOn : ObservableObject
+    {
+        [ObservableProperty]
+        private string? name;
+    }
+
+    private sealed partial class ModelWithDependsOnChildProperty : ObservableObject
+    {
+        [ObservableProperty]
+        private ChildModelForDependsOn? selectedItem;
+
+        [DependsOn(nameof(SelectedItem), NotifyOnSubPropertyChanges = true)]
+        public string? SelectedItemName => SelectedItem?.Name;
+    }
+
+    private sealed partial class ModelWithDependsOnMixedChildProperty : ObservableObject
+    {
+        [ObservableProperty]
+        private ChildModelForDependsOn? selectedItem;
+
+        [DependsOn(nameof(SelectedItem), NotifyOnSubPropertyChanges = true)]
+        public string? SelectedItemName => SelectedItem?.Name;
+
+        [DependsOn(nameof(SelectedItemName))]
+        public string? SelectedItemDisplayName => SelectedItemName?.ToUpperInvariant();
+
+        [DependsOn(nameof(SelectedItem))]
+        public bool HasSelection => SelectedItem is not null;
+
+        [RelayCommand(CanExecute = nameof(HasSelection))]
+        private void Save()
+        {
+        }
+    }
+
+    private sealed partial class ModelWithInitializedDependsOnChildProperty : ObservableObject
+    {
+        [ObservableProperty]
+        private ChildModelForDependsOn? selectedItem = new();
+
+        [DependsOn(nameof(SelectedItem), NotifyOnSubPropertyChanges = true)]
+        public string? SelectedItemName => SelectedItem?.Name;
     }
 
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
**Closes #857**

**Addresses #959**
**Addresses #906**
**Addresses #1168**

This PR adds explicit dependency graph support for MVVM source generation through a new `[DependsOn]` attribute for calculated properties.

The new API lets target-side calculated properties declare the source properties they depend on:

```csharp
[DependsOn(nameof(FirstName), nameof(LastName))]
public string FullName => $"{FirstName} {LastName}";
```

The source generator then expands those dependencies for generated observable properties, including transitive dependencies declared through `[DependsOn]`. Existing `[NotifyPropertyChangedFor]` behavior remains direct-only for compatibility.

This also adds:

- inferred command invalidation for `[RelayCommand(CanExecute = nameof(SomeBoolProperty))]` when the bool property is generated or graph-derived
- explicit child `INotifyPropertyChanged` forwarding through `[DependsOn(..., NotifyOnSubPropertyChanges = true)]`
- diagnostics for invalid dependency sources, self-dependencies, dependency cycles, and invalid child-notification sources
- regression tests for graph expansion, command invalidation, child attach/detach behavior, null handling, initially assigned backing fields, and invalid usage diagnostics

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Validation

- `dotnet restore .\dotnet.slnx`
- `dotnet test .\tests\CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests\CommunityToolkit.Mvvm.SourceGenerators.Roslyn4120.UnitTests.csproj --filter "FullyQualifiedName~DependsOn|FullyQualifiedName~ObservableProperty" --no-restore -v minimal`
- `dotnet test .\tests\CommunityToolkit.Mvvm.Roslyn4120.UnitTests\CommunityToolkit.Mvvm.Roslyn4120.UnitTests.csproj --filter "FullyQualifiedName~DependsOn|FullyQualifiedName~ObservableProperty|FullyQualifiedName~RelayCommand" --no-restore -v minimal`
- `dotnet build .\dotnet.slnx -c Debug --no-restore`
- `dotnet test .\dotnet.slnx --no-build -c Debug -l "console;verbosity=minimal"`
- `git diff --check`

## Other information

The API intentionally uses a new `[DependsOn]` attribute rather than changing `[NotifyPropertyChangedFor]` transitivity, so existing behavior remains compatibility-preserving.