### PR TITLE
Route IBufferWriterExtensions.Write through BuffersExtensions

### DIFF
--- a/src/CommunityToolkit.HighPerformance/Extensions/IBufferWriterExtensions.cs
+++ b/src/CommunityToolkit.HighPerformance/Extensions/IBufferWriterExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Buffers;
+using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -45,21 +46,17 @@ public static class IBufferWriterExtensions
     /// <param name="writer">The target <see cref="IBufferWriter{T}"/> instance to write to.</param>
     /// <param name="value">The input value to write to <paramref name="writer"/>.</param>
     /// <exception cref="ArgumentException">Thrown if <paramref name="writer"/> reaches the end.</exception>
+    /// <remarks>
+    /// The <c>sizeHint</c> passed to <see cref="IBufferWriter{T}.GetSpan"/> is a hint, not a demand: a writer is
+    /// free to return less. The write is therefore delegated to <see cref="BuffersExtensions"/>, which loops over
+    /// whatever spans it is given, rather than requiring <paramref name="value"/> to fit in a single span.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe void Write<T>(this IBufferWriter<byte> writer, T value)
         where T : unmanaged
     {
-        Span<byte> span = writer.GetSpan(sizeof(T));
-
-        if (span.Length < sizeof(T))
-        {
-            ThrowArgumentExceptionForEndOfBuffer();
-        }
-
-        ref byte r0 = ref MemoryMarshal.GetReference(span);
-
-        Unsafe.WriteUnaligned(ref r0, value);
-
-        writer.Advance(sizeof(T));
+        // the address of a parameter is stack-based, so this needs no pinning
+        BuffersExtensions.Write(writer, new ReadOnlySpan<byte>(&value, sizeof(T)));
     }
 
     /// <summary>
@@ -91,16 +88,16 @@ public static class IBufferWriterExtensions
     /// <param name="writer">The target <see cref="IBufferWriter{T}"/> instance to write to.</param>
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> to write to <paramref name="writer"/>.</param>
     /// <exception cref="ArgumentException">Thrown if <paramref name="writer"/> reaches the end.</exception>
+    /// <remarks>
+    /// The <c>sizeHint</c> passed to <see cref="IBufferWriter{T}.GetSpan"/> is a hint, not a demand: a writer is
+    /// free to return less. The write is therefore delegated to <see cref="BuffersExtensions"/>, which loops over
+    /// whatever spans it is given, rather than requiring <paramref name="span"/> to fit in a single span.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Write<T>(this IBufferWriter<byte> writer, ReadOnlySpan<T> span)
         where T : unmanaged
     {
-        ReadOnlySpan<byte> source = MemoryMarshal.AsBytes(span);
-        Span<byte> destination = writer.GetSpan(source.Length);
-
-        source.CopyTo(destination);
-
-        writer.Advance(source.Length);
+        BuffersExtensions.Write(writer, MemoryMarshal.AsBytes(span));
     }
 
 #if !NETSTANDARD2_1_OR_GREATER
@@ -111,14 +108,17 @@ public static class IBufferWriterExtensions
     /// <param name="writer">The target <see cref="IBufferWriter{T}"/> instance to write to.</param>
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> to write to <paramref name="writer"/>.</param>
     /// <exception cref="ArgumentException">Thrown if <paramref name="writer"/> reaches the end.</exception>
