### PR TITLE
Fix CanExecute(null) for value types without predicate

### DIFF
--- a/src/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/src/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -82,11 +82,20 @@ public sealed partial class RelayCommand<T> : IRelayCommand<T>
     /// <inheritdoc/>
     public bool CanExecute(object? parameter)
     {
-        // Special case a null value for a value type argument type.
-        // This ensures that no exceptions are thrown during initialization.
+        // WPF may call CanExecute(null) during initialization before the
+        // CommandParameter binding has produced a value. For non-nullable
+        // value types (e.g. int, enums), null cannot be meaningfully
+        // converted — there is no "default" that can safely stand in for
+        // "no value" (0 could be a legitimate SelectedIndex, for example).
+        //
+        // - If the user didn't supply a canExecute predicate, the command
+        //   is meant to always run — return true.
+        // - If a predicate exists, we cannot guess the user's intent, so
+        //   return false. The framework will re-query CanExecute when the
+        //   binding eventually produces the real parameter value.
         if (parameter is null && default(T) is not null)
         {
-            return false;
+            return _canExecute is null;
         }
 
         if (!TryGetCommandArgument(parameter, out T? result))

--- a/src/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/src/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -82,17 +82,16 @@ public sealed partial class RelayCommand<T> : IRelayCommand<T>
     /// <inheritdoc/>
     public bool CanExecute(object? parameter)
     {
-        // WPF may call CanExecute(null) during initialization before the
-        // CommandParameter binding has produced a value. For non-nullable
-        // value types (e.g. int, enums), null cannot be meaningfully
-        // converted — there is no "default" that can safely stand in for
-        // "no value" (0 could be a legitimate SelectedIndex, for example).
-        //
-        // - If the user didn't supply a canExecute predicate, the command
-        //   is meant to always run — return true.
-        // - If a predicate exists, we cannot guess the user's intent, so
-        //   return false. The framework will re-query CanExecute when the
-        //   binding eventually produces the real parameter value.
+        // WPF and other command sources may query CanExecute(null) before a
+        // non-nullable value-type command parameter is available.
+        // 
+        // A command without a canExecute predicate has no availability
+        // restriction, so null does not make the command unavailable.
+        // When a predicate exists, null cannot be converted to T and the
+        // predicate cannot be evaluated safely, so return false.
+        // 
+        // This result only describes command availability. Execute still
+        // validates the parameter contract and rejects an invalid argument.
         if (parameter is null && default(T) is not null)
         {
             return _canExecute is null;


### PR DESCRIPTION
Closes #1206

When `RelayCommand<T>.CanExecute(object?)` receives `null` for a non-nullable value type `T`, it unconditionally returns `false` — even when no `canExecute` predicate was provided. This violates the documented contract: *"The default return value for the CanExecute method is `true`."*

This single-line fix distinguishes between the two cases:

- **No predicate** → return `true` (the command is always executable, as documented)
- **Has predicate** → return `false` (cannot meaningfully evaluate `null` as `T`, safe fallback — unchanged from current behavior)

In WPF applications on .NET Framework, the framework may call `CanExecute(null)` during control initialization before the `CommandParameter` binding has produced a value. With the unconditional `return false`, commands without predicates are permanently disabled, as the initial `false` result is cached and never re-evaluated.

This fix is fully compatible with the reasoning in [WindowsCommunityToolkit #3619](https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/3619): for commands *with* a predicate, mapping `null` to `default(T)` would conflate "no value" with a legitimate value (e.g., `0` as `SelectedIndex`). The conclusion that `return false` is safe for that scenario is preserved here. The case of *no predicate* was not explicitly considered in that discussion — a command without a predicate should simply always be executable, as the class documentation states.

## PR Checklist

- [ ] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [ ] Based off latest main branch of toolkit
- [ ] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

**Change in `src/CommunityToolkit.Mvvm/Input/RelayCommand{T}.cs`:**

```diff
 if (parameter is null && default(T) is not null)
 {
-    return false;
+    return this.canExecute is null;
 }
```

| Scenario | `canExecute` | Before | After |
|---|---|---|---|
| `RelayCommand<int>(Do)` | `null` | `false` ❌ | `true` ✅ |
| `RelayCommand<int>(Do, i => i >= 0)` | predicate | `false` | `false` (unchanged) |

`TryGetCommandArgument`、`ThrowArgumentExceptionForInvalidCommandArgument`、`Execute(object?)` 均未改动。