+    /// <remarks>
+    /// This is not an extension method: <see cref="BuffersExtensions.Write"/> has the same signature and is always
+    /// available (the System.Memory package is a dependency of this package on netstandard2.0), so an extension
+    /// method here would only be an ambiguity. It remains for binary compatibility.
+    /// </remarks>
+    [Obsolete("Use System.Buffers.BuffersExtensions.Write instead; this overload exists only for binary compatibility.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Write<T>(this IBufferWriter<T> writer, ReadOnlySpan<T> span)
+    public static void Write<T>(IBufferWriter<T> writer, ReadOnlySpan<T> span)
     {
-        Span<T> destination = writer.GetSpan(span.Length);
-
-        span.CopyTo(destination);
-
-        writer.Advance(span.Length);
+        BuffersExtensions.Write(writer, span);
     }
 #endif
 

--- a/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_IBufferWriterExtensions.cs
+++ b/tests/CommunityToolkit.HighPerformance.UnitTests/Extensions/Test_IBufferWriterExtensions.cs
@@ -3,10 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-#if NET6_0_OR_GREATER
+
+// this was previously #if NET6_0_OR_GREATER, to dodge the CS0121 ambiguity between
+// BuffersExtensions.Write and IBufferWriterExtensions.Write on the netstandard2.0 build
 using System.Buffers;
-#endif
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using CommunityToolkit.HighPerformance.Buffers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -127,7 +130,7 @@ public class Test_IBufferWriterExtensions
 
         // Leave only one byte of free capacity
         int count = writer.Capacity - 1;
-        
+
         for (int i = 0; i < count; i++)
         {
             writer.Write<byte>(0);
@@ -135,5 +138,183 @@ public class Test_IBufferWriterExtensions
 
         // Write 4 bytes
         writer.Write(1);
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/1208
+    [TestMethod]
+    public void Test_IBufferWriterExtensions_WriteBytes_SegmentedWriter()
+    {
+        byte[] payload = CreateBytes(64);
+
+        SegmentedWriter<byte> writer = new();
+
+        writer.Write<byte>(payload);
+
+        CollectionAssert.AreEqual(payload, writer.ToArray());
+
+        // the payload is 8x the segment size; a single request could not have satisfied it
+        Assert.IsGreaterThan(1, writer.Requests);
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/1208
+    [TestMethod]
+    public void Test_IBufferWriterExtensions_WriteBytes_SegmentedWriter_ExtensionSyntax()
+    {
+        byte[] payload = CreateBytes(64);
+
+        SegmentedWriter<byte> writer = new();
+
+        // this binds to IBufferWriterExtensions.Write<byte>(IBufferWriter<byte>, ReadOnlySpan<byte>), which
+        // out-competes BuffersExtensions.Write<T>(IBufferWriter<T>, ReadOnlySpan<T>) on all TFMs; it must
+        // therefore behave the same as the method it hides
+        writer.Write(payload.AsSpan());
+
+        CollectionAssert.AreEqual(payload, writer.ToArray());
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/1208
+    [TestMethod]
+    public void Test_IBufferWriterExtensions_WriteItems_SegmentedWriter()
+    {
+        int[] payload = CreateInts(64);
+
+        SegmentedWriter<int> writer = new();
+
+        writer.Write(payload.AsSpan());
+
+        CollectionAssert.AreEqual(payload, writer.ToArray());
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/1208
+    [TestMethod]
+    public void Test_IBufferWriterExtensions_WriteBlittedItems_SegmentedWriter()
+    {
+        int[] payload = CreateInts(16);
+
+        SegmentedWriter<byte> writer = new();
+
+        writer.Write<int>(payload);
+
+        byte[] written = writer.ToArray();
+
+        Assert.HasCount(sizeof(int) * payload.Length, written);
+        Assert.IsTrue(written.AsSpan().SequenceEqual(MemoryMarshal.AsBytes(payload.AsSpan())));
+    }
+
+    // See https://github.com/CommunityToolkit/dotnet/issues/1208
+    [TestMethod]
+    public void Test_IBufferWriterExtensions_WriteValue_StraddlingSegmentBoundary()
+    {
+        const long Value = 0x0102030405060708;
+
+        SegmentedWriter<byte> writer = new();
+
+        // five bytes of padding leaves three bytes in the current segment, so the value cannot fit
+        writer.Write<byte>(new byte[5]);
+        writer.Write(Value);
+
+        byte[] written = writer.ToArray();
+
+        Assert.HasCount(5 + sizeof(long), written);
+        Assert.AreEqual(Value, MemoryMarshal.Read<long>(written.AsSpan(5)));
+    }
+
+#if NETFRAMEWORK
+    // See https://github.com/CommunityToolkit/dotnet/issues/1208; the T-to-T overload is retained on
+    // netstandard2.0 (which is what net472 resolves) for binary compatibility, but is no longer an
+    // extension method
+    [TestMethod]
+    public void Test_IBufferWriterExtensions_WriteItems_ObsoleteCompatShim()
+    {
+        int[] payload = CreateInts(64);
+
+        SegmentedWriter<int> writer = new();
+
+#pragma warning disable CS0618 // obsolete
+        IBufferWriterExtensions.Write<int>(writer, payload);
+#pragma warning restore CS0618
+
+        CollectionAssert.AreEqual(payload, writer.ToArray());
+    }
+#endif
+
+    private static byte[] CreateBytes(int count)
+    {
+        byte[] payload = new byte[count];
+
+        new Random(42).NextBytes(payload);
+
+        return payload;
+    }
+
+    private static int[] CreateInts(int count)
+    {
+        int[] payload = new int[count];
+        Random random = new(42);
+
+        for (int i = 0; i < payload.Length; i++)
+        {
+            payload[i] = random.Next(int.MinValue, int.MaxValue);
+        }
+
+        return payload;
+    }
+
+    /// <summary>
+    /// An <see cref="IBufferWriter{T}"/> that never hands out more than <see cref="SegmentSize"/> elements at a
+    /// time, whatever <c>sizeHint</c> asks for; the hint is a hint, not a demand.
+    /// </summary>
+    private sealed class SegmentedWriter<T> : IBufferWriter<T>
+    {
+        private const int SegmentSize = 8;
+
+        private readonly List<T[]> segments = new();
+        private readonly List<int> counts = new();
+        private int used;
+
+        /// <summary>
+        /// Gets the number of <see cref="GetSpan"/> calls received.
+        /// </summary>
+        public int Requests { get; private set; }
+
+        public Span<T> GetSpan(int sizeHint = 0)
+        {
+            Requests++;
+
+            if (this.segments.Count == 0 || this.used == SegmentSize)
+            {
+                this.segments.Add(new T[SegmentSize]);
+                this.counts.Add(0);
+                this.used = 0;
+            }
+
+            return this.segments[this.segments.Count - 1].AsSpan(this.used);
+        }
+
+        public Memory<T> GetMemory(int sizeHint = 0)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Advance(int count)
+        {
+            this.used += count;
+            this.counts[this.counts.Count - 1] = this.used;
+        }
+
+        public T[] ToArray()
+        {
+            List<T> result = new();
+
+            for (int i = 0; i < this.segments.Count; i++)
+            {
+                for (int j = 0; j < this.counts[i]; j++)
+                {
+                    result.Add(this.segments[i][j]);
+                }
+            }
+
+            return result.ToArray();
+        }
     }
 }


### PR DESCRIPTION
**Closes #1208**

`sizeHint` is a hint, not a demand: a writer may hand back less than was asked for, so requiring an entire payload in one contiguous span fails against writers with bounded segments, where `BuffersExtensions` loops.

- `Write<T>(IBufferWriter<byte>, ReadOnlySpan<T>)`: type-pun, then delegate
- `Write<T>(IBufferWriter<byte>, T)`: delegate (type-pun via span)
- `Write<T>(IBufferWriter<T>, ReadOnlySpan<T>)` (netstandard2.0 only): delegate, mark `[Obsolete]`, and drop the `this`; it has the same signature as the BCL method, so as an extension method it was only ever an ambiguity (CS0121). Retained for binary compatibility.

`Write<T>(IBufferWriter<T>, T)` is left alone: `GetSpan(1)` plus a length check is defensible, as a writer that cannot supply a single element is broken under any reading of the contract.

Tests use a `SegmentedWriter<T>` that never hands out more than eight elements per `GetSpan` call, whatever the hint asks for. The `using System.Buffers;` in the test file no longer needs a `#if` to dodge the ambiguity, which is itself part of the regression test.

## Note on `OverloadResolutionPriority`.

Pre-empting an obvious question: we could in principle apply `[OverloadResolutionPriority(-1)]` instead of removing the `this`. It doesn't work here.                             
                                                                                                                       
  - Priority is compared only *within* a declaring type: the spec groups candidates by declaring type, drops the lower-priority members inside each group, then recombines. The LDM confirmed this explicitly for extension methods ("we will always group"). `BuffersExtensions` and `IBufferWriterExtensions` are different types, so priority never enters the comparison - the ambiguity is still CS0121, and the `byte`-version still wins the hijack on specificity (concrete receiver beats generic receiver). Verified at C# 13.
  - It would also need a polyfilled attribute (PolySharp 1.15 doesn't offer it; this package opts into three generated types) and C# 13 in *both* the package build and the consumer. `LangVersion` here is currently 12. A consumer on an older compiler ignores the attribute silently rather than failing, so the fix would do nothing for exactly the down-level consumers this package exists to serve.      

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tested code with current [supported SDKs](../#supported)
- [ ] ~New component~
  - [ ] ~Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs).~
  - [ ] ~Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)~
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] ~Header has been added to all new source files (run _build/UpdateHeaders.bat_)~
- [x] Contains **NO** breaking changes
  - caveat: the changes to `Write<T>(IBufferWriter<T>, ReadOnlySpan<T>)` are *build-time* breaking, intentionally and necessarily, but not *runtime* breaking; a one-time "migrate to System.Buffers" is less harmful than a forever overload-ambiguity
- [ ] ~Every new API (including internal ones) has full XML docs~
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->